### PR TITLE
[OneExplorer] Open ConfigEditPanel by clicking 

### DIFF
--- a/src/OneExplorer.ts
+++ b/src/OneExplorer.ts
@@ -17,6 +17,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import {CfgEditorPanel} from './CfgEditor/CfgEditorPanel';
 
 enum NodeType {
   directory,
@@ -108,7 +109,13 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
       } else if (node.type === NodeType.model) {
         return new OneNode(node.name, vscode.TreeItemCollapsibleState.Collapsed, node);
       } else {  // (node.type == NodeType.config)
-        return new OneNode(node.name, vscode.TreeItemCollapsibleState.None, node);
+        let oneNode = new OneNode(node.name, vscode.TreeItemCollapsibleState.None, node);
+        oneNode.command = {
+          command: 'onevscode.open-cfg',
+          title: 'Open File',
+          arguments: [oneNode.node]
+        };
+        return oneNode;
       }
     };
 
@@ -191,7 +198,12 @@ export class OneExplorer {
     context.subscriptions.push(
         vscode.window.registerTreeDataProvider('OneExplorerView', oneTreeDataProvider));
 
+    vscode.commands.registerCommand('onevscode.open-cfg', (file) => this.openFile(file));
     vscode.commands.registerCommand(
         'onevscode.refresh-one-explorer', () => oneTreeDataProvider.refresh());
+  }
+
+  private openFile(node: Node) {
+    vscode.commands.executeCommand('vscode.openWith', node.uri, CfgEditorPanel.viewType);
   }
 }


### PR DESCRIPTION
This commit enables users to open ConfigEditPanel by clicking
the .cfg file on OneExplorer view.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>