### PR TITLE
Add basic support for multiple backend

### DIFF
--- a/src/Backend/API.ts
+++ b/src/Backend/API.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This file defines common API exposed by backend extension.
+ *
+ * Each backend extensions should implement Backend interface.
+ * Through registration API of ONE-vscode extension, those backend extensions
+ * needs to register implementation of Backend interface.
+ *
+ * TODO ONE-vscode and backend extensions have copies of this file. Check if this is really OK.
+ */
+
+/**
+ * Class containing information of compiler toolchains
+ */
+class CompilerToolchains {
+  /* TODO Implement */
+};
+
+/**
+ * Interface of backend extension
+ */
+interface Backend {
+  /**
+   * Return name of backend
+   */
+  name(): string;
+
+  //
+  // Compiler toolchain API
+  //
+
+  /**
+   * Search already-installed compiler toolchain in local desktop and remote server
+   */
+  getInstalledCompilerToolchain(): CompilerToolchains;
+
+  // TODO Define more functions
+}
+
+export {Backend, CompilerToolchains};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@
 
 import * as vscode from 'vscode';
 
+import {Backend} from './Backend/API';
 import {decoder} from './Circlereader/Circlereader';
 import {Circletracer} from './Circletracer';
 import {CompilePanel} from './Compile/CompilePanel';
@@ -26,6 +27,21 @@ import {HoverProvider} from './Editor/HoverProvider';
 import {Jsontracer} from './Jsontracer';
 import {Project} from './Project';
 import {Utils} from './Utils';
+
+// List of backend extensions registered
+let backends: Backend[] = [];
+
+function backendRegistrationApi() {
+  let registrationAPI = {
+    registerBackend(backend: Backend) {
+      backends.push(backend);
+
+      console.log(`Backend ${backend.name()} was registered into ONE-vscode.`);
+    }
+  };
+
+  return registrationAPI;
+}
 
 /**
  * Set vscode context that is used globally
@@ -130,6 +146,9 @@ export function activate(context: vscode.ExtensionContext) {
     });
   });
   context.subscriptions.push(disposableOneCircleTracer);
+
+  // returning backend registration function that will be called by backend extensions
+  return backendRegistrationApi();
 }
 
 export function deactivate() {


### PR DESCRIPTION
This adds API that backend extensions must implement
and a function (registerBackend) through which backend extensions
registers backend implementation.

Related issue #441
Related draft: #444 #445

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>