### PR TITLE
[Mondrian] Implement viewer for Mondrian files

### DIFF
--- a/media/Mondrian/mondrianViewer.js
+++ b/media/Mondrian/mondrianViewer.js
@@ -124,7 +124,10 @@ function updateContent(data, viewer) {
 
   segmentSelect.replaceChildren();
   for (const [index, segment] of data.segments.entries()) {
-    segmentSelect.appendChild(new Option(segment.name, index));
+    let option = document.createElement('vscode-option');
+    option.innerText = segment.name;
+    option.value = index;
+    segmentSelect.appendChild(option);
   }
   segmentSelect.value = viewer.activeSegment;
 

--- a/media/Mondrian/mondrianViewer.js
+++ b/media/Mondrian/mondrianViewer.js
@@ -209,6 +209,11 @@ function updateViewport(data, viewer) {
     box.style.left = (alloc.alive_from / viewportCycles * 100) + '%';
     box.style.right = ((viewportCycles - alloc.alive_till) / viewportCycles * 100) + '%';
     box.style.backgroundColor = boxColors[i % boxColors.length];
+    box.addEventListener('mouseover', (event) => {
+      statusLineContainer.innerHTML =
+          `<b>Origin:</b> ${alloc.origin} | <b>Size:</b> ${alloc.size} | <b>Offset:</b> ${
+              alloc.offset} | <b>Lifetime:</b> ${alloc.alive_till - alloc.alive_from}`;
+    });
     viewerContainer.appendChild(box);
   }
 }

--- a/media/Mondrian/mondrianViewer.js
+++ b/media/Mondrian/mondrianViewer.js
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(function() {
+const vscode = acquireVsCodeApi();
+
+const viewerContainer =
+    /** @type {HTMLElement} */ document.querySelector('.mondrian-viewer-bounds');
+const statusLineContainer =
+    /** @type {HTMLElement} */ document.querySelector('.mondrian-statusline');
+const memorySizeContainer =
+    /** @type {HTMLElement} */ document.querySelector('.mondrian-info-memory-size');
+const cycleCountContainer =
+    /** @type {HTMLElement} */ document.querySelector('.mondrian-info-cycle-count');
+const segmentSelect = /** @type {HTMLElement} */ document.querySelector('.mondrian-segment-picker');
+const viewerHScale = /** @type {HTMLElement} */ document.querySelector('.mondrian-viewer-h-scale');
+const viewerVScale = /** @type {HTMLElement} */ document.querySelector('.mondrian-viewer-v-scale');
+
+class Viewer {
+  constructor() {
+    this.activeSegment = 0;
+    this.viewportMinCycle = 0;
+    this.viewportMaxCycle = 0;
+    this.viewportHScale = 5;
+    this.viewportVScale = 5;
+  }
+}
+
+let viewportMemory = 0;
+
+const boxColors = [
+  '#e25935',
+  '#ee7a0b',
+  '#facb35',
+  '#56571b',
+  '#1791c2',
+  '#5453b1',
+  '#77455e',
+];
+
+// Handle messages sent from the extension to the webview
+window.addEventListener('message', event => {
+  const message = event.data;  // The json data that the extension sent
+  switch (message.type) {
+    case 'update': {
+      const data = parseText(message.text);
+      if (!data) {
+        return;
+      }
+
+      const viewer = new Viewer();
+
+      // Update our webview's content
+      updateContent(data, viewer);
+
+      // Persist state information.
+      // This state is returned in the call to `vscode.getState` below when a webview is reloaded.
+      vscode.setState({data, viewer});
+
+      return;
+    }
+  }
+});
+
+segmentSelect.addEventListener('change', event => {
+  let state = vscode.getState();
+  state.viewer.activeSegment = parseInt(segmentSelect.value);
+
+  updateContent(state.data, state.viewer);
+  vscode.setState(state);
+});
+
+function parseText(/** @type (string) */ text) {
+  if (!text) {
+    text = '{}';
+  }
+  let data;
+
+  /* Parse data JSON */
+  try {
+    data = JSON.parse(text);
+  } catch {
+    statusLineContainer.innerText = 'Error: Document is not a valid JSON';
+    return null;
+  }
+
+  /* Check schema version */
+  if (data.schema_version !== 1) {
+    statusLineContainer.innerText = 'Error: Invalid JSON schema version';
+    return null;
+  }
+
+  /* Check if data has any memory segments */
+  if (data.segments === undefined || data.segments.length === 0) {
+    statusLineContainer.innerText = 'Error: Document has no memory segments';
+    return null;
+  }
+
+  return data;
+}
+
+function updateContent(data, viewer) {
+  let loadTs = performance.now();
+
+  let totalCycles = 0;
+  let totalMemory = data.segments[viewer.activeSegment].size;
+
+  if (totalMemory === undefined) {
+    totalMemory = 0;
+  }
+
+  segmentSelect.replaceChildren();
+  for (const [index, segment] of data.segments.entries()) {
+    segmentSelect.appendChild(new Option(segment.name, index));
+  }
+  segmentSelect.value = viewer.activeSegment;
+
+  for (alloc of data.segments[viewer.activeSegment].allocations) {
+    if (alloc.alive_till > totalCycles) {
+      totalCycles = alloc.alive_till;
+    }
+
+    if (alloc.offset + alloc.size > totalMemory) {
+      totalMemory = alloc.offset + alloc.size;
+    }
+  }
+
+  memorySizeContainer.innerText = `${totalMemory}`;
+  cycleCountContainer.innerText = `${totalCycles}`;
+
+  let loadMs = (performance.now() - loadTs).toFixed(2);
+  statusLineContainer.innerText = `Document loaded in ${loadMs}ms`;
+
+  viewer.viewportMinCycle = 0;
+  viewer.viewportMaxCycle = totalCycles;
+  viewportMemory = totalMemory;
+
+  updateViewport(data, viewer);
+}
+
+function scaleViewport(viewer) {
+  const scrollContainer = viewerContainer.parentElement;
+  const scrollH = scrollContainer.scrollLeft / scrollContainer.scrollWidth;
+  const scrollV = scrollContainer.scrollTop / scrollContainer.scrollHeight;
+
+  const scaleH = Math.pow(2, viewer.viewportHScale);
+  const scaleV = Math.pow(2, viewer.viewportVScale);
+
+  const viewportCycles = viewer.viewportMaxCycle - viewer.viewportMinCycle;
+  viewerContainer.style.width = viewportCycles * scaleH + 'px';
+  viewerContainer.style.height = viewportMemory * scaleV / 8192 + 'px';
+  scrollContainer.scrollLeft = scrollContainer.scrollWidth * scrollH;
+  scrollContainer.scrollTop = scrollContainer.scrollHeight * scrollV;
+
+  if (scaleH < 4 || scaleV < 4) {
+    viewerContainer.style.backgroundImage = 'none';
+  } else {
+    viewerContainer.style.backgroundImage = `url("data:image/svg+xml;charset=UTF-8,%3csvg ` +
+        `xmlns='http://www.w3.org/2000/svg' width='${scaleH}' height='${scaleV}'%3e%3cpath ` +
+        `style='fill:none;stroke-width:1px;stroke:%23fff;opacity:0.1' ` +
+        `d='M 0,${scaleV - 0.5} ${scaleH - 0.5},${scaleV - 0.5} ${scaleH - 0.5},0' ` +
+        `/%3e%3c/svg%3e")`;
+  }
+
+  if (viewer.viewportHScale < 3) {
+    viewerContainer.classList.add('mondrian-viewer-bounds-no-label');
+  } else {
+    viewerContainer.classList.remove('mondrian-viewer-bounds-no-label');
+  }
+}
+
+function updateViewport(data, viewer) {
+  let boxTemplate = document.createElement('div');
+  boxTemplate.classList.add('mondrian-allocation-box');
+
+  let boxTemplateLabel = document.createElement('div');
+  boxTemplateLabel.classList.add('mondrian-allocation-label');
+
+  boxTemplate.appendChild(boxTemplateLabel);
+
+  viewerContainer.replaceChildren();
+  scaleViewport(viewer);
+
+  const viewportCycles = viewer.viewportMaxCycle - viewer.viewportMinCycle;
+  for (const [i, alloc] of data.segments[viewer.activeSegment].allocations.entries()) {
+    if (alloc.alive_from > viewer.viewportMaxCycle) {
+      continue;
+    }
+
+    const size = alloc.size > 1024 ? Math.round(alloc.size / 102.4) / 10 + 'K' : alloc.size;
+
+    let box = boxTemplate.cloneNode(true);
+    box.firstChild.innerText = size;
+    box.style.top = (alloc.offset / viewportMemory * 100) + '%';
+    box.style.height = (alloc.size / viewportMemory * 100) + '%';
+    box.style.left = (alloc.alive_from / viewportCycles * 100) + '%';
+    box.style.right = ((viewportCycles - alloc.alive_till) / viewportCycles * 100) + '%';
+    box.style.backgroundColor = boxColors[i % boxColors.length];
+    viewerContainer.appendChild(box);
+  }
+}
+
+function changeScale(h, v) {
+  let state = vscode.getState();
+  state.viewer.viewportHScale += h;
+  state.viewer.viewportVScale += v;
+
+  viewerHScale.children[1].value = state.viewer.viewportHScale;
+  viewerVScale.children[1].value = state.viewer.viewportVScale;
+
+  scaleViewport(state.viewer);
+  vscode.setState(state);
+}
+
+function changeVScale(v) {
+  let state = vscode.getState();
+  state.viewer.viewportVScale = v;
+  scaleViewport(state.viewer);
+  vscode.setState(state);
+}
+
+function changeHScale(h) {
+  let state = vscode.getState();
+  state.viewer.viewportHScale = h;
+  scaleViewport(state.viewer);
+  vscode.setState(state);
+}
+
+const state = vscode.getState();
+if (state) {
+  updateContent(state.data, state.viewer);
+}
+
+viewerVScale.children[0].addEventListener('click', () => {
+  changeScale(0, 1);
+});
+viewerVScale.children[1].addEventListener('input', (event) => {
+  changeVScale(parseInt(event.target.value));
+});
+viewerVScale.children[2].addEventListener('click', () => {
+  changeScale(0, -1);
+});
+viewerHScale.children[0].addEventListener('click', () => {
+  changeScale(-1, 0);
+});
+viewerHScale.children[1].addEventListener('input', (event) => {
+  changeHScale(parseInt(event.target.value));
+});
+viewerHScale.children[2].addEventListener('click', () => {
+  changeScale(1, 0);
+});
+})();

--- a/media/Mondrian/mondrianViewer.js
+++ b/media/Mondrian/mondrianViewer.js
@@ -253,21 +253,21 @@ if (state) {
 }
 
 viewerVScale.children[0].addEventListener('click', () => {
-  changeScale(0, 1);
+  changeScale(0, 0.5);
 });
 viewerVScale.children[1].addEventListener('input', (event) => {
   changeVScale(parseInt(event.target.value));
 });
 viewerVScale.children[2].addEventListener('click', () => {
-  changeScale(0, -1);
+  changeScale(0, -0.5);
 });
 viewerHScale.children[0].addEventListener('click', () => {
-  changeScale(-1, 0);
+  changeScale(-0.5, 0);
 });
 viewerHScale.children[1].addEventListener('input', (event) => {
   changeHScale(parseInt(event.target.value));
 });
 viewerHScale.children[2].addEventListener('click', () => {
-  changeScale(1, 0);
+  changeScale(0.5, 0);
 });
 })();

--- a/media/Mondrian/style.css
+++ b/media/Mondrian/style.css
@@ -105,6 +105,7 @@ div.mondrian-viewer-bounds-no-label div.mondrian-allocation-label {
 div.mondrian-statusbar {
   flex: 0;
   display: flex;
+  align-items: center;
 }
 
 div.mondrian-statusline {
@@ -116,4 +117,7 @@ div.mondrian-statusline {
 div.mondrian-info {
   flex: 0;
   white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }

--- a/media/Mondrian/style.css
+++ b/media/Mondrian/style.css
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+div.mondrian-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  height: calc(100vh - 20px);
+}
+
+div.mondrian-scrollbar {
+  background-color: rgba(96, 96, 96, 0.2);
+  min-height: 36px;
+  flex: 0;
+}
+
+div.mondrian-viewer-area {
+  contain: content;
+  overflow: auto;
+  background-color: rgba(127, 127, 127, 0.05);
+  flex: 1;
+}
+
+div.mondrian-viewer-bounds {
+  background-color: rgba(0, 0, 0, 0.05);
+  position: relative;
+  margin: 0px;
+}
+
+div.mondrian-viewer-controls {
+  display: flex;
+  position: fixed;
+  z-index: 1;
+}
+
+div.mondrian-viewer-h-scale {
+  max-height: 32px;
+  bottom: 64px;
+  left: 64px;
+}
+
+div.mondrian-viewer-v-scale {
+  max-width: 32px;
+  bottom: 96px;
+  left: 32px;
+  flex-direction: column;
+}
+
+div.mondrian-viewer-controls > button {
+  border-radius: 50%;
+  border-style: solid;
+  border-width: 1px;
+  width: 32px;
+  height: 32px;
+  overflow: hidden;
+}
+
+div.mondrian-viewer-h-scale > input[type=range] {
+  max-width: 96px;
+}
+
+div.mondrian-viewer-v-scale > input[type=range] {
+  max-height: 96px;
+  -webkit-appearance: slider-vertical;
+}
+
+div.mondrian-allocation-box {
+  overflow: visible;
+  position: absolute;
+  border-radius: 2px;
+  box-shadow: inset 0px 0px 1px #000;
+}
+
+div.mondrian-allocation-label {
+  overflow: visible;
+  border-radius: 2px;
+  height: calc(100% - 4px);
+  color: rgb(255, 255, 255);
+  text-shadow: 1px 1px 1px #000;
+  padding: 2px 4px;
+  margin: 0px;
+}
+
+div.mondrian-allocation-label:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+div.mondrian-viewer-bounds-no-label div.mondrian-allocation-label {
+  font-size: 0px;
+}
+
+div.mondrian-statusbar {
+  flex: 0;
+  display: flex;
+}
+
+div.mondrian-statusline {
+  flex: 1;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+div.mondrian-info {
+  flex: 0;
+  white-space: nowrap;
+}

--- a/package.json
+++ b/package.json
@@ -232,6 +232,18 @@
         "language": "ini",
         "path": "./src/Snippets/tools.json"
       }
+    ],
+    "customEditors": [
+      {
+        "viewType": "onevscode.mondrianViewer",
+        "displayName": "Mondrian",
+        "selector": [
+          {
+            "filenamePattern": "*.tracealloc.json"
+          }
+        ],
+        "priority": "default"
+      }
     ]
   },
   "scripts": {

--- a/res/samples/traces/sample.tracealloc.json
+++ b/res/samples/traces/sample.tracealloc.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "segments": [
+    {
+      "name": "Segment1",
+      "size": 32768,
+      "allocations": [
+        { "offset": 0, "size": 8192, "alive_from": 0, "alive_till": 8, "origin": "Node1" },
+        { "offset": 8192, "size": 8192, "alive_from": 8, "alive_till": 12, "origin": "Node2" },
+        { "offset": 0, "size": 8192, "alive_from": 12, "alive_till": 16, "origin": "Node3" },
+        { "offset": 8192, "size": 16384, "alive_from": 16, "alive_till": 24, "origin": "Node4" }
+      ]
+    },
+    {
+      "name": "Segment2",
+      "size": 16384,
+      "allocations": [
+        { "offset": 0, "size": 8192, "alive_from": 0, "alive_till": 32, "origin": "Node1" }
+      ]
+    }
+  ]
+}

--- a/res/samples/traces/sample.tracealloc.json
+++ b/res/samples/traces/sample.tracealloc.json
@@ -3,7 +3,7 @@
   "segments": [
     {
       "name": "Segment1",
-      "size": 32768,
+      "size": 16384,
       "allocations": [
         { "offset": 0, "size": 8192, "alive_from": 0, "alive_till": 8, "origin": "Node1" },
         { "offset": 8192, "size": 8192, "alive_from": 8, "alive_till": 12, "origin": "Node2" },
@@ -13,7 +13,7 @@
     },
     {
       "name": "Segment2",
-      "size": 16384,
+      "size": 8192,
       "allocations": [
         { "offset": 0, "size": 8192, "alive_from": 0, "alive_till": 32, "origin": "Node1" }
       ]

--- a/src/Mondrian/MondrianEditor.ts
+++ b/src/Mondrian/MondrianEditor.ts
@@ -16,6 +16,7 @@
 
 import * as vscode from 'vscode';
 import {getNonce} from '../Config/GetNonce';
+import {getUri} from '../Utils/Uri';
 
 export class MondrianEditorProvider implements vscode.CustomTextEditorProvider {
   public static register(context: vscode.ExtensionContext): vscode.Disposable {
@@ -53,6 +54,14 @@ export class MondrianEditorProvider implements vscode.CustomTextEditorProvider {
     const prefix = 'media/Mondrian';
     const nonce = getNonce();
 
+    const toolkitUri = getUri(webview, this.context.extensionUri, [
+      'node_modules',
+      '@vscode',
+      'webview-ui-toolkit',
+      'dist',
+      'toolkit.js',
+    ]);
+
     const scriptUri = webview.asWebviewUri(
         vscode.Uri.joinPath(this.context.extensionUri, prefix, 'mondrianViewer.js'));
 
@@ -66,8 +75,9 @@ export class MondrianEditorProvider implements vscode.CustomTextEditorProvider {
         <meta charset="UTF-8">
         <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${
         webview.cspSource} data:;
-          style-src ${webview.cspSource}; script-src 'nonce-${nonce}';" />
+          style-src 'self' 'unsafe-inline' ${webview.cspSource}; script-src 'nonce-${nonce}';" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <script nonce="${nonce}" type="module" src="${toolkitUri}"></script>
         <link href="${styleUri}" rel="stylesheet" />
         <title>Mondrian Viewer</title>
       </head>
@@ -82,7 +92,7 @@ export class MondrianEditorProvider implements vscode.CustomTextEditorProvider {
             <div class="mondrian-info">
               <b>Memory:</b> <span class="mondrian-info-memory-size">0</span> |
               <b>Cycles:</b> <span class="mondrian-info-cycle-count">0</span> |
-              <b>Segment:</b> <select class="mondrian-segment-picker"></select>
+              <b>Segment:</b> <vscode-dropdown class="mondrian-segment-picker"></vscode-dropdown>
             </div>
           </div>
         </div>

--- a/src/Mondrian/MondrianEditor.ts
+++ b/src/Mondrian/MondrianEditor.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode';
+import {getNonce} from '../Config/GetNonce';
+
+export class MondrianEditorProvider implements vscode.CustomTextEditorProvider {
+  public static register(context: vscode.ExtensionContext): vscode.Disposable {
+    const provider = new MondrianEditorProvider(context);
+    const providerRegistration =
+        vscode.window.registerCustomEditorProvider(MondrianEditorProvider.viewType, provider);
+    return providerRegistration;
+  }
+
+  private static readonly viewType = 'onevscode.mondrianViewer';
+
+  constructor(private readonly context: vscode.ExtensionContext) {}
+
+  /**
+   * Called when custom editor is opened.
+   */
+  public async resolveCustomTextEditor(
+      document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel,
+      _token: vscode.CancellationToken): Promise<void> {
+    webviewPanel.webview.options = {
+      enableScripts: true,
+    };
+    webviewPanel.webview.html = this.getHtmlForWebview(webviewPanel.webview);
+
+    webviewPanel.webview.postMessage({
+      type: 'update',
+      text: document.getText(),
+    });
+  }
+
+  /**
+   * Get the static html used for the editor webviews.
+   */
+  private getHtmlForWebview(webview: vscode.Webview): string {
+    const prefix = 'media/Mondrian';
+    const nonce = getNonce();
+
+    const scriptUri = webview.asWebviewUri(
+        vscode.Uri.joinPath(this.context.extensionUri, prefix, 'mondrianViewer.js'));
+
+    const styleUri =
+        webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, prefix, 'style.css'));
+
+    return /* html */ `
+      <!DOCTYPE html>
+      <html lang="en">
+      <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${
+        webview.cspSource} data:;
+          style-src ${webview.cspSource}; script-src 'nonce-${nonce}';" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link href="${styleUri}" rel="stylesheet" />
+        <title>Mondrian Viewer</title>
+      </head>
+      <body>
+        <div class="mondrian-layout">
+          <div class="mondrian-scrollbar"></div>
+          <div class="mondrian-viewer-area">
+            <div class="mondrian-viewer-bounds"></div>
+          </div>
+          <div class="mondrian-statusbar">
+            <div class="mondrian-statusline"></div>
+            <div class="mondrian-info">
+              Memory: <span class="mondrian-info-memory-size">0</span> |
+              Cycles: <span class="mondrian-info-cycle-count">0</span> |
+              Segment: <select class="mondrian-segment-picker"></select>
+            </div>
+          </div>
+        </div>
+
+        <div class="mondrian-viewer-controls mondrian-viewer-v-scale">
+          <button>+</button>
+          <input type="range" min="-5" max="15" value="5" />
+          <button>-</button>
+        </div>
+        <div class="mondrian-viewer-controls mondrian-viewer-h-scale">
+          <button>-</button>
+          <input type="range" min="-5" max="15" value="5" />
+          <button>+</button>
+        </div>
+
+        <script nonce="${nonce}" src="${scriptUri}"></script>
+      </body>
+      </html>`;
+  }
+}

--- a/src/Mondrian/MondrianEditor.ts
+++ b/src/Mondrian/MondrianEditor.ts
@@ -80,9 +80,9 @@ export class MondrianEditorProvider implements vscode.CustomTextEditorProvider {
           <div class="mondrian-statusbar">
             <div class="mondrian-statusline"></div>
             <div class="mondrian-info">
-              Memory: <span class="mondrian-info-memory-size">0</span> |
-              Cycles: <span class="mondrian-info-cycle-count">0</span> |
-              Segment: <select class="mondrian-segment-picker"></select>
+              <b>Memory:</b> <span class="mondrian-info-memory-size">0</span> |
+              <b>Cycles:</b> <span class="mondrian-info-cycle-count">0</span> |
+              <b>Segment:</b> <select class="mondrian-segment-picker"></select>
             </div>
           </div>
         </div>

--- a/src/Mondrian/MondrianEditor.ts
+++ b/src/Mondrian/MondrianEditor.ts
@@ -83,7 +83,9 @@ export class MondrianEditorProvider implements vscode.CustomTextEditorProvider {
       </head>
       <body>
         <div class="mondrian-layout">
-          <div class="mondrian-scrollbar"></div>
+          <div class="mondrian-scrollbar">
+            <!-- TODO Model trim scrollbar is NYI -->
+          </div>
           <div class="mondrian-viewer-area">
             <div class="mondrian-viewer-bounds"></div>
           </div>

--- a/src/Mondrian/MondrianEditor.ts
+++ b/src/Mondrian/MondrianEditor.ts
@@ -92,7 +92,7 @@ export class MondrianEditorProvider implements vscode.CustomTextEditorProvider {
           <div class="mondrian-statusbar">
             <div class="mondrian-statusline"></div>
             <div class="mondrian-info">
-              <b>Memory:</b> <span class="mondrian-info-memory-size">0</span> |
+              <b>Total memory:</b> <span class="mondrian-info-memory-size">0</span> |
               <b>Cycles:</b> <span class="mondrian-info-cycle-count">0</span> |
               <b>Segment:</b> <vscode-dropdown class="mondrian-segment-picker"></vscode-dropdown>
             </div>

--- a/src/Mondrian/README.md
+++ b/src/Mondrian/README.md
@@ -4,87 +4,17 @@ This extension adds custom editor with reads `*.tracealloc.json` files and provi
 
 ### Data format specification
 
-Trace allocation format is described in [JSON schema](https://json-schema.org/) format:
+Input data format is represented as JSON document which contains the following fields:
 
-```json
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
-  "properties": {
-    "schema_version": {
-      "title": "Schema version",
-      "description": "Allocation data format version",
-      "type": "integer",
-      "minimum": 0,
-      "required": true
-    },
-    "segments": {
-      "title": "Memory segments",
-      "description": "Array of named memory segments",
-      "type": "array",
-      "required": true,
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "title": "Name",
-            "description": "Memory segment name",
-            "type": "string",
-            "required": true,
-            "minLength": 1
-          },
-          "size": {
-            "title": "Size",
-            "description": "Memory segment size in bytes",
-            "type": "integer",
-            "minimum": 0,
-            "required": true
-          },
-          "allocations": {
-            "title": "Memory allocations",
-            "description": "Array of memory allocated zones with dimenstions and lifetimes",
-            "type": "array",
-            "required": true,
-            "items": {
-              "type": "object",
-              "properties": {
-                "offset": {
-                  "title": "Offset",
-                  "description": "Allocated memory zone offset in bytes",
-                  "type": "integer",
-                  "minimum": 0,
-                  "required": true
-                },
-                "size": {
-                  "title": "Size",
-                  "description": "Allocated memory zone size in bytes",
-                  "type": "integer",
-                  "minimum": 1,
-                  "required": true
-                },
-                "alive_from": {
-                  "title": "Alive from",
-                  "description": "Initial allocation lifetime tick",
-                  "type": "integer",
-                  "required": true
-                },
-                "alive_till": {
-                  "title": "Alive till",
-                  "description": "Final allocation lifetime tick",
-                  "type": "integer",
-                  "required": true
-                },
-                "origin": {
-                  "title": "Origin",
-                  "description": "Name of graph node related to this allocation",
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-```
+* `schema_version`: data format schema version (currently 1).
+* `segments`: array of named memory segments, each segment contains following fields:
+  * `title`: memory segment name.
+  * `size`: memory segment size in bytes.
+  * `allocations`: array of memory allocated zones with dimenstions and lifetimes:
+    * `offset`: allocated memory zone offset in bytes.
+    * `size`: allocated memory zone size in bytes.
+    * `alive_from`: initial allocation lifetime position.
+    * `alive_till`: final allocation lifetime position.
+    * `origin`: name of model graph node related to this allocation.
+
+Example of allocation trace data: `res/traces/sample.tracealloc.json`.

--- a/src/Mondrian/README.md
+++ b/src/Mondrian/README.md
@@ -1,0 +1,90 @@
+## Mondrian allocation trace viewer
+
+This extension adds custom editor with reads `*.tracealloc.json` files and provides graphical viewer for allocation trace data with ability to choose a specific memory segment.
+
+### Data format specification
+
+Trace allocation format is described in [JSON schema](https://json-schema.org/) format:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "schema_version": {
+      "title": "Schema version",
+      "description": "Allocation data format version",
+      "type": "integer",
+      "minimum": 0,
+      "required": true
+    },
+    "segments": {
+      "title": "Memory segments",
+      "description": "Array of named memory segments",
+      "type": "array",
+      "required": true,
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "description": "Memory segment name",
+            "type": "string",
+            "required": true,
+            "minLength": 1
+          },
+          "size": {
+            "title": "Size",
+            "description": "Memory segment size in bytes",
+            "type": "integer",
+            "minimum": 0,
+            "required": true
+          },
+          "allocations": {
+            "title": "Memory allocations",
+            "description": "Array of memory allocated zones with dimenstions and lifetimes",
+            "type": "array",
+            "required": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "offset": {
+                  "title": "Offset",
+                  "description": "Allocated memory zone offset in bytes",
+                  "type": "integer",
+                  "minimum": 0,
+                  "required": true
+                },
+                "size": {
+                  "title": "Size",
+                  "description": "Allocated memory zone size in bytes",
+                  "type": "integer",
+                  "minimum": 1,
+                  "required": true
+                },
+                "alive_from": {
+                  "title": "Alive from",
+                  "description": "Initial allocation lifetime tick",
+                  "type": "integer",
+                  "required": true
+                },
+                "alive_till": {
+                  "title": "Alive till",
+                  "description": "Final allocation lifetime tick",
+                  "type": "integer",
+                  "required": true
+                },
+                "origin": {
+                  "title": "Origin",
+                  "description": "Name of graph node related to this allocation",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ import {CodelensProvider} from './Editor/CodelensProvider';
 import {HoverProvider} from './Editor/HoverProvider';
 import {runInferenceQuickInput} from './Execute/executeQuickInput';
 import {Jsontracer} from './Jsontracer';
+import {MondrianEditorProvider} from './Mondrian/MondrianEditor';
 import {OneExplorer} from './OneExplorer';
 import {Project} from './Project';
 import {Utils} from './Utils';
@@ -156,6 +157,8 @@ export function activate(context: vscode.ExtensionContext) {
     });
   });
   context.subscriptions.push(disposableOneCircleTracer);
+
+  context.subscriptions.push(MondrianEditorProvider.register(context));
 
   // returning backend registration function that will be called by backend extensions
   return backendRegistrationApi();


### PR DESCRIPTION
This commit implements custom editor which provides graphical view of Mondrian JSON allocation traces (`.tracealloc.json`).

Issue: #395 
Draft: #452 

ONE-vscode-DCO-1.0-Signed-off-by: Alexander Moiseev <a.moiseev@samsung.com>

## Notes

Currently implemented features: 
* JSON input data parsing
* round-robin colorized memory blocks output
* ability to scale horizontally/vertically
* switching between memory segments.

More features such as model trim, mouse hover info, rulers, more coloring modes etc. will be added in new PRs, #395 description contains feature roadmap.

Example data: 
[example.tracealloc.json.txt](https://github.com/Samsung/ONE-vscode/files/8531449/example.tracealloc.json.txt) (remove .txt extension for plugin to properly detect .json)

## Screenshots

Scaled up memory zone view:

![image](https://user-images.githubusercontent.com/67966333/164460590-4a6e2835-f0cd-4ffe-8bd4-c545233c69cd.png)

Model "bird's eye" overview:

![image](https://user-images.githubusercontent.com/67966333/164460694-3142a36a-aaf7-4dff-8acd-24af649bde10.png)

Light theme support:

![image](https://user-images.githubusercontent.com/67966333/164460878-a77e31e3-cb16-43e1-85b7-fd51d5bf5215.png)