### PR TITLE
[CI] Fix fetch ref in Github Action

### DIFF
--- a/.github/workflows/check-commit.yml
+++ b/.github/workflows/check-commit.yml
@@ -20,7 +20,7 @@ jobs:
 
       - run: |
           ROLL_BACK_COUNT=$(( ${{ github.event.pull_request.commits }} - 1 ))
-          git log --format=%B -n 1 ${{ github.event.after }}~${ROLL_BACK_COUNT} > main_commit_msg
+          git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }}~${ROLL_BACK_COUNT} > main_commit_msg
 
       - run: npx ts-node infra/commit/signed-off-by-checker.ts main_commit_msg
 


### PR DESCRIPTION
Until now, we used `refs/pull/PR_NUMBER/merge` or `github.event.after` to fetch PR's commit.
But it causes unintened errors.
This commit will fix it with `github.event.pull_request.head.sha`.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>