### PR TITLE
[Tests] Add `@Use-onecc` suite name

### DIFF
--- a/src/Tests/Project/JobRunner.test.ts
+++ b/src/Tests/Project/JobRunner.test.ts
@@ -25,21 +25,23 @@ import {MockJob} from '../MockJob';
 suite('Project', function() {
   suite('JobRunner', function() {
     const logger = new Logger();
-    suite('#start()', function() {
-      test('jobs are done', function(done) {
-        let jobRunner = new JobRunner(logger);
-        const workspaceRoot: string = obtainWorkspaceRoot();
-        let workJobs = new WorkJobs();
-        workJobs.push(new MockJob('mockup'));
-        workJobs.push(new MockJob('mockup'));
-        assert.strictEqual(workJobs.length, 2);
+    suite('@Use-onecc', function() {
+      suite('#start()', function() {
+        test('jobs are done', function(done) {
+          let jobRunner = new JobRunner(logger);
+          const workspaceRoot: string = obtainWorkspaceRoot();
+          let workJobs = new WorkJobs();
+          workJobs.push(new MockJob('mockup'));
+          workJobs.push(new MockJob('mockup'));
+          assert.strictEqual(workJobs.length, 2);
 
-        // overwrite events so that multiple events will be emitted
-        jobRunner.on('cleanup', function() {
-          assert.strictEqual(workJobs.length, 0);
-          done();
+          // overwrite events so that multiple events will be emitted
+          jobRunner.on('cleanup', function() {
+            assert.strictEqual(workJobs.length, 0);
+            done();
+          });
+          jobRunner.start(workspaceRoot, workJobs);
         });
-        jobRunner.start(workspaceRoot, workJobs);
       });
     });
   });

--- a/src/Tests/Project/ToolRunner.test.ts
+++ b/src/Tests/Project/ToolRunner.test.ts
@@ -26,33 +26,35 @@ suite('Project', function() {
   suite('ToolRunner', function() {
     const logger = new Logger();
     let job = new MockJob('mockup');
-    suite('#getOneccPath()', function() {
-      test('returns onecc path as string', function() {
-        let toolRunner = new ToolRunner(logger);
-        let actual = toolRunner.getOneccPath();  // string or undefined
-        // Note. `onecc` path could be changed by user
+    suite('@Use-onecc', function() {
+      suite('#getOneccPath()', function() {
+        test('returns onecc path as string', function() {
+          let toolRunner = new ToolRunner(logger);
+          let actual = toolRunner.getOneccPath();  // string or undefined
+          // Note. `onecc` path could be changed by user
         assert.isTrue((actual === '/usr/share/one/bin/onecc') ||
                       (actual?.endsWith('onecc')));
+        });
       });
-    });
-    suite('#getRunner()', function() {
-      test('returns runner as Promise<string>', function(done) {
-        let toolRunner = new ToolRunner(logger);
-        const oneccPath = toolRunner.getOneccPath();
-        // oneccPath could be string or undefined. Avoid compiling error
-        if (oneccPath === undefined) {
-          assert.fail('oneccPath should be string type');
-        }
-        const workspaceRoot: string = obtainWorkspaceRoot();
-        const runner =
-            toolRunner.getRunner(job.name, oneccPath, job.tool, job.toolArgs, workspaceRoot);
-        assert.isNotNull(runner);
-        runner
-            .then(function(str) {
-              assert.ok(str);
-              done();
-            })
-            .catch(done);
+      suite('#getRunner()', function() {
+        test('returns runner as Promise<string>', function(done) {
+          let toolRunner = new ToolRunner(logger);
+          const oneccPath = toolRunner.getOneccPath();
+          // oneccPath could be string or undefined. Avoid compiling error
+          if (oneccPath === undefined) {
+            assert.fail('oneccPath should be string type');
+          }
+          const workspaceRoot: string = obtainWorkspaceRoot();
+          const runner =
+              toolRunner.getRunner(job.name, oneccPath, job.tool, job.toolArgs, workspaceRoot);
+          assert.isNotNull(runner);
+          runner
+              .then(function(str) {
+                assert.ok(str);
+                done();
+              })
+              .catch(done);
+        });
       });
     });
   });

--- a/src/Tests/README.md
+++ b/src/Tests/README.md
@@ -45,6 +45,18 @@ src/
       ...
 ```
 
+## Misc in tests
+
+Some names are used to filter specific tests.
+
+```ts
+suite('@Use-onecc', function() {
+  // ...
+});
+```
+
+Like `@Use-onecc` is expressing that these tests use `onecc` commands.
+
 ## scripts
 
 There are three scripts for tests.


### PR DESCRIPTION
This commit adds `@Use-onecc` suite name. Current github action doesn't
install the latest ONE so filter the tests which use onecc.

ONE-vscode-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>