### PR TITLE
[Tests] Fix vscode version to avoid error

### DIFF
--- a/src/Tests/runTest.ts
+++ b/src/Tests/runTest.ts
@@ -55,6 +55,7 @@ async function main() {
         path.resolve(extensionDevelopmentPath, 'out', 'Tests', 'index');
     const testWorkspace = path.resolve(extensionDevelopmentPath);
     await runTests({
+      version: '1.64.0',
       extensionDevelopmentPath,
       extensionTestsPath: extensionTestsPath,
       launchArgs: [testWorkspace]


### PR DESCRIPTION
The latest vscode v1.66 has caused errors so it needs to be fixed to
v1.64 until the problem would be resolved.

ONE-vscode-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>