### PR TITLE
[Backend] Introduce `getExecutableExt` method to executor

### DIFF
--- a/src/Backend/Executor.ts
+++ b/src/Backend/Executor.ts
@@ -18,6 +18,9 @@ import {Command} from './Command';
 import {Toolchains} from './Toolchain';
 
 interface Executor {
+  // exetensions of executable files
+  getExecutableExt(): string[];
+
   // defined/available toolchains
   toolchains(): Toolchains;
 
@@ -27,6 +30,11 @@ interface Executor {
 
 // General excutor uses onecc so default jobs can be used
 class ExecutorBase implements Executor {
+  // exetensions of executable files
+  getExecutableExt(): string[] {
+    throw Error('Invalid toolchains call');
+  }
+
   toolchains(): Toolchains {
     throw Error('Invalid toolchains call');
   }


### PR DESCRIPTION
This commit introduces `getExecutableExt` method which returns executable
extension list to Executor class.

ONE-vscode-DCO-1.0-Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>

---
draft: #522 