### PR TITLE
[OneExplorer] Implement create-cfg

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,12 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "onevscode.create-cfg",
+        "title": "Create new ONE configuration",
+        "category": "ONE",
+        "icon": "$(add)"
+      },
+      {
         "command": "onevscode.flip-cfg-to-gui",
         "title": "Open cfg in GUI",
         "category": "ONE",
@@ -184,6 +190,11 @@
           "command": "onevscode.run-cfg",
           "when": "view == OneExplorerView && viewItem == config",
           "group": "navigation"
+        },
+        {
+          "command": "onevscode.create-cfg",
+          "when": "view == OneExplorerView && viewItem == baseModel",
+          "group": "inline"
         }
       ],
       "editor/title": [


### PR DESCRIPTION
This commit implements create-cfg command and it's UI of 'add' icon
as inline command of baseModel(tflite,onnx) on OneExplorer view.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>