### PR TITLE
[infra] Add infra directory to exclude list in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
   },
   "exclude": [
     "node_modules",
-    ".vscode-test"
+    ".vscode-test",
+    "infra"
   ]
 }


### PR DESCRIPTION
`.ts` files in `infra/` directory is not related with building ONE-vscode.
Therefore excluding `infra/` directory in `tsconfig.json` would be better.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>