### PR TITLE
[CI] Enable lint for html, css and js

### DIFF
--- a/.github/workflows/check-pr-format.yml
+++ b/.github/workflows/check-pr-format.yml
@@ -17,6 +17,9 @@ jobs:
           node-version: '12'
       - run: npm install
       - run: npm run lint
+      - run: npm run lintjs
+      - run: npm run lintcss
+      - run: npm run linthtml
       - run: sudo apt-get install clang-format-8
       - run: bash infra/format
 

--- a/package.json
+++ b/package.json
@@ -65,8 +65,11 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "pretest": "npm run compile && npm run lint",
+    "pretest": "npm run compile && npm run lint && npm run lintjs && npm run lintcss && npm run linthtml",
     "lint": "eslint src --ext ts",
+    "lintjs": "eslint media --ext js",
+    "lintcss": "csslint media src",
+    "linthtml": "htmlhint media src",
     "test": "node ./out/test/runTest.js"
   },
   "devDependencies": {


### PR DESCRIPTION
This will enable lint for html, css and js files in src and/or media folder.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>