### PR TITLE
[infra] Change license-judgment.json format

### DIFF
--- a/infra/license/README.md
+++ b/infra/license/README.md
@@ -17,10 +17,17 @@ To reduce such risk and labor, automatic license checker would be good solution.
 
 - license-judgment.json
   - Each of license names are got from the result of `license-checker`
-  - Each license is classfied to following categories
-    - `Allowed` : Allowed to use
-    - `Warning` : Manual review for each package is needed
-    - `Denied` : Not allowed to use
+  - Each judgment for a license consists of following information
+    ```json
+    "License Name": {
+        "permitted": "yes / conditional / no",
+        "caution": "(Optional field) Why permitted is conditional or no"
+    },
+    ```
+    - `permitted` : Whether a license is allowed in ONE-vscode
+      - `yes` : Allowed to use
+      - `conditional` : Allowed to use under specific conditions. Each package with this should be judged manually.
+      - `no` : Not allowed to use
 - package-judgment.json
   - Each judgment for a package consists of following information
     ```json

--- a/infra/license/license-checker.ts
+++ b/infra/license/license-checker.ts
@@ -97,14 +97,19 @@ for (const pkg in usedLicenseList) {
     } else {
       throw new Error('Not implemented permitted type');
     }
-  } else if (licenseJudgment.Denied.includes(pkgInfo.licenses)) {
-    deniedList.DeniedCount++;
-    deniedList.DeniedLicenseUsed.push(pkg + ' : ' + pkgInfo.licenses + EOL);
-  } else if (licenseJudgment.Warning.includes(pkgInfo.licenses)) {
-    warningList.WarningCount++;
-    warningList.WarnedLicenseUsed.push(pkg + ' : ' + pkgInfo.licenses + EOL);
-  } else if (licenseJudgment.Allowed.includes(pkgInfo.licenses)) {
-    // Verification PASS, do nothing
+  } else if (licenseJudgment.hasOwnProperty(pkgInfo.licenses)) {
+    const licenseKey = pkgInfo.licenses as keyof typeof licenseJudgment;
+    if (licenseJudgment[licenseKey].permitted === 'no') {
+      deniedList.DeniedCount++;
+      deniedList.DeniedLicenseUsed.push(pkg + ' : ' + pkgInfo.licenses + EOL);
+    } else if (licenseJudgment[licenseKey].permitted === 'conditional') {
+      warningList.WarningCount++;
+      warningList.WarnedLicenseUsed.push(pkg + ' : ' + pkgInfo.licenses + EOL);
+    } else if (licenseJudgment[licenseKey].permitted === 'yes') {
+      // Verification PASS, do nothing
+    } else {
+      throw new Error('Not implemented permitted type');
+    }
   } else if (pkgInfo.licenses === 'UNKNOWN') {
     warningList.WarningCount++;
     warningList.UnknownLicense.push(pkg + EOL);

--- a/infra/license/license-judgment.json
+++ b/infra/license/license-judgment.json
@@ -56,11 +56,11 @@
 
     "(MIT AND CC-BY-3.0)": {
         "permitted": "conditional",
-        "caution": "Non-single license is hard to jedge automatically"
+        "caution": "Non-single license is hard to be judged automatically"
     },
 
     "(MIT OR CC0-1.0)": {
         "permitted": "conditional",
-        "caution": "Non-single license is hard to jedge automatically"
+        "caution": "Non-single license is hard to be judged automatically"
     }
 }

--- a/infra/license/license-judgment.json
+++ b/infra/license/license-judgment.json
@@ -1,25 +1,66 @@
 {
-    "Allowed": [
-        "0BSD",
-        "Apache-2.0",
-        "BSD-2-Clause",
-        "BSD-3-Clause",
-        "CC-BY-3.0",
-        "CC-BY-4.0",
-        "CC0-1.0",
-        "ISC",
-        "MIT",
-        "Unlicense"
-    ],
+    "0BSD": {
+        "permitted": "yes"
+    },
 
-    "Warning": [
-        "ODC-By-1.0",
-        "Python-2.0",
-        "(MIT AND CC-BY-3.0)",
-        "(MIT OR CC0-1.0)"
-    ],
+    "Apache-2.0": {
+        "permitted": "yes"
+    },
 
-    "Denied": [
-        "GPL-3.0"
-    ]
+    "BSD-2-Clause": {
+        "permitted": "yes"
+    },
+
+    "BSD-3-Clause": {
+        "permitted": "yes"
+    },
+
+    "CC-BY-3.0": {
+        "permitted": "yes"
+    },
+
+    "CC-BY-4.0": {
+        "permitted": "yes"   
+    },
+
+    "CC0-1.0": {
+        "permitted": "yes"
+    },
+
+    "GPL-3.0": {
+        "permitted": "no",
+        "caution": "Obligation to open source code cannot be accepted"
+    },
+
+    "ISC": {
+        "permitted": "yes"
+    },
+
+    "MIT": {
+        "permitted": "yes"
+    },
+
+    "ODC-By-1.0": {
+        "permitted": "conditional",
+        "caution": "Data verification should be done"
+    },
+
+    "Python-2.0": {
+        "permitted": "conditional",
+        "caution": "Could be conflict with GPL2, LGPL license"
+    },
+
+    "Unlicense": {
+        "permitted": "yes"
+    },
+
+    "(MIT AND CC-BY-3.0)": {
+        "permitted": "conditional",
+        "caution": "Non-single license is hard to jedge automatically"
+    },
+
+    "(MIT OR CC0-1.0)": {
+        "permitted": "conditional",
+        "caution": "Non-single license is hard to jedge automatically"
+    }
 }


### PR DESCRIPTION
This commit changes the format of `license-judgment.json` with following reason.
- To keep consistency with `package-judgment.json`
- To make understanding why `permitted` of license is not `yes`

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #356 
Draft : #358 