### PR TITLE
Fix duplicated item in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,16 @@
           }
         ],
         "priority": "default"
+      },
+      {
+        "viewType": "onevscode.mondrianViewer",
+        "displayName": "Mondrian",
+        "selector": [
+          {
+            "filenamePattern": "*.tracealloc.json"
+          }
+        ],
+        "priority": "default"
       }
     ],
     "commands": [
@@ -231,18 +241,6 @@
       {
         "language": "ini",
         "path": "./src/Snippets/tools.json"
-      }
-    ],
-    "customEditors": [
-      {
-        "viewType": "onevscode.mondrianViewer",
-        "displayName": "Mondrian",
-        "selector": [
-          {
-            "filenamePattern": "*.tracealloc.json"
-          }
-        ],
-        "priority": "default"
       }
     ]
   },


### PR DESCRIPTION
There are two `customEditors` in `package.json`.
These should be integrated as one.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>