### PR TITLE
[Editor] Fix the conditions that show the Option List.

### DIFF
--- a/src/Editor/HoverProvider.ts
+++ b/src/Editor/HoverProvider.ts
@@ -34,7 +34,9 @@ export class HoverProvider implements vscode.HoverProvider {
       if (item.name === word) {
         markdownString.appendMarkdown(`### ${item.name}\n`);
         markdownString.appendMarkdown(`${item.description}\n`);
-        markdownString.appendMarkdown(`\n --- \n Option List\n\n`);
+        if (item.body.length) {
+          markdownString.appendMarkdown(`\n --- \n Option List\n\n`);
+        }
         item.body.forEach((content) => {
           markdownString.appendMarkdown(`- ${content.attr_name} : ${content.attr_desc}\n`);
 


### PR DESCRIPTION
This will show Option List as a MarkdownString only for tools with sub-attributes.

ONE-DCO-1.0-Signed-off-by: YongSoo Kang <emoney96@naver.com>