### PR TITLE
Remove header of license verification comment

### DIFF
--- a/infra/license/check-result-formatter.ts
+++ b/infra/license/check-result-formatter.ts
@@ -35,7 +35,7 @@ for (let i = 0; i < resultPaths.length; ++i) {
   totalFailCount += Number(result['failCount']);
 }
 
-let resultComment = '### License Verification' + EOL + EOL;
+let resultComment = '';
 if (totalWarnCount + totalFailCount > 0) {
   resultComment += ':warning: Total ' + totalWarnCount.toString() + ' Warning(s) Found' + EOL;
   resultComment += ':no_entry: Total ' + totalFailCount.toString() + ' Failure(s) Found' + EOL;


### PR DESCRIPTION
Current format has a header but we can know if there's
license issue or not without the header by looking at
body of the license verification comment.

Plus, header with big bold font distracts attention about PR.
So I guess removing the header is better to concentrate
reviewing PR.

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>