### PR TITLE
[CI] Fix checkout ref in license checker

### DIFF
--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -14,6 +14,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: refs/pull/${{ github.event.number }}/merge
+
       - uses: actions/setup-node@v2
         with:
           node-version: '16'


### PR DESCRIPTION
Until now, license checker checked out with latest main ref.
As a result, PR is not correctly checked.
This commit will fix it.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>