### PR TITLE
Use codicon instead of raw image files

### DIFF
--- a/media/icon/dark/install.svg
+++ b/media/icon/dark/install.svg
@@ -1,7 +1,0 @@
-<!--
-This image is copied from
-https://github.com/microsoft/vscode-icons/blob/afa041d46f4323acdad167afdded418db08cd1da/icons/dark/desktop-download.svg
--->
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M4 15V14C6 14 6 13.4 6 13H1.5L1 12.5V2.5L1.5 2H14.5L15 2.5V11.74L14 10.74V3H2V12H7.73L7.23 12.5L9.73 15H4ZM11.86 15L14.36 12.5L13.65 11.8L12 13.45V7H11V13.44L9.35999 11.79L8.64999 12.5L11.15 15H11.86Z" fill="#C5C5C5"/>
-</svg>

--- a/media/icon/dark/refresh.svg
+++ b/media/icon/dark/refresh.svg
@@ -1,8 +1,0 @@
-<!--
-This image is copied from
-https://github.com/microsoft/vscode-icons/blob/afa041d46f4323acdad167afdded418db08cd1da/icons/dark/refresh.svg
--->
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M5.56253 2.51577C3.46348 3.4501 2 5.55414 2 7.99999C2 11.3137 4.68629 14 8 14C11.3137 14 14 11.3137 14 7.99999C14 5.32519 12.2497 3.05919 9.83199 2.28482L9.52968 3.23832C11.5429 3.88454 13 5.7721 13 7.99999C13 10.7614 10.7614 13 8 13C5.23858 13 3 10.7614 3 7.99999C3 6.31104 3.83742 4.81767 5.11969 3.91245L5.56253 2.51577Z" fill="#C5C5C5"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M5 3H2V2H5.5L6 2.5V6H5V3Z" fill="#C5C5C5"/>
-</svg>

--- a/media/icon/light/install.svg
+++ b/media/icon/light/install.svg
@@ -1,7 +1,0 @@
-<!--
-This image is copied from
-https://github.com/microsoft/vscode-icons/blob/afa041d46f4323acdad167afdded418db08cd1da/icons/light/desktop-download.svg
--->
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M4.00024 15V14C6.00024 14 6.00024 13.4 6.00024 13H1.50024L1.00024 12.5V2.5L1.50024 2H14.5002L15.0002 2.5V11.74L14.0002 10.74V3H2.00024V12H7.73024L7.23024 12.5L9.73024 15H4.00024ZM11.8602 15L14.3602 12.5L13.6502 11.8L12.0002 13.45V7H11.0002V13.44L9.36024 11.79L8.65024 12.5L11.1502 15H11.8602Z" fill="#424242"/>
-</svg>

--- a/media/icon/light/refresh.svg
+++ b/media/icon/light/refresh.svg
@@ -1,8 +1,0 @@
-<!--
-This image is copied from
-https://github.com/microsoft/vscode-icons/blob/afa041d46f4323acdad167afdded418db08cd1da/icons/light/refresh.svg
--->
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M5.56277 2.51577C3.46372 3.4501 2.00024 5.55414 2.00024 7.99999C2.00024 11.3137 4.68654 14 8.00024 14C11.314 14 14.0002 11.3137 14.0002 7.99999C14.0002 5.32519 12.25 3.05919 9.83224 2.28482L9.52992 3.23832C11.5431 3.88454 13.0002 5.7721 13.0002 7.99999C13.0002 10.7614 10.7617 13 8.00024 13C5.23882 13 3.00024 10.7614 3.00024 7.99999C3.00024 6.31104 3.83766 4.81767 5.11994 3.91245L5.56277 2.51577Z" fill="#424242"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M5.00024 3H2.00024V2H5.50024L6.00024 2.5V6H5.00024V3Z" fill="#424242"/>
-</svg>

--- a/package.json
+++ b/package.json
@@ -54,19 +54,13 @@
         "command": "onevscode.refresh-compiler",
         "title": "Refresh",
         "category": "ONE",
-        "icon": {
-          "light": "media/icon/light/refresh.svg",
-          "dark": "media/icon/dark/refresh.svg"
-        }
+        "icon": "$(refresh)"
       },
       {
         "command": "onevscode.install-compiler",
         "title": "Install",
         "category": "ONE",
-        "icon": {
-          "light": "media/icon/light/install.svg",
-          "dark": "media/icon/dark/install.svg"
-        }
+        "icon": "$(desktop-download)"
       },
       {
         "command": "onevscode.build",


### PR DESCRIPTION
Icon images in `media/` is VSCode built-in icons.
This commit will replace them with built-in icons.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>