### PR TITLE
Ignore eslint for CircleGraph/external

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ src/Circlereader/circle-analysis/circle/
 
 # External open source project files which are not modified.
 media/Circletracer/external/
+media/CircleGraph/external/


### PR DESCRIPTION
This will include to ignore external netron codes to come.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>