### PR TITLE
[infra] Refactoring license-checker

### DIFF
--- a/infra/license/license-checker.ts
+++ b/infra/license/license-checker.ts
@@ -157,7 +157,7 @@ export function verify(pkgName: string, pkgLicense: string): ResultType {
   return 'warnNeverChecked';
 };
 
-}
+}  // namespace Verification
 
 /**
  * - WarningCount : The total number of warnings


### PR DESCRIPTION
This commit refactors following things
- Reduce if-else statements
- Make verification logic clear
- Make comment creation logic clear
- Inline comments to dictionary values

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #356 
Draft : #358 