### PR TITLE
Introduce helpers loadCfgFile

### DIFF
--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
+import * as fs from 'fs';
 import * as vscode from 'vscode';
 import {Balloon} from './Balloon';
+
+var ini = require('ini');
 
 /**
  * @brief Get Workspace root folder as string
@@ -68,4 +71,16 @@ export function getImportCfgFilepath(selector: FileSelector): void {
       selector.onFileSelected(undefined);
     }
   });
+}
+
+/**
+ * @brief Load cfg file and return Object
+ */
+export function loadCfgFile(filePath: string): any {
+  let cfgData = fs.readFileSync(filePath, 'utf-8');
+  // TODO check cfgData validity
+  let cfgIni = ini.parse(cfgData);
+  // TODO check cfgIni validity
+
+  return cfgIni;
 }


### PR DESCRIPTION
This will introduce loadCfgFile method in helpers that will load
onecc cfg file.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>