### PR TITLE
[CI] Fix wrong format of ref

### DIFF
--- a/.github/workflows/check-daily-license.yml
+++ b/.github/workflows/check-daily-license.yml
@@ -15,7 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        ref: main
+        with:
+          ref: main
 
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
This commit fixes wrong format of `ref`.
It should be used with `with`.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>