### PR TITLE
Add 'test-no-screen' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "linthtml": "htmlhint media src",
     "unittest": "node ./out/Tests/runTest.js",
     "test": "npm run unittest",
+    "test-no-screen": "DISPLAY=:44 xvfb-run --server-num 44 npm run test",
     "clean": "rm -rf out"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds `test-no-screen` script in package.json, which is used
when dev environment cannot run vscode GUI. (e.g., Windows connecting
Linux machine via SSH extension).

This is originated from [ .github/workflows/check-pr-format.yml.](https://github.com/Samsung/ONE-vscode/blob/e6e52be227ae83e1622a303646b3aad14047dbdd/.github/workflows/check-pr-test.yml#L18)

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>