### PR TITLE
Upgrade package engines vscode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "vsce": "^2.7.0"
       },
       "engines": {
-        "vscode": "^1.46.0"
+        "vscode": "^1.57.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "publisher": "Samsung",
   "engines": {
-    "vscode": "^1.46.0"
+    "vscode": "^1.57.0"
   },
   "categories": [
     "Other"


### PR DESCRIPTION
This will upgrade engines.vscode in package file to 1.57+.
- postMessage with Uint8Array works correctly and faster with this.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>