### PR TITLE
[Editor] Add fuse_add_with_fully_connected tool attribute

### DIFF
--- a/src/Editor/json/tools_attr.json
+++ b/src/Editor/json/tools_attr.json
@@ -243,6 +243,10 @@
         "attr_desc" : "fuse Add op to Transposed"
       },
       {
+        "attr_name" : "fuse_add_with_fully_connected",
+        "attr_desc" : "fuse Add op to FullyConnected op"
+      },
+      {
         "attr_name" : "fuse_batchnorm_with_conv",
         "attr_desc" : "fuse BatchNorm op to Convolution op"
       },


### PR DESCRIPTION
This commit adds `fuse_add_with_fully_connected` tool attribute to provide missing option for one-optimize.

Draft PR: #276 

Signed-off-by: Alexander Moiseev <a.moiseev@samsung.com>