### PR TITLE
[OneExplorer] Refactor Node as class

### DIFF
--- a/src/OneExplorer.ts
+++ b/src/OneExplorer.ts
@@ -118,11 +118,15 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
   private getTree(rootPath: vscode.Uri): Node {
     const node = new Node(NodeType.directory, [], rootPath);
 
-    this.searchNode(node, node.path);
+    this.searchNode(node);
     return node;
   }
 
-  private searchNode(node: Node, dirPath: string) {
+  /**
+   * Construct a tree under the given node
+   * @returns void
+   */
+  private searchNode(node: Node) {
     const files = fs.readdirSync(node.path);
 
     for (const fname of files) {
@@ -132,7 +136,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
       if (fstat.isDirectory()) {
         const childNode = new Node(NodeType.directory, [], vscode.Uri.file(fpath));
 
-        this.searchNode(childNode, fpath);
+        this.searchNode(childNode);
         if (childNode.childNodes.length > 0) {
           node.childNodes.push(childNode);
         }
@@ -141,9 +145,9 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
           (fname.endsWith('.pb') || fname.endsWith('.tflite') || fname.endsWith('.onnx'))) {
         const childNode = new Node(NodeType.model, [], vscode.Uri.file(fpath));
 
-        this.searchPairConfig(childNode, node.path);
+        this.searchPairConfig(childNode);
 
-        node.childNodes.push(node);
+        node.childNodes.push(childNode);
       }
     }
   }
@@ -157,8 +161,8 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
    * TODO(dayo) Search by parsing config file's model entry (Currently model name and cfg name must
    * match)
    */
-  private searchPairConfig(node: Node, dirPath: string) {
-    const dirpath = path.dirname(path.join(dirPath, node.name));
+  private searchPairConfig(node: Node) {
+    const dirpath = path.dirname(node.path);
     const files = fs.readdirSync(dirpath);
 
     const extSlicer = (fileName: string) => {

--- a/src/OneExplorer.ts
+++ b/src/OneExplorer.ts
@@ -42,12 +42,16 @@ class Node {
     return this.uri.fsPath;
   }
 
-  get dir():string {
-    return this.uri.fsPath;
+  get parent():string {
+    return path.dirname(this.uri.fsPath);
   }
 
   get name(): string {
     return path.parse(this.uri.fsPath).base;
+  }
+
+  get ext(): string {
+    return path.extname(this.uri.fsPath);
   }
 }
 

--- a/src/OneExplorer.ts
+++ b/src/OneExplorer.ts
@@ -166,15 +166,14 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
    * match)
    */
   private searchPairConfig(node: Node) {
-    const dirpath = path.dirname(node.path);
-    const files = fs.readdirSync(dirpath);
+    const files = fs.readdirSync(node.parent);
 
     const extSlicer = (fileName: string) => {
       return fileName.slice(0, fileName.lastIndexOf('.'));
     };
 
     for (const fname of files) {
-      const fpath = path.join(dirpath, fname);
+      const fpath = path.join(node.parent, fname);
       const fstat = fs.statSync(fpath);
 
       if (fstat.isFile() && fname.endsWith('.cfg') && (extSlicer(fname) === extSlicer(node.name))) {

--- a/src/OneExplorer.ts
+++ b/src/OneExplorer.ts
@@ -29,20 +29,17 @@ class Node {
   childNodes: Node[];
   uri: vscode.Uri;
 
-  constructor(type: NodeType,
-    childNodes: Node[],
-    uri: vscode.Uri)
-  {
+  constructor(type: NodeType, childNodes: Node[], uri: vscode.Uri) {
     this.type = type;
     this.childNodes = childNodes;
     this.uri = uri;
   }
 
-  get path():string {
+  get path(): string {
     return this.uri.fsPath;
   }
 
-  get parent():string {
+  get parent(): string {
     return path.dirname(this.uri.fsPath);
   }
 
@@ -144,8 +141,8 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
         if (childNode.childNodes.length > 0) {
           node.childNodes.push(childNode);
         }
-      } 
-      else if (fstat.isFile() &&
+      } else if (
+          fstat.isFile() &&
           (fname.endsWith('.pb') || fname.endsWith('.tflite') || fname.endsWith('.onnx'))) {
         const childNode = new Node(NodeType.model, [], vscode.Uri.file(fpath));
 


### PR DESCRIPTION
This commit refactors Node interface.
It converts Node interface to class
as it requires more functionality thus it needs OOP.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>