### PR TITLE
[CircleGraph] Disable show node properties window

### DIFF
--- a/media/CircleGraph/view.js
+++ b/media/CircleGraph/view.js
@@ -1131,7 +1131,6 @@ view.Node = class extends grapher.Node {
         });
         if (initializers.length > 0 || hiddenInitializers || sortedAttributes.length > 0) {
             const list = this.list();
-            list.on('click', () => this.context.view.showNodeProperties(node));
             for (const initializer of initializers) {
                 const argument = initializer.arguments[0];
                 const type = argument.type;


### PR DESCRIPTION
This will disable showing node properties window when clicked.
- click is changed to toggle selection of the node

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>