### PR TITLE
[ONE Explorer] Find model by input_path

### DIFF
--- a/src/OneExplorer.ts
+++ b/src/OneExplorer.ts
@@ -149,12 +149,6 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
 
   /**
    * Search .cfg files in the same directory of the node
-   *
-   * NOTE It assumes 1-1 relation for model and config
-   *
-   * TODO(dayo) Support N-N relation
-   * TODO(dayo) Search by parsing config file's model entry (Currently model name and cfg name must
-   * match)
    */
   private searchPairConfig(node: Node) {
     const modelPath = node.path;


### PR DESCRIPTION
This commit changes ONE Explorer's behavior
to search a modelfile specified in a configuration file.
It still assumes they are in the same directory.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>