### PR TITLE
[Tests] Add MockupJob for unittests of Jobs

### DIFF
--- a/src/Tests/MockJob.ts
+++ b/src/Tests/MockJob.ts
@@ -18,7 +18,7 @@ import {JobBase} from '../Project/JobBase';
 import {ToolArgs} from '../Project/ToolArgs';
 
 // Job for mock-up
-export class MockupJob extends JobBase {
+export class MockJob extends JobBase {
   constructor(name: string) {
     super();
     this.name = name;
@@ -29,12 +29,12 @@ export class MockupJob extends JobBase {
   }
 
   public get tool() {
-    // Just `onecc -h` as dummy
+    // Just use `onecc` as dummy
     return 'onecc';
   }
 
   public get toolArgs() {
-    // Just `onecc -h` as dummy
+    // Just use `-h` of `onecc` as dummy
     let args = new ToolArgs();
     args.push('-h');
     return args;

--- a/src/Tests/MockupJob.ts
+++ b/src/Tests/MockupJob.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {JobBase} from '../Project/JobBase';
+import {ToolArgs} from '../Project/ToolArgs';
+
+// Job for mock-up
+export class MockupJob extends JobBase {
+  constructor(name: string) {
+    super();
+    this.name = name;
+  }
+
+  public get valid() {
+    return true;
+  }
+
+  public get tool() {
+    // Just `onecc -h` as dummy
+    return 'onecc';
+  }
+
+  public get toolArgs() {
+    // Just `onecc -h` as dummy
+    let args = new ToolArgs();
+    args.push('-h');
+    return args;
+  }
+}


### PR DESCRIPTION
Let's add MockupJob for preparing unittests of Jobs such as JobCodegen.

ONE-vscode-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>