### PR TITLE
Log with shorter date-time prefix

### DIFF
--- a/src/Utils/Logger.ts
+++ b/src/Utils/Logger.ts
@@ -35,7 +35,7 @@ export class Logger {
   public outputWithTime(msg: string) {
     let dateTime = new Date();
     this.checkShow();
-    this.outputChannel.appendLine('[' + dateTime + '] ' + msg);
+    this.outputChannel.appendLine('[' + dateTime.toLocaleString() + '] ' + msg);
   }
 
   public output(msg: string) {


### PR DESCRIPTION
This will revise log to show shorter date-time prefix in message.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>