### PR TITLE
[Draft] [View] Add context explorer view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,10 @@
       "devDependencies": {
         "@types/chai": "^4.3.0",
         "@types/glob": "^7.1.3",
+        "@types/mkdirp": "^1.0.2",
         "@types/mocha": "^9.1.0",
         "@types/node": "^12.11.7",
+        "@types/rimraf": "^3.0.2",
         "@types/vscode": "^1.46.0",
         "@typescript-eslint/eslint-plugin": "^4.9.0",
         "@typescript-eslint/parser": "^4.9.0",
@@ -343,6 +345,15 @@
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
       "dev": true
     },
+    "node_modules/@types/mkdirp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
+      "integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mocha": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
@@ -354,6 +365,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.47.tgz",
       "integrity": "sha512-BzcaRsnFuznzOItW1WpQrDHM7plAa7GIDMZ6b5pnMbkqEtM/6WCOhvZar39oeMQP79gwvFUWjjptE7/KGcNqFg==",
       "dev": true
+    },
+    "node_modules/@types/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/vscode": {
       "version": "1.65.0",
@@ -4954,6 +4975,15 @@
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
       "dev": true
     },
+    "@types/mkdirp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
+      "integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mocha": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
@@ -4965,6 +4995,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.47.tgz",
       "integrity": "sha512-BzcaRsnFuznzOItW1WpQrDHM7plAa7GIDMZ6b5pnMbkqEtM/6WCOhvZar39oeMQP79gwvFUWjjptE7/KGcNqFg==",
       "dev": true
+    },
+    "@types/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "@types/vscode": {
       "version": "1.65.0",

--- a/package.json
+++ b/package.json
@@ -180,8 +180,10 @@
   "devDependencies": {
     "@types/chai": "^4.3.0",
     "@types/glob": "^7.1.3",
+    "@types/mkdirp": "^1.0.2",
     "@types/mocha": "^9.1.0",
     "@types/node": "^12.11.7",
+    "@types/rimraf": "^3.0.2",
     "@types/vscode": "^1.46.0",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",

--- a/package.json
+++ b/package.json
@@ -180,10 +180,8 @@
   "devDependencies": {
     "@types/chai": "^4.3.0",
     "@types/glob": "^7.1.3",
-    "@types/mkdirp": "^1.0.2",
     "@types/mocha": "^9.1.0",
     "@types/node": "^12.11.7",
-    "@types/rimraf": "^3.0.2",
     "@types/vscode": "^1.46.0",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,15 @@
     "views": {
       "ONE-Views": [
         {
+          "id": "ContextExplorerView",
+          "name": "Context Explorer"
+        },
+        {
+          "id": "DetailExplorerView",
+          "name": "Detail Explorer",
+          "visibility": "collapsed"
+        },
+        {
           "id": "CompilerToolchainView",
           "name": "Compiler Toolchain"
         },

--- a/src/contextExplorer.ts
+++ b/src/contextExplorer.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { config } from 'process';
+
+export class ContextNode extends vscode.TreeItem {
+
+  constructor(
+    public readonly label: string,
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+    public readonly command?: vscode.Command
+  ) {
+    super(label, collapsibleState);
+
+    this.tooltip = `${this.label}`;
+    this.description = this.label;
+  }
+
+  iconPath = vscode.ThemeIcon.File;
+
+  
+}
+
+export class ContextTreeDataProvider implements vscode.TreeDataProvider<ContextNode> {
+
+  private _onDidChangeTreeData: vscode.EventEmitter<ContextNode | undefined | void> = new vscode.EventEmitter<ContextNode | undefined | void>();
+  readonly onDidChangeTreeData: vscode.Event<ContextNode | undefined | void> = this._onDidChangeTreeData.event;
+
+  constructor(private workspaceRoot: string | undefined) {
+  }
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(element: ContextNode): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(element?: ContextNode): ContextNode[] | Thenable<ContextNode[]> {
+    if (!this.workspaceRoot) {
+      vscode.window.showInformationMessage('No context in empty workspace');
+      return Promise.resolve([]);
+    }
+
+    if (element) {
+      // return Promise.resolve(this.getContextFile(this.workspaceRoot));
+      console.log(element);
+      return Promise.resolve([]);
+    } else {
+      return Promise.resolve(this.getConfigFiles(this.workspaceRoot));
+    }
+  }
+
+  private getConfigFiles(rootPath: string): ContextNode[] {
+    if (this.pathExists(rootPath)) {
+      const configLists: ContextNode[] = [];
+
+    //   const searchConfig = (rootPath: string) => {
+    //     fs.readdir(rootPath, function (err, files) {
+    //     if (err) {
+    //       vscode.window.showErrorMessage('Unable to load config files: ' + err);
+    //     } else {
+    //       files.forEach(function (file) {
+    //         console.log(file);
+    //         // if (file.endsWith('cfg')) {
+    //         //   configLists.push(new ContextNode(file, false, vscode.TreeItemCollapsibleState.None));
+    //         // } else {
+    //         const stat = fs.lstatSync(file);
+    //         if (stat.isDirectory()) {
+    //           searchConfig(file);
+    //         }
+    //         // }
+    //       });
+    //     }
+    //   });
+    // };
+
+    // searchConfig(rootPath);
+
+      // const searchConfig = (rootPath: string) => {
+      //   if (this.pathExists(rootPath)) {
+      //     const isDir = (fn: string) => {
+      //       return fs.lstatSync(fn).isDirectory();
+      //     };
+      //     const dirs = fs.readdirSync(rootPath).map(fn => {
+      //       return path.join(rootPath, fn);
+      //     })
+      //     .filter(isDir);
+      //     dirs.map(fn => {
+      //       // configLists.push(new ContextNode(fn, true, vscode.TreeItemCollapsibleState.Collapsed));
+      //       searchConfig(fn);
+      //     });
+      //     const cfgs = fs.readdirSync(rootPath).filter(fn => fn.endsWith('.cfg'));
+      //     cfgs.forEach(fn => {
+      //       console.log(fn);
+      //       configLists.push(new ContextNode(fn, vscode.TreeItemCollapsibleState.None));
+      //     });
+      //   }
+      // };
+
+      const searchConfig = (rootPath: string) => {
+        if (this.pathExists(rootPath)) {
+          const isDir = (fn: string) => {
+            return fs.lstatSync(fn).isDirectory();
+          };
+          const dirs = fs.readdirSync(rootPath).map(fn => {
+            return path.join(rootPath, fn);
+          })
+          .filter(isDir);
+          dirs.map(fn => {
+            // configLists.push(new ContextNode(fn, true, vscode.TreeItemCollapsibleState.Collapsed));
+            searchConfig(fn);
+          });
+          const cfgs = fs.readdirSync(rootPath).filter(fn => fn.endsWith('.cfg'));
+          if (cfgs.length > 0) {
+            configLists.push(new ContextNode(rootPath.replace(this.workspaceRoot!, ''), vscode.TreeItemCollapsibleState.Collapsed));
+          }
+          cfgs.forEach(fn => {
+            console.log(fn);
+            configLists.push(new ContextNode(fn, vscode.TreeItemCollapsibleState.None));
+          });
+        }
+      };
+
+      searchConfig(rootPath);
+
+      return configLists;
+    } else {
+      return [];
+    }
+  }
+
+  private pathExists(p: string): boolean {
+    try {
+      fs.accessSync(p);
+    } catch (err) {
+      return false;
+    }
+    return true;
+  }
+}
+
+export class ContextExplorer {
+  constructor(context: vscode.ExtensionContext) {
+    const rootPath = (vscode.workspace.workspaceFolders && (vscode.workspace.workspaceFolders.length > 0))
+		? vscode.workspace.workspaceFolders[0].uri.fsPath : undefined;
+
+    const contextProvider = new ContextTreeDataProvider(rootPath);
+    vscode.window.registerTreeDataProvider('ContextExplorerView', contextProvider);
+  }
+}

--- a/src/contextExplorer.ts
+++ b/src/contextExplorer.ts
@@ -14,324 +14,115 @@
  * limitations under the License.
  */
 
-import * as vscode from 'vscode';
-import * as path from 'path';
 import * as fs from 'fs';
-import * as mkdirp from 'mkdirp';
-import * as rimraf from 'rimraf';
+import * as path from 'path';
+import {config} from 'process';
+import {stringify} from 'querystring';
+import * as vscode from 'vscode';
 
-//#region Utilities
-
-namespace _ {
-
-	function handleResult<T>(resolve: (result: T) => void, reject: (error: Error) => void, error: Error | null | undefined, result: T): void {
-		if (error) {
-			reject(massageError(error));
-		} else {
-			resolve(result);
-		}
-	}
-
-	function massageError(error: Error & { code?: string }): Error {
-		if (error.code === 'ENOENT') {
-			return vscode.FileSystemError.FileNotFound();
-		}
-
-		if (error.code === 'EISDIR') {
-			return vscode.FileSystemError.FileIsADirectory();
-		}
-
-		if (error.code === 'EEXIST') {
-			return vscode.FileSystemError.FileExists();
-		}
-
-		if (error.code === 'EPERM' || error.code === 'EACCESS') {
-			return vscode.FileSystemError.NoPermissions();
-		}
-
-		return error;
-	}
-
-	export function checkCancellation(token: vscode.CancellationToken): void {
-		if (token.isCancellationRequested) {
-			throw new Error('Operation cancelled');
-		}
-	}
-
-	export function normalizeNFC(items: string): string;
-	export function normalizeNFC(items: string[]): string[];
-	export function normalizeNFC(items: string | string[]): string | string[] {
-		if (process.platform !== 'darwin') {
-			return items;
-		}
-
-		if (Array.isArray(items)) {
-			return items.map(item => item.normalize('NFC'));
-		}
-
-		return items.normalize('NFC');
-	}
-
-	export function readdir(path: string): Promise<string[]> {
-		return new Promise<string[]>((resolve, reject) => {
-			fs.readdir(path, (error, children) => handleResult(resolve, reject, error, normalizeNFC(children)));
-		});
-	}
-
-	export function stat(path: string): Promise<fs.Stats> {
-		return new Promise<fs.Stats>((resolve, reject) => {
-			fs.stat(path, (error, stat) => handleResult(resolve, reject, error, stat));
-		});
-	}
-
-	export function readfile(path: string): Promise<Buffer> {
-		return new Promise<Buffer>((resolve, reject) => {
-			fs.readFile(path, (error, buffer) => handleResult(resolve, reject, error, buffer));
-		});
-	}
-
-	export function writefile(path: string, content: Buffer): Promise<void> {
-		return new Promise<void>((resolve, reject) => {
-			fs.writeFile(path, content, error => handleResult(resolve, reject, error, void 0));
-		});
-	}
-
-	export function exists(path: string): Promise<boolean> {
-		return new Promise<boolean>((resolve, reject) => {
-			fs.exists(path, exists => handleResult(resolve, reject, null, exists));
-		});
-	}
-
-	export function rmrf(path: string): Promise<void> {
-		return new Promise<void>((resolve, reject) => {
-			rimraf.default(path, error => handleResult(resolve, reject, error, void 0));
-		});
-	}
-
-	export function mkdir(path: string): Promise<void> {
-		return new Promise<void>((resolve, reject) => {
-			mkdirp.default(path);
-		});
-	}
-
-	export function rename(oldPath: string, newPath: string): Promise<void> {
-		return new Promise<void>((resolve, reject) => {
-			fs.rename(oldPath, newPath, error => handleResult(resolve, reject, error, void 0));
-		});
-	}
-
-	export function unlink(path: string): Promise<void> {
-		return new Promise<void>((resolve, reject) => {
-			fs.unlink(path, error => handleResult(resolve, reject, error, void 0));
-		});
-	}
+interface DirNode {
+  dir: boolean, name: string, childs: DirNode[],
 }
 
-export class FileStat implements vscode.FileStat {
+export class ContextNode extends vscode.TreeItem {
+  constructor(
+      public readonly label: string,
+      public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+      public readonly dirnode: DirNode,
+  ) {
+    super(label, collapsibleState);
 
-	constructor(private fsStat: fs.Stats) { }
+    this.tooltip = `${this.label}`;
+  }
 
-	get type(): vscode.FileType {
-		return this.fsStat.isFile() ? vscode.FileType.File : this.fsStat.isDirectory() ? vscode.FileType.Directory : this.fsStat.isSymbolicLink() ? vscode.FileType.SymbolicLink : vscode.FileType.Unknown;
-	}
-
-	get isFile(): boolean | undefined {
-		return this.fsStat.isFile();
-	}
-
-	get isDirectory(): boolean | undefined {
-		return this.fsStat.isDirectory();
-	}
-
-	get isSymbolicLink(): boolean | undefined {
-		return this.fsStat.isSymbolicLink();
-	}
-
-	get size(): number {
-		return this.fsStat.size;
-	}
-
-	get ctime(): number {
-		return this.fsStat.ctime.getTime();
-	}
-
-	get mtime(): number {
-		return this.fsStat.mtime.getTime();
-	}
+  iconPath = vscode.ThemeIcon.File;
 }
 
-interface Entry {
-	uri: vscode.Uri;
-	type: vscode.FileType;
-}
+export class ContextTreeDataProvider implements vscode.TreeDataProvider<ContextNode> {
+  private _onDidChangeTreeData: vscode.EventEmitter<ContextNode|undefined|void> =
+      new vscode.EventEmitter<ContextNode|undefined|void>();
+  readonly onDidChangeTreeData: vscode.Event<ContextNode|undefined|void> =
+      this._onDidChangeTreeData.event;
 
-//#endregion
+  private cfgMap: DirNode|undefined;
 
-export class FileSystemProvider implements vscode.TreeDataProvider<Entry>, vscode.FileSystemProvider {
+  constructor(private workspaceRoot: string|undefined) {
+    if (workspaceRoot !== undefined) {
+      this.cfgMap = this.getConfigMap(workspaceRoot);
+    }
+  }
 
-	private _onDidChangeFile: vscode.EventEmitter<vscode.FileChangeEvent[]>;
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
 
-	constructor() {
-		this._onDidChangeFile = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
-	}
+  getTreeItem(element: ContextNode): vscode.TreeItem {
+    return element;
+  }
 
-	get onDidChangeFile(): vscode.Event<vscode.FileChangeEvent[]> {
-		return this._onDidChangeFile.event;
-	}
-
-	watch(uri: vscode.Uri, options: { recursive: boolean; excludes: string[]; }): vscode.Disposable {
-		const watcher = fs.watch(uri.fsPath, { recursive: options.recursive }, async (event: string, filename: string | Buffer) => {
-			const filepath = path.join(uri.fsPath, _.normalizeNFC(filename.toString()));
-
-			// TODO support excludes (using minimatch library?)
-
-			this._onDidChangeFile.fire([{
-				type: event === 'change' ? vscode.FileChangeType.Changed : await _.exists(filepath) ? vscode.FileChangeType.Created : vscode.FileChangeType.Deleted,
-				uri: uri.with({ path: filepath })
-			} as vscode.FileChangeEvent]);
-		});
-
-		return { dispose: () => watcher.close() };
-	}
-
-	stat(uri: vscode.Uri): vscode.FileStat | Thenable<vscode.FileStat> {
-		return this._stat(uri.fsPath);
-	}
-
-	async _stat(path: string): Promise<vscode.FileStat> {
-		return new FileStat(await _.stat(path));
-	}
-
-	readDirectory(uri: vscode.Uri): [string, vscode.FileType][] | Thenable<[string, vscode.FileType][]> {
-		return this._readDirectory(uri);
-	}
-
-	async _readDirectory(uri: vscode.Uri): Promise<[string, vscode.FileType][]> {
-		const children = await _.readdir(uri.fsPath);
-
-		const result: [string, vscode.FileType][] = [];
-		for (let i = 0; i < children.length; i++) {
-			const child = children[i];
-			const stat = await this._stat(path.join(uri.fsPath, child));
-			result.push([child, stat.type]);
-		}
-
-		return Promise.resolve(result);
-	}
-
-	createDirectory(uri: vscode.Uri): void | Thenable<void> {
-		return _.mkdir(uri.fsPath);
-	}
-
-	readFile(uri: vscode.Uri): Uint8Array | Thenable<Uint8Array> {
-		return _.readfile(uri.fsPath);
-	}
-
-	writeFile(uri: vscode.Uri, content: Uint8Array, options: { create: boolean; overwrite: boolean; }): void | Thenable<void> {
-		return this._writeFile(uri, content, options);
-	}
-
-	async _writeFile(uri: vscode.Uri, content: Uint8Array, options: { create: boolean; overwrite: boolean; }): Promise<void> {
-		const exists = await _.exists(uri.fsPath);
-		if (!exists) {
-			if (!options.create) {
-				throw vscode.FileSystemError.FileNotFound();
-			}
-
-			await _.mkdir(path.dirname(uri.fsPath));
-		} else {
-			if (!options.overwrite) {
-				throw vscode.FileSystemError.FileExists();
-			}
-		}
-
-		return _.writefile(uri.fsPath, content as Buffer);
-	}
-
-	delete(uri: vscode.Uri, options: { recursive: boolean; }): void | Thenable<void> {
-		if (options.recursive) {
-			return _.rmrf(uri.fsPath);
-		}
-
-		return _.unlink(uri.fsPath);
-	}
-
-	rename(oldUri: vscode.Uri, newUri: vscode.Uri, options: { overwrite: boolean; }): void | Thenable<void> {
-		return this._rename(oldUri, newUri, options);
-	}
-
-	async _rename(oldUri: vscode.Uri, newUri: vscode.Uri, options: { overwrite: boolean; }): Promise<void> {
-		const exists = await _.exists(newUri.fsPath);
-		if (exists) {
-			if (!options.overwrite) {
-				throw vscode.FileSystemError.FileExists();
-			} else {
-				await _.rmrf(newUri.fsPath);
-			}
-		}
-
-		const parentExists = await _.exists(path.dirname(newUri.fsPath));
-		if (!parentExists) {
-			await _.mkdir(path.dirname(newUri.fsPath));
-		}
-
-		return _.rename(oldUri.fsPath, newUri.fsPath);
-	}
-
-	// tree data provider
-
-	async getChildren(element?: Entry): Promise<Entry[]> {
-		if (element) {
-			const children = await this.readDirectory(element.uri);
-			return children.map(([name, type]) => ({ uri: vscode.Uri.file(path.join(element.uri.fsPath, name)), type }));
-		}
-
-    // NOTE
-    // error: Object is possibly 'undefined'
-    // List of workspace folders (0-N) that are open in the editor. undefined when no workspace has been opened.
-    // Refer to https://code.visualstudio.com/docs/editor/workspaces for more information on workspaces.
-
-    if (!vscode.workspace.workspaceFolders) {
+  getChildren(element?: ContextNode): ContextNode[]|Thenable<ContextNode[]> {
+    if (this.cfgMap === undefined) {
       vscode.window.showInformationMessage('No context in empty workspace');
-      return [];
+      return Promise.resolve([]);
     }
 
-		const workspaceFolder = vscode.workspace.workspaceFolders.filter(folder => folder.uri.scheme === 'file')[0];
-		if (workspaceFolder) {
-			const children = await this.readDirectory(workspaceFolder.uri);
-			children.sort((a, b) => {
-				if (a[1] === b[1]) {
-					return a[0].localeCompare(b[0]);
-				}
-				return a[1] === vscode.FileType.Directory ? -1 : 1;
-			});
-      const cfgs = children.filter(a => a[0].endsWith('.cfg') || a[1] === vscode.FileType.Directory);
-			console.log(cfgs);
-      return cfgs.map(([name, type]) => ({ uri: vscode.Uri.file(path.join(workspaceFolder.uri.fsPath, name)), type }));
-		}
+    if (element) {
+      return Promise.resolve(this.getContextNode(element.dirnode));
+    } else {
+      return Promise.resolve(this.getContextNode(this.cfgMap));
+    }
+  }
 
-		return [];
-	}
+  private getContextNode(node: DirNode): ContextNode[] {
+    const toContext = (node: DirNode): ContextNode => {
+      if (node.dir) {
+        return new ContextNode(node.name, vscode.TreeItemCollapsibleState.Collapsed, node);
+      } else {
+        return new ContextNode(node.name, vscode.TreeItemCollapsibleState.None, node);
+      }
+    };
 
-	getTreeItem(element: Entry): vscode.TreeItem {
-    console.log('getTreeItem');
-		const treeItem = new vscode.TreeItem(element.uri, element.type === vscode.FileType.Directory ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None);
-		if (element.type === vscode.FileType.File) {
-			treeItem.command = { command: 'fileExplorer.openFile', title: "Open File", arguments: [element.uri], };
-			treeItem.contextValue = 'file';
-		}
-		return treeItem;
-	}
+    return node.childs.map(node => toContext(node));
+  }
+
+  private getConfigMap(rootPath: string): DirNode {
+    const node = {name: path.parse(rootPath).base, dir: true, childs: []};
+    this.searchConfigs(node, path.dirname(rootPath));
+    return node;
+  }
+
+  private searchConfigs(node: DirNode, rootPath: string) {
+    const dirpath = path.join(rootPath, node.name);
+    const files = fs.readdirSync(dirpath);
+    for (const fn of files) {
+      const fpath = path.join(dirpath, fn);
+      const fstat = fs.statSync(fpath);
+
+      if (fstat.isDirectory()) {
+        const dirnode = {name: fn, dir: true, childs: []};
+
+        this.searchConfigs(dirnode, dirpath);
+        if (dirnode.childs.length > 0) {
+          node.childs.push(dirnode);
+        }
+      }
+      if (fstat.isFile() && fn.endsWith('.cfg')) {
+        const dirnode = {name: fn, dir: false, childs: []};
+        node.childs.push(dirnode);
+      }
+    }
+  }
 }
 
 export class ContextExplorer {
-	constructor(context: vscode.ExtensionContext) {
-		const treeDataProvider = new FileSystemProvider();
-		context.subscriptions.push(vscode.window.createTreeView('ContextExplorerView', { treeDataProvider }));
-		vscode.commands.registerCommand('contextExplorer.openFile', (resource) => this.openResource(resource));
-	}
+  constructor(context: vscode.ExtensionContext) {
+    const rootPath =
+        (vscode.workspace.workspaceFolders && (vscode.workspace.workspaceFolders.length > 0)) ?
+        vscode.workspace.workspaceFolders[0].uri.fsPath :
+        undefined;
 
-	private openResource(resource: vscode.Uri): void {
-		vscode.window.showTextDocument(resource);
-	}
+    const contextProvider = new ContextTreeDataProvider(rootPath);
+    context.subscriptions.push(
+        vscode.window.registerTreeDataProvider('ContextExplorerView', contextProvider));
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ import {HoverProvider} from './Editor/HoverProvider';
 import {Jsontracer} from './Jsontracer';
 import {Project} from './Project';
 import {Utils} from './Utils';
+import {ContextExplorer} from './contextExplorer';
 
 // List of backend extensions registered
 let backends: Backend[] = [];
@@ -67,6 +68,8 @@ export function activate(context: vscode.ExtensionContext) {
   console.log('one-vscode activate OK');
 
   setGlobalContext();
+
+  new ContextExplorer(context);
 
   // ONE view
   let refreshCompiler = vscode.commands.registerCommand('onevscode.refresh-compiler', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,12 +22,12 @@ import {Circletracer} from './Circletracer';
 import {CompilePanel} from './Compile/CompilePanel';
 import {ConfigPanel} from './Config/ConfigPanel';
 import {createStatusBarItem} from './Config/ConfigStatusBar';
+import {ContextExplorer} from './contextExplorer';
 import {CodelensProvider} from './Editor/CodelensProvider';
 import {HoverProvider} from './Editor/HoverProvider';
 import {Jsontracer} from './Jsontracer';
 import {Project} from './Project';
 import {Utils} from './Utils';
-import {ContextExplorer} from './contextExplorer';
 
 // List of backend extensions registered
 let backends: Backend[] = [];


### PR DESCRIPTION
This commit adds context and detail explorers on ONE view container.
The detail explorer is collapsed at the first installed.
Once the user has changed the view state by moving, hiding the view,
the initial state will not be used again.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>