### PR TITLE
[infra] Generate failure logfile for license check result

### DIFF
--- a/infra/license/check-result-formatter.ts
+++ b/infra/license/check-result-formatter.ts
@@ -51,9 +51,6 @@ resultComment += '</details>';
 
 writeFileSync('license_check_result.md', resultComment);
 
-if (totalWarnCount + totalFailCount === 0) {
-  writeFileSync('license_check_result.pass',"");
-}
-else {
+if (totalWarnCount + totalFailCount > 0) {
   writeFileSync('license_check_result.fail',"");
 }

--- a/infra/license/check-result-formatter.ts
+++ b/infra/license/check-result-formatter.ts
@@ -50,3 +50,10 @@ commentBody.forEach((comment) => {
 resultComment += '</details>';
 
 writeFileSync('license_check_result.md', resultComment);
+
+if (totalWarnCount + totalFailCount === 0) {
+  writeFileSync('license_check_result.pass',"");
+}
+else {
+  writeFileSync('license_check_result.fail',"");
+}


### PR DESCRIPTION
When daily license check result is not passed, new issue should be created.
However, generating failure mark is not added.
This commit will fix it.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #356 
Draft : #358 