### PR TITLE
[infra] Exclude one-vscode from license checker

### DIFF
--- a/infra/license/license-checker.ts
+++ b/infra/license/license-checker.ts
@@ -113,6 +113,11 @@ export class ResultSet {
 };
 
 export function verify(pkgName: string, pkgLicense: string): ResultType {
+  if (pkgName === 'one-vscode') {
+    // As one-vscode is our product, always pass!
+    return 'pass';
+  }
+
   if (packageJudgment.hasOwnProperty(pkgName)) {
     switch (packageJudgment[pkgName as keyof typeof packageJudgment].permitted) {
       case 'yes':

--- a/infra/license/package-judgment.json
+++ b/infra/license/package-judgment.json
@@ -36,12 +36,6 @@
       "permitted": "yes"
     },
 
-    "one-vscode@0.0.1": {
-      "licenses": "Apache-2.0",
-      "repository": "https://github.com/Samsung/ONE-vscode",
-      "permitted": "yes"
-    },
-
     "rc@1.2.8": {
       "licenses": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "repository": "https://github.com/dominictarr/rc",


### PR DESCRIPTION
Until now, `one-vscode` is added in `package-judgment.json`.
Let's exclude `one-vscode` from the logic itself.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>