### PR TITLE
Introduce getInstalledToolchains() method

### DIFF
--- a/src/Backend/Compiler.ts
+++ b/src/Backend/Compiler.ts
@@ -59,8 +59,8 @@ interface Compiler {
   getToolchains(toolchainType: string, start: number, count: number): Toolchains;
 
   /**
-   * @brief Function to return the list of already-installed toolchain
-   * @param toolchainType One of value returned from toolchainTypes()
+   * @brief Function to return the list of already-installed toolchains
+   * @param toolchainType One of the values returned from toolchainTypes()
    */
   getInstalledToolchains(toolchainType: string): Toolchains;
 

--- a/src/Backend/Compiler.ts
+++ b/src/Backend/Compiler.ts
@@ -58,6 +58,12 @@ interface Compiler {
    */
   getToolchains(toolchainType: string, start: number, count: number): Toolchains;
 
+  /**
+   * @brief Function to return the list of already-installed toolchain
+   * @param toolchainType One of value returned from toolchainTypes()
+   */
+  getInstalledToolchains(toolchainType: string): Toolchains;
+
   // compiler jobs
   compile(cfg: string): Command;
 
@@ -86,6 +92,10 @@ class CompilerBase implements Compiler {
 
   getToolchains(toolchainType: string, start: number, count: number): Toolchains {
     throw Error('Invalid getToolchains call');
+  }
+
+  getInstalledToolchains(toolchainType: string): Toolchains {
+    throw Error('Invalid getInstalledToolchains call');
   }
 
   compile(cfg: string): Command {


### PR DESCRIPTION
This introduces `getInstalledToolchains()` method in backend API.

For #659

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>