### PR TITLE
Revise Command.str() considering root

### DIFF
--- a/src/Backend/Command.ts
+++ b/src/Backend/Command.ts
@@ -37,7 +37,7 @@ class Command extends Array<string> {
   }
 
   str(): string {
-    return this.strs().join(' ');
+    return (this.root ? 'sudo ' : '') + this.strs().join(' ');
   }
 };
 


### PR DESCRIPTION
This revises `Command.str()` in a way that when `root === true`, `str()` starts with `"sudo"`.


ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>