### PR TITLE
Initialize Builder current workspace

### DIFF
--- a/src/Project/Builder.ts
+++ b/src/Project/Builder.ts
@@ -17,9 +17,14 @@
 import * as vscode from 'vscode';
 
 import {Balloon} from '../Utils/Balloon';
+import * as helpers from '../Utils/Helpers';
 
 export class Builder {
-  constructor() {}
+  currentWorkspace: string;
+
+  constructor() {
+    this.currentWorkspace = '';
+  }
 
   // TODO import .cfg file to BuildFlow
 
@@ -29,6 +34,12 @@ export class Builder {
 
   // called from user interface
   public build(context: vscode.ExtensionContext) {
-    // TODO implement
+    try {
+      this.currentWorkspace = helpers.obtainWorkspaceRoot();
+    } catch (e) {
+      Balloon.error(e);
+      return;
+    }
+    // TODO initialize workflow
   }
 }

--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode';
+import {Balloon} from './Balloon';
+
+/**
+ * @brief Get Workspace root folder as string
+ * @note  will throw if not working in workspace mode.
+ */
+export function obtainWorkspaceRoot(): string {
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders) {
+    console.log('obtainWorkspaceRoot: NO workspaceFolders');
+    // TODO revise message
+    throw new Error('Need workspace');
+  }
+
+  // TODO support active workspace from multiple workspace
+  if (workspaceFolders.length > 1) {
+    Balloon.info('Warning: only first Workspace is supported');
+  }
+  const workspaceRoot = workspaceFolders[0].uri.path;
+  if (!workspaceRoot) {
+    console.log('obtainWorkspaceRoot: NO workspaceRoot');
+    // TODO revise message
+    throw new Error('Need workspace');
+  }
+  console.log('obtainWorkspaceRoot:', workspaceRoot);
+
+  return workspaceRoot;
+}


### PR DESCRIPTION
This will initialize Builder current workspace folder with
introducing obtainWorkspaceRoot method in Helpers in Utils.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>