### PR TITLE
[OneExplorer] Remove openfile command

### DIFF
--- a/src/OneExplorer.ts
+++ b/src/OneExplorer.ts
@@ -71,8 +71,6 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
   }
 
   getTreeItem(element: OneNode): vscode.TreeItem {
-    element
-        .command = {command: 'oneExplorer.openFile', title: 'Open File', arguments: [element.node]};
     return element;
   }
 
@@ -181,10 +179,5 @@ export class OneExplorer {
     const oneTreeDataProvider = new OneTreeDataProvider(rootPath);
     context.subscriptions.push(
         vscode.window.registerTreeDataProvider('OneExplorerView', oneTreeDataProvider));
-    vscode.commands.registerCommand('oneExplorer.openFile', (file) => this.openFile(file));
-  }
-
-  private openFile(node: Node) {
-    vscode.window.showTextDocument(node.uri);
   }
 }


### PR DESCRIPTION
This commit removes openfile command which currently generates
many warnings.
Let's remove this now and implement properly later.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>