### PR TITLE
Add basic event handlers for HTML element in [Compile] webview

### DIFF
--- a/media/Compile/compile.js
+++ b/media/Compile/compile.js
@@ -89,7 +89,7 @@ function handleCompileClick() {
 
   // Ask vscode extension to compile model file
   vscode.postMessage({
-    command: 'compile-completed',
+    command: 'request-compile',
     // TODO Revise this message in a way that these params can be handled easily by ONE
     text: `Compilation is finished for ${targetCode}. || ` +
         `- Output dir: ${outputDir} || ` +

--- a/media/Compile/compile.js
+++ b/media/Compile/compile.js
@@ -13,6 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+/*
+This code refers to
+https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/b807107df40271e83ea6d36828357fdb10d71f12/default/hello-world/webview-ui/main.js
+*/
+
+// Get access to the VS Code API from within the webview context
+const vscode = acquireVsCodeApi();
 
 // Just like a regular webpage we need to wait for the webview
 // DOM to load before we can reference any of the HTML elements
@@ -21,8 +50,55 @@ window.addEventListener('load', main);
 
 // Main function that gets executed once the webview DOM loads
 function main() {
+  // event from html
+  const compileButton = document.getElementById('compile-button');
+  compileButton.addEventListener('click', handleCompileClick);
+
   const showDetailedOptions = document.getElementById('show-detailed-options');
   showDetailedOptions.addEventListener('click', handleShowDetailedOptionClick);
+
+  const outputDir = document.getElementById('output-dir');
+  outputDir.addEventListener('click', handleOutputDirClick);
+
+  // event from vscode extension
+  window.addEventListener('message', event => {
+    const message = event.data;  // The JSON data our extension sent
+
+    switch (message.command) {
+      case 'set-output-dir':  // called when user enteres output directory in vscode extension UI
+        outputDir.textContent = message.data;
+        break;
+    }
+  });
+}
+
+// Callback function that is executed when the [Compile] button is clicked
+function handleCompileClick() {
+  const targetCode = document.getElementById('target-code').value;
+  const outputDir = document.getElementById('output-dir').textContent;
+  const compilerVer = document.getElementById('compiling-env-ver').value;
+
+  // circle_optimizer options
+  const foldAddV2 = document.getElementById('fold_add_v2').value;
+  const fuseActivationFunction = document.getElementById('fuse_activation_function').value;
+  // TODO Handle more options from circle_optimizer
+
+  // circle_quantizer options
+  const quantizeDequantizeWeights = document.getElementById('quantize_dequantize_weights').value;
+  // TODO Handle more options from circle_quantizer
+
+  // Ask vscode extension to compile model file
+  vscode.postMessage({
+    command: 'compile-completed',
+    // TODO Revise this message in a way that these params can be handled easily by ONE
+    text: `Compilation is finished for ${targetCode}. || ` +
+        `- Output dir: ${outputDir} || ` +
+        `- Compiling env: ${compilerVer} || ` +
+        `Options: || ` +
+        ` --fold_add_v2=${foldAddV2} || ` +
+        ` --fuse_activation_function=${fuseActivationFunction}` +
+        ` --quantize_dequantize_weights=${quantizeDequantizeWeights}`
+  });
 }
 
 function handleShowDetailedOptionClick() {
@@ -32,4 +108,8 @@ function handleShowDetailedOptionClick() {
   } else if (showDetailedOptions.style.display === 'block') {
     showDetailedOptions.style.display = 'none';
   }
+}
+
+function handleOutputDirClick() {
+  vscode.postMessage({command: 'set-output-dir'});
 }

--- a/src/Compile/CompilePanel.ts
+++ b/src/Compile/CompilePanel.ts
@@ -140,7 +140,7 @@ export class CompilePanel {
       const text = message.text;
 
       switch (command) {
-        case 'compile-completed':  // Called when [Compile] button was pressed
+        case 'request-compile':  // Called when [Compile] button was pressed
           //
           // TODO Run ONE compile command
           //

--- a/src/Compile/CompilePanel.ts
+++ b/src/Compile/CompilePanel.ts
@@ -132,13 +132,34 @@ export class CompilePanel {
   /**
    * Sets up an event listener to listen for messages passed from the webview context and
    * executes code based on the message that is recieved.
-   *
-   * @param webview A reference to the extension webview
-   * @param context A reference to the extension context
    */
   private _setWebviewMessageListener() {
-    /* NYI */
-    vscode.window.showInformationMessage('NYI');
+    const webview = this._panel.webview;
+    webview.onDidReceiveMessage((message: any) => {
+      const command = message.command;
+      const text = message.text;
+
+      switch (command) {
+        case 'compile-completed':  // Called when [Compile] button was pressed
+          //
+          // TODO Run ONE compile command
+          //
+          vscode.window.showInformationMessage(text);
+          return;
+        case 'set-output-dir':  // Called to set output directory
+          const options = {canSelectMany: false, canSelectFiles: false, canSelectFolders: true};
+
+          vscode.window.showOpenDialog(options).then((val: vscode.Uri[]|undefined) => {
+            if (val !== undefined) {
+              this._panel.webview.postMessage({command: 'set-output-dir', data: val[0].fsPath});
+            }
+            //
+            // TODO handle directory user entered
+            //
+          });
+          return;
+      }
+    }, undefined, this._disposables);
   }
 
   private _getHtmlForWebview() {
@@ -154,8 +175,6 @@ export class CompilePanel {
 
     const cssUri =
         getUri(this._panel.webview, this._extensionUri, ['media', 'Compile', 'compile.css']);
-
-    // TODO Make each component work by writing code in media/Compile/compile.js
 
     // TODO Extract html file into a separate file
 


### PR DESCRIPTION
This adds basic event handlers for HTML element in [Compile] webview.

The purpose of this PR is to provide basic way to handle events in
JS and vs extension.

Later, "Compile" modeum needs to enable compilation by ONE by adding
more code into this JS code or `_setWebviewMessageListener` in
`CompilePanel.ts` file.

For https://github.com/Samsung/ONE-vscode/issues/331
Draft https://github.com/Samsung/ONE-vscode/pull/297

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>