### PR TITLE
[Jsontracer] Add level to render bar-graph

### DIFF
--- a/media/Jsontracer/dashboard.js
+++ b/media/Jsontracer/dashboard.js
@@ -50,8 +50,7 @@ import renderLevel from './level.js';
 
 export default function renderDashboard(utility, timeLimit, digit, data) {
   // TODO renderRuler(timeLimit, digit);
-  Object.keys(data).map(
-      key => {
-          renderLevel(timeLimit, key, utility[key], data[key]);
-      });
+  Object.keys(data).map(key => {
+    renderLevel(timeLimit, key, utility[key], data[key]);
+  });
 }

--- a/media/Jsontracer/level.js
+++ b/media/Jsontracer/level.js
@@ -45,13 +45,34 @@
 // This file referenced the result of
 // https://github.com/catapult-project/catapult/tree/444aba89e1c30edf348c611a9df79e2376178ba8/tracing
 
-// TODO import renderRuler from './ruler.js';
-import renderLevel from './level.js';
+// TODO import renderCategory from './category.js';
 
-export default function renderDashboard(utility, timeLimit, digit, data) {
-  // TODO renderRuler(timeLimit, digit);
-  Object.keys(data).map(
-      key => {
-          renderLevel(timeLimit, key, utility[key], data[key]);
-      });
+export default function renderLevel(timeLimit, title, usage, data) {
+  const graph = document.querySelector('.graph');
+
+  const levelContainer = document.createElement('section');
+  levelContainer.className = 'level-container';
+
+  const levelHeader = document.createElement('header');
+  levelHeader.className = 'level-header';
+  levelHeader.addEventListener('click', () => {
+    levelHeader.classList.toggle('fold');
+  });
+
+  const levelTitle = document.createElement('div');
+  levelTitle.className = 'level-title';
+  levelTitle.innerText = title;
+
+  const utility = document.createElement('span');
+  utility.className = 'utility';
+  utility.innerText = usage < 1 ? ' (' + usage * 100 + '%)' : '';
+
+  levelTitle.append(utility);
+  levelHeader.append(levelTitle);
+  levelContainer.append(levelHeader);
+  graph.append(levelContainer);
+
+  Object.keys(data).map(key => {
+    // TODO renderCategory(timeLimit, key, data[key]);
+  });
 }

--- a/media/Jsontracer/level.js
+++ b/media/Jsontracer/level.js
@@ -72,7 +72,8 @@ export default function renderLevel(timeLimit, title, usage, data) {
   levelContainer.append(levelHeader);
   graph.append(levelContainer);
 
-  Object.keys(data).map(key => {
-    // TODO renderCategory(timeLimit, key, data[key]);
-  });
+  Object.keys(data).map(
+      key => {
+          // TODO renderCategory(timeLimit, key, data[key]);
+      });
 }


### PR DESCRIPTION
This will render level-container. The level container will contain several bars on the bar chart.

ONE-vscode-DCO-1.0-Signed-off-by: Jisu Park <parkjisu6239@gmail.com>