### PR TITLE
Add Setting For Model Directory Path

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
           "type": "boolean",
           "default": true
         },
-        "one-vscode.projectRootPath": {
+        "one-vscode.projectRootDirectory": {
           "type": "string",
           "description": "The directory path where model files are managed.",
           "default": ""

--- a/package.json
+++ b/package.json
@@ -77,6 +77,11 @@
         "one-vscode.enableCodelens": {
           "type": "boolean",
           "default": true
+        },
+        "one-vscode.projectRootDir": {
+          "type": "string",
+          "description": "The directory path where model files are managed.",
+          "default": ""
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
           "type": "boolean",
           "default": true
         },
-        "one-vscode.projectRootDir": {
+        "one-vscode.projectRootPath": {
           "type": "string",
           "description": "The directory path where model files are managed.",
           "default": ""


### PR DESCRIPTION
This adds an input box into Setting under [ONE] section,
where end-user can enter directory path for model files.
    
for #330

reference: https://code.visualstudio.com/api/references/contribution-points#contributes.configuration

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>
