### PR TITLE
Enable ts format checker with clang

### DIFF
--- a/.github/workflows/check-pr-format.yml
+++ b/.github/workflows/check-pr-format.yml
@@ -17,3 +17,5 @@ jobs:
           node-version: '12'
       - run: npm install
       - run: npm run lint
+      - run: sudo apt-get install clang-format-8
+      - run: bash infra/format


### PR DESCRIPTION
This will enable TypeScript format checker with clang.

Signed-off-by: SaeHie Park <saehie.park@gmail.com>