### PR TITLE
Remove PipedCommand and CommandList

### DIFF
--- a/src/Backend/Command.ts
+++ b/src/Backend/Command.ts
@@ -41,26 +41,4 @@ class Command extends Array<string> {
   }
 };
 
-/**
- * Class representing `$ pipingCmd | pipedCmd` type of piped command chain.
- */
-class PipedCommand {
-  constructor(private _pipingCmd: Command, private _pipedCmd: Command) { /* empty */
-  }
-
-  str(): string {
-    return this._pipingCmd.str() + ' | ' + this._pipedCmd.str();
-  }
-
-  public get pipingCmd(): Command {
-    return this._pipingCmd;
-  }
-
-  public get pipedCmd(): Command {
-    return this._pipedCmd;
-  }
-};
-
-type CommandList = (Command|PipedCommand)[];
-
-export {Command, PipedCommand, CommandList};
+export {Command};


### PR DESCRIPTION
Previously we wanted to send a list of commands as `CommandList`
and command with pipe as `PipedCommand`.
After more discussion, we will create one shell script that contains
list of command and return the path of shell script.

Due to this decision, let's remove `PipedCommand` and `CommandList`.

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>