### PR TITLE
Move some packages into `dependencies` in package.json

### DIFF
--- a/infra/license/package-judgment.json
+++ b/infra/license/package-judgment.json
@@ -24,6 +24,12 @@
       "permitted": "yes"
     },
 
+    "flatbuffers@2.0.3": {
+      "licenses": "Apache-2.0",
+      "repository": "https://github.com/google/flatbuffers",
+      "permitted": "yes"
+    },
+
     "flatbuffers@2.0.4": {
       "licenses": "Apache-2.0",
       "repository": "https://github.com/google/flatbuffers",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,13 @@
     "": {
       "name": "one-vscode",
       "version": "0.0.1",
+      "dependencies": {
+        "@vscode/webview-ui-toolkit": "^0.9.3",
+        "configparser": "^0.3.9",
+        "flatbuffers": "^2.0.3",
+        "ini": "^2.0.0",
+        "which": "^2.0.2"
+      },
       "devDependencies": {
         "@types/chai": "^4.3.0",
         "@types/glob": "^7.1.3",
@@ -16,21 +23,16 @@
         "@typescript-eslint/eslint-plugin": "^4.9.0",
         "@typescript-eslint/parser": "^4.9.0",
         "@vscode/test-electron": "^2.1.3",
-        "@vscode/webview-ui-toolkit": "^0.9.3",
         "chai": "^4.3.6",
-        "configparser": "^0.3.9",
         "csslint": "^1.0.5",
         "eslint": "^7.15.0",
-        "flatbuffers": "^2.0.3",
         "glob": "^7.1.6",
         "htmlhint": "^1.1.3",
-        "ini": "^2.0.0",
         "license-checker": "^25.0.1",
         "mocha": "^9.2.1",
         "ts-node": "^10.7.0",
         "typescript": "^4.1.2",
-        "vsce": "^2.7.0",
-        "which": "^2.0.2"
+        "vsce": "^2.7.0"
       },
       "engines": {
         "vscode": "^1.46.0"
@@ -210,43 +212,39 @@
       "dev": true
     },
     "node_modules/@microsoft/fast-element": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.8.0.tgz",
-      "integrity": "sha512-92GhkCYcay+vcI2yE+P1yD+v59u8Thprmaqg9PgTstf8jLOrevW/6Hna76tMioQQOFtZ8wm2NiiMHD/4sjrfhQ==",
-      "dev": true
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.9.0.tgz",
+      "integrity": "sha512-VxDwoLEEQRRxXfLOB5Llzha9WWvjVJHZFHNE1mn2s1QV5IAkOhrYrhFe9vzv50eI6CqazChDyHDy1km3+rn0wg=="
     },
     "node_modules/@microsoft/fast-foundation": {
-      "version": "2.38.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.38.0.tgz",
-      "integrity": "sha512-jD907wwTMJzXltch234GFHKxnn+ycbZQor7kFolb3Ij6PXqGTUotUEqRrZpiECp7T522t5pYxi305cYc7HQ/ZA==",
-      "dev": true,
+      "version": "2.41.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.41.1.tgz",
+      "integrity": "sha512-q3t43CVsYrLeBbmiY6+GvV0/uUqnz7anmagD8qMBpHIpC6XpEERGBNbyC6AxQrRoBrYBFFhBJRTPn7vCqi4iPA==",
       "dependencies": {
-        "@microsoft/fast-element": "^1.8.0",
-        "@microsoft/fast-web-utilities": "^5.1.0",
+        "@microsoft/fast-element": "^1.9.0",
+        "@microsoft/fast-web-utilities": "^5.2.0",
         "tabbable": "^5.2.0",
         "tslib": "^1.13.0"
       }
     },
     "node_modules/@microsoft/fast-react-wrapper": {
-      "version": "0.1.44",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.1.44.tgz",
-      "integrity": "sha512-zsvInnvT8QEvsTtuA2Fx26OGzX9VIg+YeuY3otOYW2hMFc6IzY4ZRpJP5lhaE+CRDmbDnQ9fpilYeJbjMkySnQ==",
-      "dev": true,
+      "version": "0.1.48",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.1.48.tgz",
+      "integrity": "sha512-9NvEjru9Kn5ZKjomAMX6v+eF0DR+eDkxKDwDfi+Wb73kTbrNzcnmlwd4diN15ygH97kldgj2+lpvI4CKLQQWLg==",
       "dependencies": {
-        "@microsoft/fast-element": "^1.8.0",
-        "@microsoft/fast-foundation": "^2.38.0"
+        "@microsoft/fast-element": "^1.9.0",
+        "@microsoft/fast-foundation": "^2.41.1"
       },
       "peerDependencies": {
         "react": ">=16.9.0"
       }
     },
     "node_modules/@microsoft/fast-web-utilities": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.1.0.tgz",
-      "integrity": "sha512-S2PCxI4XqtIxLM1N7i/NuIAgx+mJM01+mDzyB3vZlYibAkOT0bzp5YZCp+coXowokSin/nK5T2kqShMXEzI6Jg==",
-      "dev": true,
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.2.0.tgz",
+      "integrity": "sha512-Ri5FR4MotdAPKeFLo/yhZu6/xMVo/H9OXcGaC/qiQo+U0zY8cLPCViGmHYYgxpCYviS4VpgqPL5dslTE6wg9Yg==",
       "dependencies": {
-        "exenv-es6": "^1.0.0"
+        "exenv-es6": "^1.1.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -563,7 +561,6 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-0.9.3.tgz",
       "integrity": "sha512-uEEpTVA21zkHtWMR8TPT7vbIZ1+tvfhQPThEdmmDjh0PulKPvaAVNqnGbQitU3F9GVqpq2AdIKAq6N1jFeBoXg==",
-      "dev": true,
       "dependencies": {
         "@microsoft/fast-element": "^1.6.2",
         "@microsoft/fast-foundation": "^2.34.0",
@@ -1176,7 +1173,6 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/configparser/-/configparser-0.3.9.tgz",
       "integrity": "sha512-ZlHt4SyiCfcQmFkt+2OfUQG6PC4GLyXthfBHvCH9I4ZtDxqMaAkfeEP+bkgePWgO3869+dRMVIcjklwfZmPDjg==",
-      "dev": true,
       "dependencies": {
         "mkdirp": "^0.5.1"
       }
@@ -1725,10 +1721,9 @@
       }
     },
     "node_modules/exenv-es6": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.0.0.tgz",
-      "integrity": "sha512-fcG/TX8Ruv9Ma6PBaiNsUrHRJzVzuFMP6LtPn/9iqR+nr9mcLeEOGzXQGLC5CVQSXGE98HtzW2mTZkrCA3XrDg==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz",
+      "integrity": "sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ=="
     },
     "node_modules/expand-template": {
       "version": "2.0.3",
@@ -1854,10 +1849,9 @@
       }
     },
     "node_modules/flatbuffers": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-2.0.4.tgz",
-      "integrity": "sha512-4rUFVDPjSoP0tOII34oQf+72NKU7E088U5oX7kwICahft0UB2kOQ9wUzzCp+OHxByERIfxRDCgX5mP8Pjkfl0g==",
-      "dev": true
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-2.0.3.tgz",
+      "integrity": "sha512-lTN0GS4FjwPY6h8BDDuq8f2ZORIyRgI4pHXzIt7GBsTgyCt2z9OAPiWNaeEaNcjrmuLLzFagEDwpYiqGv5BEWg=="
     },
     "node_modules/flatted": {
       "version": "3.2.5",
@@ -2315,7 +2309,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
       "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -2413,14 +2406,12 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -2658,7 +2649,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -2792,14 +2782,12 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -3456,7 +3444,6 @@
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.0.0.tgz",
       "integrity": "sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -3993,8 +3980,7 @@
     "node_modules/tabbable": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.2.1.tgz",
-      "integrity": "sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ==",
-      "dev": true
+      "integrity": "sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ=="
     },
     "node_modules/table": {
       "version": "6.8.0",
@@ -4197,8 +4183,7 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -4527,7 +4512,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -4854,40 +4838,36 @@
       "dev": true
     },
     "@microsoft/fast-element": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.8.0.tgz",
-      "integrity": "sha512-92GhkCYcay+vcI2yE+P1yD+v59u8Thprmaqg9PgTstf8jLOrevW/6Hna76tMioQQOFtZ8wm2NiiMHD/4sjrfhQ==",
-      "dev": true
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.9.0.tgz",
+      "integrity": "sha512-VxDwoLEEQRRxXfLOB5Llzha9WWvjVJHZFHNE1mn2s1QV5IAkOhrYrhFe9vzv50eI6CqazChDyHDy1km3+rn0wg=="
     },
     "@microsoft/fast-foundation": {
-      "version": "2.38.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.38.0.tgz",
-      "integrity": "sha512-jD907wwTMJzXltch234GFHKxnn+ycbZQor7kFolb3Ij6PXqGTUotUEqRrZpiECp7T522t5pYxi305cYc7HQ/ZA==",
-      "dev": true,
+      "version": "2.41.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.41.1.tgz",
+      "integrity": "sha512-q3t43CVsYrLeBbmiY6+GvV0/uUqnz7anmagD8qMBpHIpC6XpEERGBNbyC6AxQrRoBrYBFFhBJRTPn7vCqi4iPA==",
       "requires": {
-        "@microsoft/fast-element": "^1.8.0",
-        "@microsoft/fast-web-utilities": "^5.1.0",
+        "@microsoft/fast-element": "^1.9.0",
+        "@microsoft/fast-web-utilities": "^5.2.0",
         "tabbable": "^5.2.0",
         "tslib": "^1.13.0"
       }
     },
     "@microsoft/fast-react-wrapper": {
-      "version": "0.1.44",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.1.44.tgz",
-      "integrity": "sha512-zsvInnvT8QEvsTtuA2Fx26OGzX9VIg+YeuY3otOYW2hMFc6IzY4ZRpJP5lhaE+CRDmbDnQ9fpilYeJbjMkySnQ==",
-      "dev": true,
+      "version": "0.1.48",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.1.48.tgz",
+      "integrity": "sha512-9NvEjru9Kn5ZKjomAMX6v+eF0DR+eDkxKDwDfi+Wb73kTbrNzcnmlwd4diN15ygH97kldgj2+lpvI4CKLQQWLg==",
       "requires": {
-        "@microsoft/fast-element": "^1.8.0",
-        "@microsoft/fast-foundation": "^2.38.0"
+        "@microsoft/fast-element": "^1.9.0",
+        "@microsoft/fast-foundation": "^2.41.1"
       }
     },
     "@microsoft/fast-web-utilities": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.1.0.tgz",
-      "integrity": "sha512-S2PCxI4XqtIxLM1N7i/NuIAgx+mJM01+mDzyB3vZlYibAkOT0bzp5YZCp+coXowokSin/nK5T2kqShMXEzI6Jg==",
-      "dev": true,
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.2.0.tgz",
+      "integrity": "sha512-Ri5FR4MotdAPKeFLo/yhZu6/xMVo/H9OXcGaC/qiQo+U0zY8cLPCViGmHYYgxpCYviS4VpgqPL5dslTE6wg9Yg==",
       "requires": {
-        "exenv-es6": "^1.0.0"
+        "exenv-es6": "^1.1.1"
       }
     },
     "@nodelib/fs.scandir": {
@@ -5108,7 +5088,6 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-0.9.3.tgz",
       "integrity": "sha512-uEEpTVA21zkHtWMR8TPT7vbIZ1+tvfhQPThEdmmDjh0PulKPvaAVNqnGbQitU3F9GVqpq2AdIKAq6N1jFeBoXg==",
-      "dev": true,
       "requires": {
         "@microsoft/fast-element": "^1.6.2",
         "@microsoft/fast-foundation": "^2.34.0",
@@ -5566,7 +5545,6 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/configparser/-/configparser-0.3.9.tgz",
       "integrity": "sha512-ZlHt4SyiCfcQmFkt+2OfUQG6PC4GLyXthfBHvCH9I4ZtDxqMaAkfeEP+bkgePWgO3869+dRMVIcjklwfZmPDjg==",
-      "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
       }
@@ -5975,10 +5953,9 @@
       "dev": true
     },
     "exenv-es6": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.0.0.tgz",
-      "integrity": "sha512-fcG/TX8Ruv9Ma6PBaiNsUrHRJzVzuFMP6LtPn/9iqR+nr9mcLeEOGzXQGLC5CVQSXGE98HtzW2mTZkrCA3XrDg==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz",
+      "integrity": "sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ=="
     },
     "expand-template": {
       "version": "2.0.3",
@@ -6080,10 +6057,9 @@
       }
     },
     "flatbuffers": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-2.0.4.tgz",
-      "integrity": "sha512-4rUFVDPjSoP0tOII34oQf+72NKU7E088U5oX7kwICahft0UB2kOQ9wUzzCp+OHxByERIfxRDCgX5mP8Pjkfl0g==",
-      "dev": true
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-2.0.3.tgz",
+      "integrity": "sha512-lTN0GS4FjwPY6h8BDDuq8f2ZORIyRgI4pHXzIt7GBsTgyCt2z9OAPiWNaeEaNcjrmuLLzFagEDwpYiqGv5BEWg=="
     },
     "flatted": {
       "version": "3.2.5",
@@ -6428,8 +6404,7 @@
     "ini": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-      "dev": true
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -6497,14 +6472,12 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -6701,7 +6674,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "peer": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -6804,14 +6776,12 @@
     "minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.6"
       }
@@ -7314,7 +7284,6 @@
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.0.0.tgz",
       "integrity": "sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==",
-      "dev": true,
       "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
@@ -7708,8 +7677,7 @@
     "tabbable": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.2.1.tgz",
-      "integrity": "sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ==",
-      "dev": true
+      "integrity": "sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ=="
     },
     "table": {
       "version": "6.8.0",
@@ -7862,8 +7830,7 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -8133,7 +8100,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -143,24 +143,26 @@
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
     "@vscode/test-electron": "^2.1.3",
-    "@vscode/webview-ui-toolkit": "^0.9.3",
     "chai": "^4.3.6",
-    "configparser": "^0.3.9",
     "csslint": "^1.0.5",
     "eslint": "^7.15.0",
-    "flatbuffers": "^2.0.3",
     "glob": "^7.1.6",
     "htmlhint": "^1.1.3",
-    "ini": "^2.0.0",
     "license-checker": "^25.0.1",
     "mocha": "^9.2.1",
     "ts-node": "^10.7.0",
     "typescript": "^4.1.2",
-    "vsce": "^2.7.0",
-    "which": "^2.0.2"
+    "vsce": "^2.7.0"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/Samsung/ONE-vscode.git"
+  },
+  "dependencies": {
+    "@vscode/webview-ui-toolkit": "^0.9.3",
+    "configparser": "^0.3.9",
+    "flatbuffers": "^2.0.3",
+    "ini": "^2.0.0",
+    "which": "^2.0.2"
   }
 }


### PR DESCRIPTION
This moves some packages from `devDependencies` to `dependencies`
in pckage.json.

Parent issue: https://github.com/Samsung/ONE-vscode/issues/447 for background and solutions.

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>