### PR TITLE
[Editor] add onStartupFinished event

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "onCommand:onevscode.import",
     "onCommand:onevscode.json-tracer",
     "onCommand:onevscode.configuration-settings",
-    "onCommand:onevscode.toggle-codelens"
+    "onCommand:onevscode.toggle-codelens",
+    "onStartupFinished"
   ],
   "main": "./out/extension.js",
   "contributes": {


### PR DESCRIPTION
This will call the activate function immediately after the vscode is executed.

Without this, you can only look codelens and hover after another event occurs.

ONE-DCO-1.0-Signed-off-by: YongSoo Kang emoney96@naver.com