### PR TITLE
[media/Jsontracer] Add missing copyright statement

### DIFF
--- a/media/Jsontracer/colorList.js
+++ b/media/Jsontracer/colorList.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const colorList = [
   'aquamarine',
   'cornflowerblue',


### PR DESCRIPTION
This commit adds missing copyright statement to `colorList.js`.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Originated from : #298 