### PR TITLE
[infra] Rename keywords for license-checker

### DIFF
--- a/infra/license/README.md
+++ b/infra/license/README.md
@@ -27,15 +27,14 @@ To reduce such risk and labor, automatic license checker would be good solution.
     "pkgname@version": {
       "licenses": "License name",
       "repository": "URL for package repository",
-      "ONE_permitted": "yes / conditional / no",
-      "ONE_caution": "(Optional field) Cautions when package is used"
+      "permitted": "yes / conditional / no",
+      "caution": "(Optional field) Cautions when package is used"
     },
     ```
-    - `ONE_permitted` : Whether the package is allowed in ONE-vscode
+    - `permitted` : Whether a package is allowed in ONE-vscode
       - `yes` : Allowed to use
       - `conditional` : Allowed to use under specific conditions. Needed to be checked manually when release is progressed.
       - `no` : Not allowed to use
-    - `ONE_caution` : Comment about why `ONE_permitted` is `conditional` or `no`.
 
 ### Guideline
 
@@ -58,7 +57,7 @@ To reduce such risk and labor, automatic license checker would be good solution.
   - As a result, `package-judgment.json` includes judgments for each of packages which cannot be judged by `license-judgment.json`
 - `PASS` and `FAIL` in the flowchart is the result of verification, not a result of Github Action
   - Even verification result is `FAIL`, it does not mean Github Action is failed.
-  - This is because we may need to merge pull request even there are some `Warning` or `Denied`
+  - This is because we may need to merge pull request even there are some `Warning` or `Failure`
     - When verification result has `Warning` and the package is under manual review, we cannot merge any pull requests until the manual reivew is finished. But the manual review may take more than 2~3 days.
     - When verification result was recognized and related updates are not yet applied, we cannot merge any pull requests until the updates are applied.
 - `license-checker` can deduce for some unknown licenses. However, we do not use this function because we cannot assure it is always correctly deduced.

--- a/infra/license/check-result-formatter.ts
+++ b/infra/license/check-result-formatter.ts
@@ -26,19 +26,19 @@ const resultPaths = args;
 
 let commentBody = [] as string[];
 let totalWarnCount = 0;
-let totalDenialCount = 0;
+let totalFailCount = 0;
 for (let i = 0; i < resultPaths.length; ++i) {
   const result = JSON.parse(readFileSync(resultPaths[i], 'utf-8'));
 
   commentBody.push(result['resultComment']);
   totalWarnCount += Number(result['warnCount']);
-  totalDenialCount += Number(result['denialCount']);
+  totalFailCount += Number(result['failCount']);
 }
 
 let resultComment = '### License Verification' + EOL + EOL;
-if (totalWarnCount + totalDenialCount > 0) {
-  resultComment += ':warning: Total ' + totalWarnCount.toString() + ' Warnings Found' + EOL;
-  resultComment += ':no_entry: Total ' + totalDenialCount.toString() + ' Denials Found' + EOL;
+if (totalWarnCount + totalFailCount > 0) {
+  resultComment += ':warning: Total ' + totalWarnCount.toString() + ' Warning(s) Found' + EOL;
+  resultComment += ':no_entry: Total ' + totalFailCount.toString() + ' Failure(s) Found' + EOL;
 } else {
   resultComment += ':heavy_check_mark: No License Issues Found' + EOL;
 }
@@ -46,7 +46,7 @@ resultComment += '<details><summary>Detailed Result</summary>' + EOL;
 commentBody.forEach((comment) => {
   resultComment += EOL + '---' + EOL;
   resultComment += comment + EOL;
-})
+});
 resultComment += '</details>';
 
 writeFileSync('license_check_result.md', resultComment);

--- a/infra/license/license-checker.ts
+++ b/infra/license/license-checker.ts
@@ -87,15 +87,15 @@ for (const pkg in usedLicenseList) {
   if (packageJudgment.hasOwnProperty(pkg)) {
     const pkgKey = pkg as keyof typeof packageJudgment;
 
-    if (packageJudgment[pkgKey].ONE_permitted === 'no') {
+    if (packageJudgment[pkgKey].permitted === 'no') {
       deniedList.DeniedCount++;
       deniedList.ONEForbidden.push(pkg + EOL);
-    } else if (packageJudgment[pkgKey].ONE_permitted === 'yes') {
+    } else if (packageJudgment[pkgKey].permitted === 'yes') {
       // Verification PASS, do nothing
-    } else if (packageJudgment[pkgKey].ONE_permitted === 'conditional') {
+    } else if (packageJudgment[pkgKey].permitted === 'conditional') {
       // Verification PASS, check manually when release
     } else {
-      throw new Error('Not implemented ONE_permitted type');
+      throw new Error('Not implemented permitted type');
     }
   } else if (licenseJudgment.Denied.includes(pkgInfo.licenses)) {
     deniedList.DeniedCount++;
@@ -173,7 +173,7 @@ if (issueFound === false) {
 var resultZip = {
   'resultComment': resultComment,
   'warnCount': warningList.WarningCount.toString(),
-  'denialCount': deniedList.DeniedCount.toString()
+  'failCount': deniedList.DeniedCount.toString()
 };
 
 writeFileSync(verificationTag + '.json', JSON.stringify(resultZip));

--- a/infra/license/package-judgment.json
+++ b/infra/license/package-judgment.json
@@ -2,61 +2,61 @@
     "argparse@2.0.1": {
       "licenses": "Python-2.0",
       "repository": "https://github.com/nodeca/argparse",
-      "ONE_permitted": "conditional",
-      "ONE_caution": "Could be conflict with GPL2, LGPL license"
+      "permitted": "conditional",
+      "caution": "Could be conflict with GPL2, LGPL license"
     },
 
     "buffers@0.1.1": {
       "licenses": "MIT",
       "repository": "https://github.com/substack/node-buffers",
-      "ONE_permitted": "yes"
+      "permitted": "yes"
     },
 
     "chainsaw@0.1.0": {
       "licenses": "MIT",
       "repository": "https://github.com/substack/node-chainsaw",
-      "ONE_permitted": "yes"
+      "permitted": "yes"
     },
 
     "expand-template@2.0.3": {
       "licenses": "(MIT OR WTFPL)",
       "repository": "https://github.com/ralphtheninja/expand-template",
-      "ONE_permitted": "yes"
+      "permitted": "yes"
     },
 
     "flatbuffers@2.0.4": {
       "licenses": "Apache-2.0",
       "repository": "https://github.com/google/flatbuffers",
-      "ONE_permitted": "yes"
+      "permitted": "yes"
     },
 
     "one-vscode@0.0.1": {
       "licenses": "Apache-2.0",
       "repository": "https://github.com/Samsung/ONE-vscode",
-      "ONE_permitted": "yes"
+      "permitted": "yes"
     },
 
     "rc@1.2.8": {
       "licenses": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "repository": "https://github.com/dominictarr/rc",
-      "ONE_permitted": "yes"
+      "permitted": "yes"
     },
 
     "spdx-ranges@2.1.1": {
       "licenses": "(MIT AND CC-BY-3.0)",
       "repository": "https://github.com/kemitchell/spdx-ranges.js",
-      "ONE_permitted": "yes"
+      "permitted": "yes"
     },
 
     "traverse@0.3.9": {
       "licenses": "MIT",
       "repository": "https://github.com/substack/js-traverse",
-      "ONE_permitted": "yes"
+      "permitted": "yes"
     },
 
     "type-fest@0.20.2": {
       "licenses": "(MIT OR CC0-1.0)",
       "repository": "https://github.com/sindresorhus/type-fest",
-      "ONE_permitted": "yes"
+      "permitted": "yes"
     }
 }


### PR DESCRIPTION
This commit renames following things for consistancy.
- Remove `ONE_` prefix
- Rename `deny` to `fail`.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

- `flowchart.png` will be modified in another PR because of size limit

Parent Issue : #356 
Draft : #358 
Originated from https://github.com/Samsung/ONE-vscode/pull/295#discussion_r819540232