### PR TITLE
Renaming params of ToolRunner.getRunner()

### DIFF
--- a/src/Project/ToolRunner.ts
+++ b/src/Project/ToolRunner.ts
@@ -83,10 +83,10 @@ export class ToolRunner {
     return oneccRealPath;
   }
 
-  public getRunner(name: string, tool: string, toolargs: ToolArgs, path: string) {
+  public getRunner(name: string, toolPath: string, toolargs: ToolArgs, cwd: string) {
     return new Promise<string>((resolve, reject) => {
       this.logger.outputWithTime('Running: ' + name);
-      let cmd = cp.spawn(tool, toolargs, {cwd: path});
+      let cmd = cp.spawn(toolPath, toolargs, {cwd: cwd});
       this.handlePromise(resolve, reject, cmd);
     });
   }


### PR DESCRIPTION
Some params were renamed to have more specific meaning.

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>