### PR TITLE
Introduce utils.getImportCfgFilepath method

### DIFF
--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -43,3 +43,29 @@ export function obtainWorkspaceRoot(): string {
 
   return workspaceRoot;
 }
+
+export interface FileSelector {
+  onFileSelected(uri: vscode.Uri|undefined): void;
+}
+
+/**
+ * @brief Get import cfg file path using file open dialog
+ */
+export function getImportCfgFilepath(selector: FileSelector): void {
+  const options: vscode.OpenDialogOptions = {
+    canSelectMany: false,
+    openLabel: 'Import',
+    filters: {
+      /* eslint-disable-next-line @typescript-eslint/naming-convention */
+      'ONE .cfg Files': ['cfg']
+    }
+  };
+
+  vscode.window.showOpenDialog(options).then(fileUri => {
+    if (fileUri && fileUri[0]) {
+      selector.onFileSelected(fileUri[0]);
+    } else {
+      selector.onFileSelected(undefined);
+    }
+  });
+}


### PR DESCRIPTION
This will introduce getImportCfgFilepath in utils to get import cfg file
path from the user.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>