### PR TITLE
Change Compiler Toolchain name to Toolchain

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
           "name": "ONE Explorer"
         },
         {
-          "id": "CompilerToolchainView",
-          "name": "Compiler Toolchain"
+          "id": "ToolchainView",
+          "name": "Toolchain"
         },
         {
           "id": "TargetDeviceView",
@@ -91,13 +91,13 @@
         "category": "ONE"
       },
       {
-        "command": "onevscode.refresh-compiler",
+        "command": "onevscode.refresh-toolchain",
         "title": "Refresh",
         "category": "ONE",
         "icon": "$(refresh)"
       },
       {
-        "command": "onevscode.install-compiler",
+        "command": "onevscode.install-toolchain",
         "title": "Install",
         "category": "ONE",
         "icon": "$(desktop-download)"
@@ -153,13 +153,13 @@
           "group": "navigation"
         },
         {
-          "command": "onevscode.refresh-compiler",
-          "when": "view == CompilerToolchainView",
+          "command": "onevscode.refresh-toolchain",
+          "when": "view == ToolchainView",
           "group": "navigation"
         },
         {
-          "command": "onevscode.install-compiler",
-          "when": "view == CompilerToolchainView",
+          "command": "onevscode.install-toolchain",
+          "when": "view == ToolchainView",
           "group": "navigation"
         },
         {

--- a/src/Backend/Backend.ts
+++ b/src/Backend/Backend.ts
@@ -16,7 +16,7 @@
 
 const assert = require('assert');
 import {Backend} from './API';
-import {gCompileEnvMap, CompileEnv} from '../Compile/CompileEnv';
+import {gToolchainEnvMap, ToolchainEnv} from '../Toolchain/ToolchainEnv';
 import {Logger} from '../Utils/Logger';
 
 /**
@@ -38,7 +38,7 @@ function backendRegistrationApi() {
       globalBackendMap[backendName] = backend;
       const compiler = backend.compiler();
       if (compiler) {
-        gCompileEnvMap[backend.name()] = new CompileEnv(new Logger(), compiler);
+        gToolchainEnvMap[backend.name()] = new ToolchainEnv(new Logger(), compiler);
       }
       console.log(`Backend ${backendName} was registered into ONE-vscode.`);
     }

--- a/src/Tests/Toolchain/ToolchainEnv.test.ts
+++ b/src/Tests/Toolchain/ToolchainEnv.test.ts
@@ -17,10 +17,9 @@
 import {assert} from 'chai';
 
 import {CompilerBase} from '../../Backend/Compiler';
-import {Toolchains} from '../../Backend/Toolchain';
-import {ToolchainInfo} from '../../Backend/Toolchain';
+import {ToolchainInfo, Toolchains} from '../../Backend/Toolchain';
 import {DebianToolchain} from '../../Backend/ToolchainImpl/DebianToolchain';
-import {CompileEnv} from '../../Compile/CompileEnv';
+import {ToolchainEnv} from '../../Toolchain/ToolchainEnv';
 import {Logger} from '../../Utils/Logger';
 
 class MockCompiler extends CompilerBase {
@@ -44,15 +43,15 @@ class MockCompiler extends CompilerBase {
   }
 };
 
-suite('Compile', function() {
-  suite('CompileEnv', function() {
+suite('Toolchain', function() {
+  suite('ToolchainEnv', function() {
     const K_CLEANUP: string = 'cleanup';
     const logger = new Logger();
     const compiler = new MockCompiler();
 
     suite('#constructor()', function() {
       test('is constructed with params', function() {
-        let env = new CompileEnv(logger, compiler);
+        let env = new ToolchainEnv(logger, compiler);
         assert.equal(env.installed, undefined);
         assert.strictEqual(env.compiler, compiler);
       });
@@ -60,7 +59,7 @@ suite('Compile', function() {
 
     suite('#listAvailable()', function() {
       test('lists available toolchains', function() {
-        let env = new CompileEnv(logger, compiler);
+        let env = new ToolchainEnv(logger, compiler);
         let toolchains = env.listAvailable();
         assert.strictEqual(toolchains, compiler.toolchains());
       });
@@ -70,7 +69,7 @@ suite('Compile', function() {
     suite('@Use-onecc', function() {
       suite('#confirmInstalled()', function() {
         test('confirms the toolchain is installed', function(done) {
-          let env = new CompileEnv(logger, compiler);
+          let env = new ToolchainEnv(logger, compiler);
           assert.equal(env.installed, undefined);
           env.confirmInstalled();
           env.workFlow.jobRunner.on(K_CLEANUP, function() {
@@ -82,7 +81,7 @@ suite('Compile', function() {
 
       suite('#listInstalled()', function() {
         test('lists installed toolchain', function(done) {
-          let env = new CompileEnv(logger, compiler);
+          let env = new ToolchainEnv(logger, compiler);
           env.confirmInstalled();
           env.workFlow.jobRunner.on(K_CLEANUP, function() {
             assert.notEqual(env.installed, undefined);
@@ -98,7 +97,7 @@ suite('Compile', function() {
       // that needs root permission like install and uninstall.
       // suite('#install()', function() {
       //   test('installes the toolchain', function(done) {
-      //     let env = new CompileEnv(logger, compiler);
+      //     let env = new ToolchainEnv(logger, compiler);
       //     env.install(compiler.availableToolchain);
       //     env.workFlow.jobRunner.on(K_CLEANUP, function() {
       //       assert.notEqual(env.installed, undefined);
@@ -111,7 +110,7 @@ suite('Compile', function() {
       //
       // suite('#uninstall()', function() {
       //   test('uninstalles the toolchain', function(done) {
-      //     let env = new CompileEnv(logger, compiler);
+      //     let env = new ToolchainEnv(logger, compiler);
       //     env.uninstall(compiler.installedToolchain);
       //     env.workFlow.jobRunner.on(K_CLEANUP, function() {
       //       assert.equal(env.installed, undefined);

--- a/src/Toolchain/ToolchainEnv.ts
+++ b/src/Toolchain/ToolchainEnv.ts
@@ -79,8 +79,8 @@ class Env implements BuilderJob {
   }
 }
 
-// A CompileEnv has a Toolchain
-class CompileEnv extends Env {
+class ToolchainEnv extends Env {
+  // TODO(jyoung): Support multiple installed toolchains
   installed?: Toolchain;
   compiler: Compiler;
 
@@ -170,11 +170,11 @@ class CompileEnv extends Env {
  * Interface of backend map
  * - Use Obejct class to use the only string key
  */
-interface CompileEnvMap {
-  [key: string]: CompileEnv;
+interface ToolchainEnvMap {
+  [key: string]: ToolchainEnv;
 }
 
 // List of compile environments
-let gCompileEnvMap: CompileEnvMap = {};
+let gToolchainEnvMap: ToolchainEnvMap = {};
 
-export {Env, CompileEnv, gCompileEnvMap};
+export {Env, ToolchainEnv, gToolchainEnvMap};

--- a/src/View/InstallQuickInput.ts
+++ b/src/View/InstallQuickInput.ts
@@ -15,7 +15,7 @@
  */
 
 import * as vscode from 'vscode';
-import {gCompileEnvMap} from '../Compile/CompileEnv';
+import {gToolchainEnvMap} from '../Toolchain/ToolchainEnv';
 import {MultiStepInput} from '../Utils/MultiStepInput';
 
 export async function showInstallQuickInput(context: vscode.ExtensionContext) {
@@ -37,7 +37,7 @@ export async function showInstallQuickInput(context: vscode.ExtensionContext) {
 
   async function pickBackend(input: MultiStepInput, state: Partial<State>) {
     const backendGroups: vscode.QuickPickItem[] =
-        Object.keys(gCompileEnvMap).map((label) => ({label}));
+        Object.keys(gToolchainEnvMap).map((label) => ({label}));
     state.backend = await input.showQuickPick({
       title,
       step: 1,
@@ -53,7 +53,7 @@ export async function showInstallQuickInput(context: vscode.ExtensionContext) {
     if (state.backend === undefined) {
       throw Error('Backend is undefined.');
     }
-    const toolchains = gCompileEnvMap[state.backend.label].listAvailable();
+    const toolchains = gToolchainEnvMap[state.backend.label].listAvailable();
     const versions =
         toolchains.map((value) => value.info.version !== undefined ? value.info.version.str() : '');
     const versionGroups: vscode.QuickPickItem[] = versions.map((label) => ({label}));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,11 +61,11 @@ export function activate(context: vscode.ExtensionContext) {
   new OneExplorer(context);
 
   // ONE view
-  let refreshCompiler = vscode.commands.registerCommand('onevscode.refresh-compiler', () => {
-    console.log('refresh-compiler: NYI');
+  let refreshCompiler = vscode.commands.registerCommand('onevscode.refresh-toolchain', () => {
+    console.log('refresh-toolchain: NYI');
   });
   context.subscriptions.push(refreshCompiler);
-  let installCompiler = vscode.commands.registerCommand('onevscode.install-compiler', () => {
+  let installCompiler = vscode.commands.registerCommand('onevscode.install-toolchain', () => {
     showInstallQuickInput(context);
   });
   context.subscriptions.push(installCompiler);


### PR DESCRIPTION
This commit changes the compiler toolchain view name and
related codes. It uses toolchain word instead of compiler toolchain.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>