### PR TITLE
[Compiler/View] Remove contextual title in compiler toolchain view

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
       "ONE-Views": [
         {
           "id": "CompilerToolchainView",
-          "name": "Compiler Toolchain",
-          "contextualTitle": "ONE"
+          "name": "Compiler Toolchain"
         }
       ]
     },


### PR DESCRIPTION
This contextual title is not required if CompilerToolchainView is
included in ONE-Views container.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>