### PR TITLE
[Draft] Add missing options to one-optimize

### DIFF
--- a/media/Config/tools.js
+++ b/media/Config/tools.js
@@ -111,6 +111,7 @@ const oneOptimize = {
     {optionName: 'fold_sparse_to_dense', optionValue: false},
     {optionName: 'forward_reshape_to_unaryop', optionValue: false},
     {optionName: 'fuse_add_with_tconv', optionValue: false},
+    {optionName: 'fuse_add_with_fully_connected', optionValue: false},
     {optionName: 'fuse_batchnorm_with_conv', optionValue: false},
     {optionName: 'fuse_batchnorm_with_dwconv', optionValue: false},
     {optionName: 'fuse_batchnorm_with_tconv', optionValue: false},

--- a/src/Editor/json/tools_attr.json
+++ b/src/Editor/json/tools_attr.json
@@ -243,6 +243,10 @@
         "attr_desc" : "fuse Add op to Transposed"
       },
       {
+        "attr_name" : "fuse_add_with_fully_connected",
+        "attr_desc" : "fuse Add op to FullyConnected op"
+      },
+      {
         "attr_name" : "fuse_batchnorm_with_conv",
         "attr_desc" : "fuse BatchNorm op to Convolution op"
       },

--- a/src/Project/BuilderCfgFile.ts
+++ b/src/Project/BuilderCfgFile.ts
@@ -71,6 +71,7 @@ const K_OPT_fold_dwconv: string = 'fold_dwconv';
 const K_OPT_fold_sparse_to_dense: string = 'fold_sparse_to_dense';
 const K_OPT_forward_reshape_to_unaryop: string = 'forward_reshape_to_unaryop';
 const K_OPT_fuse_add_with_tconv: string = 'fuse_add_with_tconv';
+const K_OPT_fuse_add_with_fully_connected: string = 'fuse_add_with_fully_connected';
 const K_OPT_fuse_batchnorm_with_conv: string = 'fuse_batchnorm_with_conv';
 const K_OPT_fuse_batchnorm_with_dwconv: string = 'fuse_batchnorm_with_dwconv';
 const K_OPT_fuse_batchnorm_with_tconv: string = 'fuse_batchnorm_with_tconv';
@@ -80,8 +81,10 @@ const K_OPT_fuse_mean_with_mean: string = 'fuse_mean_with_mean';
 const K_OPT_fuse_transpose_with_mean: string = 'fuse_transpose_with_mean';
 const K_OPT_make_batchnorm_gamma_positive: string = 'make_batchnorm_gamma_positive';
 const K_OPT_fuse_activation_function: string = 'fuse_activation_function';
+const K_OPT_fuse_instnorm: string = 'fuse_instnorm';
 const K_OPT_replace_cw_mul_add_with_depthwise_conv: string =
     'replace_cw_mul_add_with_depthwise_conv';
+const K_OPT_remove_fakequant: string = 'remove_fakequant';
 const K_OPT_remove_quantdequant: string = 'remove_quantdequant';
 const K_OPT_remove_redundant_reshape: string = 'remove_redundant_reshape';
 const K_OPT_remove_redundant_transpose: string = 'remove_redundant_transpose';
@@ -202,6 +205,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
     optimize.oFoldSparseToDense = prop[K_OPT_fold_sparse_to_dense];
     optimize.oForwardReshapeToUnaryop = prop[K_OPT_forward_reshape_to_unaryop];
     optimize.oFuseAddWithTconv = prop[K_OPT_fuse_add_with_tconv];
+    optimize.oFuseAddWithFullyConnected = prop[K_OPT_fuse_add_with_fully_connected];
     optimize.oFuseBatchnormWithConv = prop[K_OPT_fuse_batchnorm_with_conv];
     optimize.oFuseBatchnormWithDwconv = prop[K_OPT_fuse_batchnorm_with_dwconv];
     optimize.oFuseBatchnormWithTconv = prop[K_OPT_fuse_batchnorm_with_tconv];
@@ -211,7 +215,9 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
     optimize.oFuseTransposeWithMean = prop[K_OPT_fuse_transpose_with_mean];
     optimize.oMakeBatchnormGammaPositive = prop[K_OPT_make_batchnorm_gamma_positive];
     optimize.oFuseActivationFunction = prop[K_OPT_fuse_activation_function];
+    optimize.oFuseInstnorm = prop[K_OPT_fuse_instnorm];
     optimize.oReplaceCwMulAddWithDepthwiseConv = prop[K_OPT_replace_cw_mul_add_with_depthwise_conv];
+    optimize.oRemoveFakequant = prop[K_OPT_remove_fakequant];
     optimize.oRemoveQuantdequant = prop[K_OPT_remove_quantdequant];
     optimize.oRemoveRedundantReshape = prop[K_OPT_remove_redundant_reshape];
     optimize.oRemoveRedundantTranspose = prop[K_OPT_remove_redundant_transpose];

--- a/src/Project/JobOptimize.ts
+++ b/src/Project/JobOptimize.ts
@@ -31,6 +31,7 @@ export class JobOptimize extends JobBase {
   oFoldSparseToDense?: boolean = undefined;           // fold_sparse_to_dense
   oForwardReshapeToUnaryop?: boolean = undefined;     // forward_reshape_to_unaryop
   oFuseAddWithTconv?: boolean = undefined;            // fuse_add_with_tconv
+  oFuseAddWithFullyConnected?: boolean = undefined;   // fuse_add_with_fully_connected
   oFuseBatchnormWithConv?: boolean = undefined;       // fuse_batchnorm_with_conv
   oFuseBatchnormWithDwconv?: boolean = undefined;     // fuse_batchnorm_with_dwconv
   oFuseBatchnormWithTconv?: boolean = undefined;      // fuse_batchnorm_with_tconv
@@ -40,8 +41,10 @@ export class JobOptimize extends JobBase {
   oFuseTransposeWithMean?: boolean = undefined;       // fuse_transpose_with_mean
   oMakeBatchnormGammaPositive?: boolean = undefined;  // make_batchnorm_gamma_positive
   oFuseActivationFunction?: boolean = undefined;      // fuse_activation_function
+  oFuseInstnorm?: boolean = undefined;                // fuse_instnorm
   oReplaceCwMulAddWithDepthwiseConv?: boolean =
       undefined;                                         // replace_cw_mul_add_with_depthwise_conv
+  oRemoveFakequant?: boolean = undefined;                // remove_fakequant
   oRemoveQuantdequant?: boolean = undefined;             // remove_quantdequant
   oRemoveRedundantReshape?: boolean = undefined;         // remove_redundant_reshape
   oRemoveRedundantTranspose?: boolean = undefined;       // remove_redundant_transpose
@@ -99,6 +102,7 @@ export class JobOptimize extends JobBase {
     if (this.oFoldSparseToDense) { args.push('--fold_sparse_to_dense'); }
     if (this.oForwardReshapeToUnaryop) { args.push('--forward_reshape_to_unaryop'); }
     if (this.oFuseAddWithTconv) { args.push('--fuse_add_with_tconv'); }
+    if (this.oFuseAddWithFullyConnected) { args.push('--fuse_add_with_fully_connected'); }
     if (this.oFuseBatchnormWithConv) { args.push('--fuse_batchnorm_with_conv'); }
     if (this.oFuseBatchnormWithDwconv) { args.push('--fuse_batchnorm_with_dwconv'); }
     if (this.oFuseBatchnormWithTconv) { args.push('--fuse_batchnorm_with_tconv'); }
@@ -107,8 +111,10 @@ export class JobOptimize extends JobBase {
     if (this.oFuseMeanWithMean) { args.push('--fuse_mean_with_mean'); }
     if (this.oFuseTransposeWithMean) { args.push('--fuse_transpose_with_mean'); }
     if (this.oMakeBatchnormGammaPositive) { args.push('--make_batchnorm_gamma_positive'); }
+    if (this.oFuseInstnorm) { args.push('--fuse_instnorm'); }
     if (this.oFuseActivationFunction) { args.push('--fuse_activation_function'); }
     if (this.oReplaceCwMulAddWithDepthwiseConv) { args.push('--replace_cw_mul_add_with_depthwise_conv'); }
+    if (this.oRemoveFakequant) { args.push('--remove_fakequant'); }
     if (this.oRemoveQuantdequant) { args.push('--remove_quantdequant'); }
     if (this.oRemoveRedundantReshape) { args.push('--remove_redundant_reshape'); }
     if (this.oRemoveRedundantTranspose) { args.push('--remove_redundant_transpose'); }


### PR DESCRIPTION
This commit adds three missing options to one-optimize:

* fuse_add_with_fully_connected
* fuse_instnorm
* remove_fakequant

Sub-PRs:
* Editor: #278
* Project: #280 
* Config: #279 

Signed-off-by: Alexander Moiseev <a.moiseev@samsung.com>