### PR TITLE
[Circletracer] Add a file that init builtin options

### DIFF
--- a/src/Circlereader/util/initBuiltinOptions.ts
+++ b/src/Circlereader/util/initBuiltinOptions.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {BuiltinOperator} from '../circle-analysis/circle/builtin-operator';
+import {Model} from '../circle-analysis/circle/model';
+
+export function initBuiltInOperator(model: Model): Array<String> {
+  let builtinCodes = [];
+
+  for (let opcodeIdx = 0; opcodeIdx < model.operatorCodesLength(); opcodeIdx++) {
+    builtinCodes[opcodeIdx] = BuiltinOperator[model.operatorCodes(opcodeIdx)!.builtinCode()];
+  }
+
+  return builtinCodes;
+}


### PR DESCRIPTION
Returns the builtInCodes of model.
The value returning from this function will help recognize the model type during visualization.

ONE-vscode-DCO-1.0-Signed-off-by: Donggil Lee donggillee94@gmail.com