### PR TITLE
[OneExplorer] Expand tree until model file

### DIFF
--- a/src/OneExplorer.ts
+++ b/src/OneExplorer.ts
@@ -91,9 +91,11 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
 
   private getNode(node: Node): OneNode[] {
     const toOneNode = (node: Node): OneNode => {
-      if (node.childNodes.length > 0) {
+      if (node.type === NodeType.directory) {
+        return new OneNode(node.name, vscode.TreeItemCollapsibleState.Expanded, node);
+      } else if (node.type === NodeType.model) {
         return new OneNode(node.name, vscode.TreeItemCollapsibleState.Collapsed, node);
-      } else {
+      } else {  // (node.type == NodeType.config)
         return new OneNode(node.name, vscode.TreeItemCollapsibleState.None, node);
       }
     };


### PR DESCRIPTION
This commit expands the tree until model files.
It improves UI to save user clicks.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>