### PR TITLE
[CI] Use clang-format-14 on Ubuntu 22.04

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,3 +2,6 @@ BasedOnStyle: Google
 Language: JavaScript
 ColumnLimit: 100
 NamespaceIndentation: None
+---
+Language: Json
+BasedOnStyle: Google

--- a/.github/workflows/check-pr-format.yml
+++ b/.github/workflows/check-pr-format.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -20,7 +20,7 @@ jobs:
       - run: npm run lintjs
       - run: npm run lintcss
       - run: npm run linthtml
-      - run: sudo apt-get install clang-format-8
+      - run: sudo apt-get install -yqq clang-format file
       - run: bash infra/format
 
       - name: Upload format.patch

--- a/infra/format
+++ b/infra/format
@@ -67,7 +67,7 @@ function exclude_symbolic_links() {
 }
 
 function check_ts_files() {
-  CLANG_FORMAT_CANDIDATES+=("clang-format-8")
+  CLANG_FORMAT_CANDIDATES+=("clang-format-14")
   for CLANG_FORMAT_CANDIDATE in ${CLANG_FORMAT_CANDIDATES[@]}; do
     if command_exists ${CLANG_FORMAT_CANDIDATE} ; then
       CLANG_FORMAT="${CLANG_FORMAT_CANDIDATE}"
@@ -90,6 +90,9 @@ function check_ts_files() {
       FILES_TO_CHECK_TS+=("${f}")
     fi
     if [[ ${f} == +(*.js) ]]; then
+      FILES_TO_CHECK_TS+=("${f}")
+    fi
+    if [[ ${f} == +(*.json) ]]; then
       FILES_TO_CHECK_TS+=("${f}")
     fi
   done


### PR DESCRIPTION
This commit uses clang-format-14 on Ubuntu 22.04.
clang-format-14 supports to run format-check on json files.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>