### PR TITLE
Add 'Compile' menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "menus": {
       "view/item/context": [
         {
-          "_comment": "When model file is right-cliched, [Compile] menu will be shown.",
+          "_comment": "When model file is right-clicked, [Compile] menu will be shown.",
           "command": "onevscode.show-compile-webview",
           "when": "view == FileTreeView && viewItem == compilableFile"
         }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "onCommand:onevscode.configuration-settings",
     "onCommand:onevscode.toggle-codelens",
     "onCommand:onevscode.circle-tracer",
+    "onCommand:onevscode.show-compile-webview",
     "onCommand:onevscode.fileTreeView-open",
     "onCommand:onevscode.register-installed-toolchain",
     "onCommand:onevscode.install-new-toolchain",
@@ -58,6 +59,12 @@
         "_comment": "Call this command to set the model directory of local machine."
       },
       {
+        "command": "onevscode.show-compile-webview",
+        "title": "compile",
+        "category": "ONE",
+        "_comment": "call this when compiling *.tflite, *.onnx, *.pth, etc"
+      },
+      {
         "command": "onevscode.build",
         "title": "build",
         "category": "ONE"
@@ -89,6 +96,13 @@
       }
     ],
     "menus": {
+      "view/item/context": [
+        {
+          "_comment": "When model file is right-cliched, [Compile] menu will be shown.",
+          "command": "onevscode.show-compile-webview",
+          "when": "view == FileTreeView && viewItem == compilableFile"
+        }
+      ],
       "view/title": [
         {
           "command": "onevscode.fileTreeView-open",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,12 @@ export function activate(context: vscode.ExtensionContext) {
 
   FileTreeViewActivator.activate('onevscode.fileTreeView-open', context);
 
+  let showCompileWebViewCmd =
+      vscode.commands.registerCommand('onevscode.show-compile-webview', () => {
+        vscode.window.showInformationMessage('NYI');
+      });
+  context.subscriptions.push(showCompileWebViewCmd);
+
   let registerInstaelledToolchainCmd = vscode.commands.registerCommand(
       'onevscode.register-installed-toolchain', () => {/* TODO Implement */});
 


### PR DESCRIPTION
This adds 'Compile' menu when user right-clicks compilable file
(e.g., *.tflite) in Files view.

For #330 and #331 
draft #297

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>