### PR TITLE
[CI] Fix trigger condition for pull request

### DIFF
--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -1,7 +1,7 @@
 name: License Verification
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ main ]
 
 jobs:
@@ -35,6 +35,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: refs/pull/${{ github.event.number }}/merge
+
       - uses: actions/setup-node@v2
         with:
           node-version: '16'


### PR DESCRIPTION
Until now, `pull_request` is used for triggering github action.
But it causes authrization error.
This commit replaces `pull_request` to `pull_request_target`.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>