### PR TITLE
Fix typo in BuilderCfgFile

### DIFF
--- a/src/Project/BuilderCfgFile.ts
+++ b/src/Project/BuilderCfgFile.ts
@@ -51,7 +51,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
   // helpers.FileSelector implements
   public onFileSelected(fileUri: vscode.Uri|undefined): void {
     if (fileUri === undefined) {
-      Balloon.error('Invalid file selecttion');
+      Balloon.error('Invalid file selection');
       return;
     }
     console.log('Selected file: ' + fileUri.fsPath);


### PR DESCRIPTION
This will fix typo 'selection' in BuilderCfgFile.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>