### PR TITLE
Show "ONE" instead of "one-vscode" in setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
       }
     ],
     "configuration": {
+      "title": "ONE",
       "properties": {
         "one-vscode.enableCodelens": {
           "type": "boolean",


### PR DESCRIPTION
This shows "ONE" in setting. Previously it was "one-vscode".

For #311

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>