### PR TITLE
[Jsontracer] Fix RegExp in index.html

### DIFF
--- a/media/Jsontracer/index.html
+++ b/media/Jsontracer/index.html
@@ -49,11 +49,19 @@ This file referenced the result of https://github.com/catapult-project/catapult/
 -->
 <head>
   <meta charset="utf-8">
+  <!--
+    Use a content security policy to only allow loading images from https or from our extension directory,
+    and only allow scripts that have a specific nonce.
+  -->
+  <meta 
+      http-equiv="Content-Security-Policy"
+      content="img-src https: data:;
+                style-src 'unsafe-inline' ${webview.cspSource};
+                script-src 'nonce-${nonce}';">
   <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
   <meta name="theme-color" content="#000000">
   <title>json-tracer</title>
-  <link rel="stylesheet" type="text/css" href="styleUri">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src webview.cspSource; img-src webview.cspSource https:; script-src webview.cspSource;;">
+  <link rel="stylesheet" type="text/css" href="${styleUri}">
 </head>
 <body>
   <div id="root">
@@ -84,6 +92,6 @@ This file referenced the result of https://github.com/catapult-project/catapult/
       </article>
     </main>
   </div>
-  <script nonce="nonce" type="module" src="scriptUri"></script>
+  <script nonce="${nonce}" type="module" src="${scriptUri}"></script>
 </body>
 </html>

--- a/media/Jsontracer/index.html
+++ b/media/Jsontracer/index.html
@@ -50,12 +50,12 @@ This file referenced the result of https://github.com/catapult-project/catapult/
 <head>
   <meta charset="utf-8">
   <!--
-    Use a content security policy to only allow loading images from https or from our extension directory,
+    Use a content security policy to only allow styles from our extension directory,
     and only allow scripts that have a specific nonce.
   -->
   <meta 
       http-equiv="Content-Security-Policy"
-      content="img-src https: data:;
+      content="img-src none;
                 style-src 'unsafe-inline' ${webview.cspSource};
                 script-src 'nonce-${nonce}';">
   <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">

--- a/src/Jsontracer.ts
+++ b/src/Jsontracer.ts
@@ -132,10 +132,10 @@ export class Jsontracer {
     let html = fs.readFileSync(htmlPath.fsPath, {encoding: 'utf-8'});
 
     // Apply js and cs to html
-    html = html.replace(/styleUri/g, `${styleUri}`);
-    html = html.replace(/scriptUri/g, `${scriptUri}`);
-    html = html.replace(/nonce/g, `${nonce}`);
-    html = html.replace(/webview.cspSource/g, `${webview.cspSource}`);
+    html = html.replace(/\${styleUri}/g, `${styleUri}`);
+    html = html.replace(/\${scriptUri}/g, `${scriptUri}`);
+    html = html.replace(/\${nonce}/g, `${nonce}`);
+    html = html.replace(/\${webview.cspSource}/g, `${webview.cspSource}`);
 
     return html;
   }


### PR DESCRIPTION
this will fix RegExp in Jsontracer/index.html, which was applied incorrectly

ONE-vscode-DCO-1.0-Signed-off-by: Junyeong Yang <wnsdud4197@naver.com>