### PR TITLE
[Config] fix bug that getOutputPath is not defined

### DIFF
--- a/media/Config/pathAutoComplete.js
+++ b/media/Config/pathAutoComplete.js
@@ -22,6 +22,14 @@ const getInputPath = function(tool) {
   }
 };
 
+const getOutputPath = function(tool) {
+  for (let i = 0; i < tool.options.length; i++) {
+    if (tool.options[i].optionName === 'output_path') {
+      return tool.options[i].optionValue;
+    }
+  }
+};
+
 const makeOutputPath = function(tool, input) {
   // because os maybe win32, divisor can be '\\'
   let divisor = '/';


### PR DESCRIPTION
in pathAutoComplete, getOutputPath is used but not defined
so add getOutputPath to pathAutoComplete.js

ONE-vscode-DCO-1.0-Signed-off-by: TaeKyuRyu <appn12@gmail.com>