### PR TITLE
Add compilerEnvMap for managing compiler env

### DIFF
--- a/src/Backend/Backend.ts
+++ b/src/Backend/Backend.ts
@@ -16,6 +16,8 @@
 
 const assert = require('assert');
 import {Backend} from './API';
+import {gCompileEnvMap, CompileEnv} from '../Compile/CompileEnv';
+import {Logger} from '../Utils/Logger';
 
 /**
  * Interface of backend map
@@ -34,6 +36,10 @@ function backendRegistrationApi() {
       const backendName = backend.name();
       assert(backendName.length > 0);
       globalBackendMap[backendName] = backend;
+      const compiler = backend.compiler();
+      if (compiler) {
+        gCompileEnvMap[backend.name()] = new CompileEnv(new Logger(), compiler);
+      }
       console.log(`Backend ${backendName} was registered into ONE-vscode.`);
     }
   };

--- a/src/Compile/CompileEnv.ts
+++ b/src/Compile/CompileEnv.ts
@@ -166,4 +166,15 @@ class CompileEnv extends Env {
   }
 };
 
-export {Env, CompileEnv};
+/**
+ * Interface of backend map
+ * - Use Obejct class to use the only string key
+ */
+interface CompileEnvMap {
+  [key: string]: CompileEnv;
+}
+
+// List of compile environments
+let gCompileEnvMap: CompileEnvMap = {};
+
+export {Env, CompileEnv, gCompileEnvMap};


### PR DESCRIPTION
This commit adds compilerEnvMap for managing compiler environment
with backend name.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>