### PR TITLE
Dynamic loading of backend

### DIFF
--- a/src/Backends/Backend.ts
+++ b/src/Backends/Backend.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export abstract class Backend {
+  public abstract download(): void;
+
+  public abstract install(): void;
+
+  public abstract runValueTest(): void;
+
+  public abstract runLatencyTest(): void;
+}

--- a/src/Backends/NPUBackend.ts
+++ b/src/Backends/NPUBackend.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Backend} from './Backend';
+
+export class NPUBackend extends Backend {
+  name: string = 'NPUBackend';
+
+  public override download() {
+    console.log(this.name + ': downloaded');
+  }
+
+  public override install() {
+    console.log(this.name + ': installed');
+  }
+
+  public override runValueTest(): void {
+    console.log(this.name + ': runValueTest');
+  }
+
+  public override runLatencyTest(): void {
+    console.log(this.name + ': runLatencyTest');
+  }
+}

--- a/src/Backends/ONERTBackend.ts
+++ b/src/Backends/ONERTBackend.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Backend} from './Backend';
+
+export class ONERTBackend extends Backend {
+  name: string = 'ONERTBackend';
+
+  public override download() {
+    console.log(this.name + ': downloaded');
+  }
+
+  public override install() {
+    console.log(this.name + ': installed');
+  }
+
+  public override runValueTest(): void {
+    console.log(this.name + ': runValueTest');
+  }
+
+  public override runLatencyTest(): void {
+    console.log(this.name + ': runLatencyTest');
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@
 
 import * as vscode from 'vscode';
 
+import {Backend} from './Backends/Backend';
 import {decoder} from './Circlereader/Circlereader';
 import {Circletracer} from './Circletracer';
 import {CompilePanel} from './Compile/CompilePanel';
@@ -26,6 +27,32 @@ import {HoverProvider} from './Editor/HoverProvider';
 import {Jsontracer} from './Jsontracer';
 import {Project} from './Project';
 import {Utils} from './Utils';
+
+async function loadBackend(backendName: string) {
+  let modulePath = `./Backends/${backendName}Backend`;
+
+  let backendModule = await import(modulePath);
+
+  let backendClass = backendModule[`${backendName}Backend`];
+
+  let backend = (new backendClass() as Backend);
+
+  return backend;
+}
+
+async function testBackendAction() {
+  let backend = await loadBackend('NPU');
+  backend.download();
+  backend.install();
+  backend.runValueTest();
+  backend.runLatencyTest();
+
+  backend = await loadBackend('ONERT');
+  backend.download();
+  backend.install();
+  backend.runValueTest();
+  backend.runLatencyTest();
+}
 
 /**
  * Set vscode context that is used globally
@@ -49,6 +76,8 @@ function setGlobalContext() {
 
 export function activate(context: vscode.ExtensionContext) {
   console.log('one-vscode activate OK');
+
+  testBackendAction();
 
   setGlobalContext();
 


### PR DESCRIPTION
Let's test if we can load backend dynamically by looking at directory name.

Usage:
- We provide ONE-vscode with ONERT backend only.
- Some other companies can clone our repo and copy their backend modules under `./src/Backends/`. After that, they can use their backend in ONE-vscode.

for #435

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>