### PR TITLE
Change Package Descripion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "one-vscode",
   "displayName": "one-vscode",
-  "description": "ONE compiler for VSCode",
+  "description": "ONE for VSCode",
   "version": "0.0.1",
   "publisher": "Samsung",
   "engines": {


### PR DESCRIPTION
This changes package description form "ONE Compiler for VSCode"
to "ONE for VSCode"
to synchronize comment at https://github.com/Samsung/ONE-vscode/pull/332#discussion_r824399840.

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>