### PR TITLE
[Backend] Change executor inference API

### DIFF
--- a/src/Backend/Executor.ts
+++ b/src/Backend/Executor.ts
@@ -21,8 +21,8 @@ interface Executor {
   // defined/available toolchains
   toolchains(): Toolchains;
 
-  // inference a job with a cmd
-  inference(): Command;
+  // TODO: use cfg path to run onecc after one-infer landed
+  runInference(_modelPath: string, _options?: string[]): Command;
 }
 
 // General excutor uses onecc so default jobs can be used
@@ -31,7 +31,7 @@ class ExecutorBase implements Executor {
     throw Error('Invalid toolchains call');
   }
 
-  inference(): Command {
+  runInference(_modelPath: string, _options?: string[]): Command {
     throw Error('Invalid inference call');
   }
 };


### PR DESCRIPTION
This commit changes inference API of executor to `runInference`.
Each executor takes the model path to infer and specific option list.

ONE-vscode-DCO-1.0-Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>

draft: #522 