### PR TITLE
[OneExplorer] Get workspace root from helper

### DIFF
--- a/src/OneExplorer.ts
+++ b/src/OneExplorer.ts
@@ -149,7 +149,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
   private fileWatcher =
       vscode.workspace.createFileSystemWatcher(`**/*.{cfg,tflite,onnx,circle,tvn}`);
 
-  constructor(private workspaceRoot: vscode.Uri|undefined) {
+  constructor(private workspaceRoot: vscode.Uri) {
     const fileWatchersEvents =
         [this.fileWatcher.onDidCreate, this.fileWatcher.onDidChange, this.fileWatcher.onDidDelete];
 

--- a/src/OneExplorer.ts
+++ b/src/OneExplorer.ts
@@ -388,7 +388,7 @@ input_path=${filename}.${extname}
 }
 
 export class OneExplorer {
-  // TODO Support multi-workspace
+  // TODO Support multi-root workspace
   public workspaceRoot: vscode.Uri = vscode.Uri.file(obtainWorkspaceRoot());
 
   constructor(context: vscode.ExtensionContext, logger: Logger) {

--- a/src/OneExplorer.ts
+++ b/src/OneExplorer.ts
@@ -23,6 +23,7 @@ import * as vscode from 'vscode';
 import {CfgEditorPanel} from './CfgEditor/CfgEditorPanel';
 import {ToolArgs} from './Project/ToolArgs';
 import {ToolRunner} from './Project/ToolRunner';
+import {obtainWorkspaceRoot} from './Utils/Helpers';
 import {Logger} from './Utils/Logger';
 
 /**
@@ -387,13 +388,12 @@ input_path=${filename}.${extname}
 }
 
 export class OneExplorer {
-  constructor(context: vscode.ExtensionContext, logger: Logger) {
-    const rootPath =
-        (vscode.workspace.workspaceFolders && (vscode.workspace.workspaceFolders.length > 0)) ?
-        vscode.workspace.workspaceFolders[0].uri :
-        undefined;
+  // TODO Support multi-workspace
+  public workspaceRoot: vscode.Uri = vscode.Uri.file(obtainWorkspaceRoot());
 
-    const oneTreeDataProvider = new OneTreeDataProvider(rootPath);
+  constructor(context: vscode.ExtensionContext, logger: Logger) {
+    // NOTE: Fix `obtainWorksapceRoot` if non-null assertion is false
+    const oneTreeDataProvider = new OneTreeDataProvider(this.workspaceRoot!);
     context.subscriptions.push(
         vscode.window.registerTreeDataProvider('OneExplorerView', oneTreeDataProvider));
 

--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -35,7 +35,7 @@ export function obtainWorkspaceRoot(): string {
   // TODO support active workspace among the multiple workspaceFolders
   // TODO support multi-root workspace
   if (workspaceFolders.length > 1) {
-    Balloon.info('Warning: Only the first workspace directory will be recognized by ONE-vscode');
+    Balloon.info('Warning: Only the first workspace directory is currently supported');
   }
   const workspaceRoot = workspaceFolders[0].uri.path;
   if (!workspaceRoot) {

--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -32,9 +32,10 @@ export function obtainWorkspaceRoot(): string {
     throw new Error('Need workspace');
   }
 
-  // TODO support active workspace from multiple workspace
+  // TODO support active workspace among the multiple workspaceFolders
+  // TODO support multi-root workspace
   if (workspaceFolders.length > 1) {
-    Balloon.info('Warning: only first Workspace is supported');
+    Balloon.info('Warning: Only the first workspace directory will be recognized by ONE-vscode');
   }
   const workspaceRoot = workspaceFolders[0].uri.path;
   if (!workspaceRoot) {


### PR DESCRIPTION
This commit gets workspace root from helper.
The helper takes charge of handling related exceptions
on workspace root.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>