### PR TITLE
[CI] Fix trigger condition and ref

### DIFF
--- a/.github/workflows/check-copyright.yml
+++ b/.github/workflows/check-copyright.yml
@@ -1,7 +1,7 @@
 name: Check Copyright
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ main ]
 
 jobs:
@@ -10,6 +10,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: refs/pull/${{ github.event.number }}/merge
+
       - uses: actions/setup-node@v2
         with:
           node-version: '16'


### PR DESCRIPTION
To create comment, authorization is needed but `pull_request` does not have it.
This commit fixes `pull_request` to `pull_request_target`.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>