### PR TITLE
Make ONE-vscode run on the machine where workspace is

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "categories": [
     "Other"
   ],
+  "extensionKind ": "workspace",
   "activationEvents": [
     "onCommand:onevscode.build",
     "onCommand:onevscode.import",


### PR DESCRIPTION
Make ONE-vscode run on the machine where workspace is.

With this PR, when in a local workspace, ONE-vscode runs on the local machine.
When in a remote workspace, ONE-vscode runs on the remote machine.

https://code.visualstudio.com/api/advanced-topics/remote-extensions#architecture-and-extension-kinds
https://code.visualstudio.com/api/advanced-topics/extension-host#preferred-extension-location

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>