### PR TITLE
Add csslint to exclude CircleGraph/external

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "pretest": "npm run compile && npm run lint && npm run lintjs && npm run lintcss && npm run linthtml",
     "lint": "eslint src --ext ts --max-warnings 0",
     "lintjs": "eslint media --ext js --max-warnings 0",
-    "lintcss": "csslint media src",
+    "lintcss": "csslint media src --exclude-list=media/CircleGraph/external",
     "linthtml": "htmlhint media src",
     "unittest": "node ./out/Tests/runTest.js",
     "test": "npm run unittest",


### PR DESCRIPTION
This will add csslint tool to exclude media/CircleGraph/external folder
as files are from external source.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>