### PR TITLE
[infra] Apply format deny for json files

### DIFF
--- a/infra/format
+++ b/infra/format
@@ -123,7 +123,12 @@ function check_json_files()
   for f in ${FILES_TO_CHECK[@]}; do
     # File extension to check
     if [[ ${f} == +(*.json) ]]; then
-      FILES_TO_CHECK_JSON+=("${f}")
+      FILES_TO_CHECK_DIR="$(dirname "${f}")"
+      # skip if ".FORMATDENY" exist
+      JQIGNORE_DIR=${FILES_TO_CHECK_DIR}/.FORMATDENY
+      if [[ ! -f ${JQIGNORE_DIR} ]]; then
+        FILES_TO_CHECK_JSON+=("${f}")
+      fi
     fi
   done
   


### PR DESCRIPTION
This will skip format checker for json files if .FORMATDENY exist in folder.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>