### PR TITLE
[View] Add context and detail explorers

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,15 @@
     "views": {
       "ONE-Views": [
         {
+          "id": "ContextExplorerView",
+          "name": "Context Explorer"
+        },
+        {
+          "id": "DetailExplorerView",
+          "name": "Detail Explorer",
+          "visibility": "collapsed"
+        },
+        {
           "id": "CompilerToolchainView",
           "name": "Compiler Toolchain"
         },


### PR DESCRIPTION
This commit adds context and detail explorers on ONE view container.
The detail explorer is collapsed at the first installed.
Once the user has changed the view state by moving, hiding the view,
the initial state will not be used again.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

related issue: #476 
/cc @Samsung/one-vscode 