### PR TITLE
[OneExplorer] Remove 'oneTree' member

### DIFF
--- a/src/OneExplorer.ts
+++ b/src/OneExplorer.ts
@@ -71,14 +71,14 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
   }
 
   getChildren(element?: OneNode): OneNode[]|Thenable<OneNode[]> {
+    if (!this.workspaceRoot) {
+      vscode.window.showInformationMessage('Cannot find workspace root');
+      return Promise.resolve([]);
+    }
+
     if (element) {
       return Promise.resolve(this.getNode(element.node));
     } else {
-      if (!this.workspaceRoot) {
-        vscode.window.showInformationMessage('Cannot find workspace root');
-        return Promise.resolve([]);
-      }
-
       return Promise.resolve(this.getNode(this.getTree(this.workspaceRoot)));
     }
   }

--- a/src/OneExplorer.ts
+++ b/src/OneExplorer.ts
@@ -57,13 +57,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
   readonly onDidChangeTreeData: vscode.Event<OneNode|undefined|void> =
       this._onDidChangeTreeData.event;
 
-  private oneTree: Node|undefined;
-
-  constructor(private workspaceRoot: vscode.Uri|undefined) {
-    if (workspaceRoot !== undefined) {
-      this.oneTree = this.getTree(workspaceRoot);
-    }
-  }
+  constructor(private workspaceRoot: vscode.Uri|undefined) {}
 
   // TODO(dayo): enable refresh command
   refresh(): void {
@@ -77,15 +71,15 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
   }
 
   getChildren(element?: OneNode): OneNode[]|Thenable<OneNode[]> {
-    if (this.oneTree === undefined) {
-      vscode.window.showInformationMessage('No ONE model or config in empty workspace');
-      return Promise.resolve([]);
-    }
-
     if (element) {
       return Promise.resolve(this.getNode(element.node));
     } else {
-      return Promise.resolve(this.getNode(this.oneTree));
+      if (!this.workspaceRoot) {
+        vscode.window.showInformationMessage('Cannot find workspace root');
+        return Promise.resolve([]);
+      }
+
+      return Promise.resolve(this.getNode(this.getTree(this.workspaceRoot)));
     }
   }
 


### PR DESCRIPTION
Let's remove 'oneTree' member.
**This change is necessary for a bug fix for refresh command.**
NOTE that OneNodes are generated on the first expansion of tree view.
'oneTree' is not used as getChildren method should returns
freshly generated trees.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>