### PR TITLE
[infra] Fix one-vscode checking logic

### DIFF
--- a/infra/license/license-checker.ts
+++ b/infra/license/license-checker.ts
@@ -113,7 +113,7 @@ export class ResultSet {
 };
 
 export function verify(pkgName: string, pkgLicense: string): ResultType {
-  if (pkgName === 'one-vscode') {
+  if (pkgName.startsWith('one-vscode')) {
     // As one-vscode is our product, always pass!
     return 'pass';
   }


### PR DESCRIPTION
`pkgName` is like `one-vscode@0.0.1`.
To filter all versions of `one-vscode`, logic should be fixed.
This commit will fix it.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>