### PR TITLE
Add menu to `Files` view

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,14 @@
         "category": "ONE"
       }
     ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "onevscode.fileTreeView-open",
+          "when": "view == FileTreeView"
+        }
+      ]
+    },
     "configuration": {
       "title": "ONE",
       "properties": {


### PR DESCRIPTION
This adds a menu, `set model directory`, to `Files view.
After setting an initial directory, user can set it to
another directory using this menu.

parent issue: https://github.com/Samsung/ONE-vscode/issues/330
draft: https://github.com/Samsung/ONE-vscode/pull/297

after #375

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>