### PR TITLE
[CI] Fix license checker on push event

### DIFF
--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -1,8 +1,6 @@
 name: License Verification
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
`report_verification_result` cannot be run on `push` event.
But current codes did not care about this.
This commit will fix it.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>