### PR TITLE
Remove passing Logger as param

### DIFF
--- a/src/Backend/Backend.ts
+++ b/src/Backend/Backend.ts
@@ -38,7 +38,7 @@ function backendRegistrationApi() {
       globalBackendMap[backendName] = backend;
       const compiler = backend.compiler();
       if (compiler) {
-        gToolchainEnvMap[backend.name()] = new ToolchainEnv(Logger.getInstance(), compiler);
+        gToolchainEnvMap[backend.name()] = new ToolchainEnv(compiler);
       }
       console.log(`Backend ${backendName} was registered into ONE-vscode.`);
     }

--- a/src/OneExplorer.ts
+++ b/src/OneExplorer.ts
@@ -418,7 +418,7 @@ export class OneExplorer {
   // TODO Support multi-root workspace
   public workspaceRoot: vscode.Uri = vscode.Uri.file(obtainWorkspaceRoot());
 
-  constructor(context: vscode.ExtensionContext, logger: Logger) {
+  constructor(context: vscode.ExtensionContext) {
     // NOTE: Fix `obtainWorksapceRoot` if non-null assertion is false
     const oneTreeDataProvider = new OneTreeDataProvider(this.workspaceRoot!);
     context.subscriptions.push(
@@ -439,7 +439,7 @@ export class OneExplorer {
       vscode.commands.registerCommand(
           'onevscode.run-cfg',
           (oneNode: OneNode) => {
-            const oneccRunner = new OneccRunner(oneNode.node.uri, logger);
+            const oneccRunner = new OneccRunner(oneNode.node.uri);
             oneccRunner.run();
           })
     ]);
@@ -460,7 +460,7 @@ class OneccRunner extends EventEmitter {
   private startRunningOnecc: string = 'START_RUNNING_ONECC';
   private finishedRunningOnecc: string = 'FINISHED_RUNNING_ONECC';
 
-  constructor(private cfgUri: vscode.Uri, private logger: Logger) {
+  constructor(private cfgUri: vscode.Uri) {
     super();
   }
 
@@ -468,7 +468,7 @@ class OneccRunner extends EventEmitter {
    * Function called when onevscode.run-cfg is called (when user clicks 'Run' on cfg file).
    */
   public run() {
-    const toolRunner = new ToolRunner(this.logger);
+    const toolRunner = new ToolRunner();
 
     this.on(this.startRunningOnecc, this.onStartRunningOnecc);
     this.on(this.finishedRunningOnecc, this.onFinishedRunningOnecc);

--- a/src/Project/Builder.ts
+++ b/src/Project/Builder.ts
@@ -18,7 +18,6 @@ import * as vscode from 'vscode';
 
 import {Balloon} from '../Utils/Balloon';
 import * as helpers from '../Utils/Helpers';
-import {Logger} from '../Utils/Logger';
 
 import {BuilderCfgFile} from './BuilderCfgFile';
 import {BuilderJob} from './BuilderJob';
@@ -26,15 +25,13 @@ import {Job} from './Job';
 import {WorkFlow} from './WorkFlow';
 
 export class Builder implements BuilderJob {
-  logger: Logger;
   workFlow: WorkFlow;  // our build WorkFlow
   currentWorkspace: string = '';
   builderCfgFile: BuilderCfgFile;
 
-  constructor(l: Logger) {
-    this.logger = l;
-    this.workFlow = new WorkFlow(l);
-    this.builderCfgFile = new BuilderCfgFile(this, l);
+  constructor() {
+    this.workFlow = new WorkFlow();
+    this.builderCfgFile = new BuilderCfgFile(this);
   }
 
   public init() {

--- a/src/Project/BuilderCfgFile.ts
+++ b/src/Project/BuilderCfgFile.ts
@@ -116,10 +116,10 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
   cfgFilePath: string = '';
   cfgFilename: string = '';
 
-  constructor(jobOwner: BuilderJob, l: Logger) {
+  constructor(jobOwner: BuilderJob) {
     super();
     this.jobOwner = jobOwner;
-    this.logger = l;
+    this.logger = Logger.getInstance();
 
     this.on(K_BEGIN_IMPORT, this.onBeginImport);
   }

--- a/src/Project/JobRunner.ts
+++ b/src/Project/JobRunner.ts
@@ -37,10 +37,10 @@ export class JobRunner extends EventEmitter {
   private progressTimer?: NodeJS.Timeout;
   private progress?: vscode.Progress<{message?: string, increment?: number}>;
 
-  constructor(l: Logger) {
+  constructor() {
     super();
-    this.logger = l;
-    this.toolRunner = new ToolRunner(l);
+    this.logger = Logger.getInstance();
+    this.toolRunner = new ToolRunner();
 
     this.on(K_INVOKE, this.onInvoke);
     this.on(K_CLEANUP, this.onCleanup);

--- a/src/Project/ToolRunner.ts
+++ b/src/Project/ToolRunner.ts
@@ -28,8 +28,8 @@ const K_EXIT: string = 'exit';
 export class ToolRunner {
   logger: Logger;
 
-  constructor(l: Logger) {
-    this.logger = l;
+  constructor() {
+    this.logger = Logger.getInstance();
   }
 
   private handlePromise(

--- a/src/Project/WorkFlow.ts
+++ b/src/Project/WorkFlow.ts
@@ -15,21 +15,18 @@
  */
 
 import {Balloon} from '../Utils/Balloon';
-import {Logger} from '../Utils/Logger';
 import {Job} from './Job';
 import {JobRunner} from './JobRunner';
 import {WorkJobs} from './WorkJobs';
 
 export class WorkFlow {
-  logger: Logger;
   workspace: string = '';
   jobs: WorkJobs;
   jobRunner: JobRunner;
 
-  constructor(logger: Logger) {
-    this.logger = logger;
+  constructor() {
     this.jobs = new WorkJobs();
-    this.jobRunner = new JobRunner(this.logger);
+    this.jobRunner = new JobRunner();
   }
 
   private validateJobs(): boolean {

--- a/src/Tests/Project/Builder.test.ts
+++ b/src/Tests/Project/Builder.test.ts
@@ -21,17 +21,16 @@ import {MockJob} from '../MockJob';
 
 suite('Project', function() {
   suite('Builder', function() {
-    const logger = Logger.getInstance();
     suite('#contructor()', function() {
       test('is contructed with Logger', function() {
-        let builder = new Builder(logger);
+        let builder = new Builder();
         assert.isObject<Builder>(builder);
       });
     });
 
     suite('#init()', function() {
       test('inits members of Builder', function() {
-        let builder = new Builder(logger);
+        let builder = new Builder();
         builder.init();
         assert.equal(builder.workFlow.jobs.length, 0);
       });
@@ -39,7 +38,7 @@ suite('Project', function() {
 
     suite('#addJob()', function() {
       test('adds job', function() {
-        let builder = new Builder(logger);
+        let builder = new Builder();
         builder.init();
         assert.equal(builder.workFlow.jobs.length, 0);
         let job = new MockJob('job0');
@@ -50,7 +49,7 @@ suite('Project', function() {
 
     suite('#clearJobs()', function() {
       test('clears jobs', function() {
-        let builder = new Builder(logger);
+        let builder = new Builder();
         builder.init();
         assert.equal(builder.workFlow.jobs.length, 0);
         let job = new MockJob('job0');

--- a/src/Tests/Project/JobRunner.test.ts
+++ b/src/Tests/Project/JobRunner.test.ts
@@ -19,16 +19,14 @@ import {assert} from 'chai';
 import {JobRunner} from '../../Project/JobRunner';
 import {WorkJobs} from '../../Project/WorkJobs';
 import {obtainWorkspaceRoot} from '../../Utils/Helpers';
-import {Logger} from '../../Utils/Logger';
 import {MockJob} from '../MockJob';
 
 suite('Project', function() {
   suite('JobRunner', function() {
-    const logger = Logger.getInstance();
     suite('@Use-onecc', function() {
       suite('#start()', function() {
         test('jobs are done', function(done) {
-          let jobRunner = new JobRunner(logger);
+          let jobRunner = new JobRunner();
           const workspaceRoot: string = obtainWorkspaceRoot();
           let workJobs = new WorkJobs();
           workJobs.push(new MockJob('mockup'));

--- a/src/Tests/Project/ToolRunner.test.ts
+++ b/src/Tests/Project/ToolRunner.test.ts
@@ -19,16 +19,14 @@ import {join} from 'path';
 
 import {ToolRunner} from '../../Project/ToolRunner';
 import {obtainWorkspaceRoot} from '../../Utils/Helpers';
-import {Logger} from '../../Utils/Logger';
 import {MockJob} from '../MockJob';
 
 suite('Project', function() {
   suite('ToolRunner', function() {
-    const logger = Logger.getInstance();
     suite('@Use-onecc', function() {
       suite('#getOneccPath()', function() {
         test('returns onecc path as string', function() {
-          let toolRunner = new ToolRunner(logger);
+          let toolRunner = new ToolRunner();
           let actual = toolRunner.getOneccPath();  // string or undefined
           // Note. `onecc` path could be changed by user
         assert.isTrue((actual === '/usr/share/one/bin/onecc') ||
@@ -38,7 +36,7 @@ suite('Project', function() {
       suite('#getRunner()', function() {
         test('returns runner as Promise<string>', function(done) {
           let job = new MockJob('mockup');
-          let toolRunner = new ToolRunner(logger);
+          let toolRunner = new ToolRunner();
           const oneccPath = toolRunner.getOneccPath();
           // oneccPath could be string or undefined. Avoid compiling error
           if (oneccPath === undefined) {

--- a/src/Tests/Project/Workflow.test.ts
+++ b/src/Tests/Project/Workflow.test.ts
@@ -16,12 +16,10 @@
 
 import {assert} from 'chai';
 import {WorkFlow} from '../../Project/WorkFlow';
-import {Logger} from '../../Utils/Logger';
 import {MockJob} from '../MockJob';
 
 suite('Project', function() {
   suite('WorkFlow', function() {
-    const logger = Logger.getInstance();
     // jobs for WorkFlow
     const name0 = 'job0';
     const name1 = 'job1';
@@ -29,16 +27,15 @@ suite('Project', function() {
     const job1 = new MockJob(name1);
     suite('#contructor()', function() {
       test('is constructed as WorkFlow', function() {
-        let workFlow = new WorkFlow(logger);
+        let workFlow = new WorkFlow();
         assert.isNotNull(workFlow);
-        assert.isNotNull(workFlow.logger);
         assert.isNotNull(workFlow.jobs);
         assert.isNotNull(workFlow.jobRunner);
       });
     });
     suite('#addJob()', function() {
       test('adds jobs', function() {
-        let workFlow = new WorkFlow(logger);
+        let workFlow = new WorkFlow();
         workFlow.addJob(job0);
         workFlow.addJob(job1);
         assert.strictEqual(workFlow.jobs.length, 2);
@@ -48,7 +45,7 @@ suite('Project', function() {
     });
     suite('#clearJobs()', function() {
       test('clears jobs', function() {
-        let workFlow = new WorkFlow(logger);
+        let workFlow = new WorkFlow();
         workFlow.addJob(job0);
         workFlow.addJob(job1);
         workFlow.clearJobs();

--- a/src/Tests/Toolchain/ToolchainEnv.test.ts
+++ b/src/Tests/Toolchain/ToolchainEnv.test.ts
@@ -46,12 +46,11 @@ class MockCompiler extends CompilerBase {
 suite('Toolchain', function() {
   suite('ToolchainEnv', function() {
     const K_CLEANUP: string = 'cleanup';
-    const logger = Logger.getInstance();
     const compiler = new MockCompiler();
 
     suite('#constructor()', function() {
       test('is constructed with params', function() {
-        let env = new ToolchainEnv(logger, compiler);
+        let env = new ToolchainEnv(compiler);
         assert.equal(env.installed, undefined);
         assert.strictEqual(env.compiler, compiler);
       });
@@ -59,7 +58,7 @@ suite('Toolchain', function() {
 
     suite('#listAvailable()', function() {
       test('lists available toolchains', function() {
-        let env = new ToolchainEnv(logger, compiler);
+        let env = new ToolchainEnv(compiler);
         let toolchains = env.listAvailable();
         assert.strictEqual(toolchains, compiler.toolchains());
       });
@@ -69,7 +68,7 @@ suite('Toolchain', function() {
     suite('@Use-onecc', function() {
       suite('#confirmInstalled()', function() {
         test('confirms the toolchain is installed', function(done) {
-          let env = new ToolchainEnv(logger, compiler);
+          let env = new ToolchainEnv(compiler);
           assert.equal(env.installed, undefined);
           env.confirmInstalled();
           env.workFlow.jobRunner.on(K_CLEANUP, function() {
@@ -81,7 +80,7 @@ suite('Toolchain', function() {
 
       suite('#listInstalled()', function() {
         test('lists installed toolchain', function(done) {
-          let env = new ToolchainEnv(logger, compiler);
+          let env = new ToolchainEnv(compiler);
           env.confirmInstalled();
           env.workFlow.jobRunner.on(K_CLEANUP, function() {
             assert.notEqual(env.installed, undefined);

--- a/src/Toolchain/ToolchainEnv.ts
+++ b/src/Toolchain/ToolchainEnv.ts
@@ -35,8 +35,8 @@ class Env implements BuilderJob {
   currentWorkspace: string = '';
   isPrepared: boolean = false;
 
-  constructor(l: Logger) {
-    this.workFlow = new WorkFlow(l);
+  constructor() {
+    this.workFlow = new WorkFlow();
   }
 
   public init() {
@@ -99,8 +99,8 @@ class ToolchainEnv extends Env {
   installed?: Toolchain;
   compiler: Compiler;
 
-  constructor(l: Logger, compiler: Compiler) {
-    super(l);
+  constructor(compiler: Compiler) {
+    super();
     this.installed = undefined;
     this.compiler = compiler;
     this.init();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,7 +62,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   setGlobalContext();
 
-  new OneExplorer(context, logger);
+  new OneExplorer(context);
 
   // ONE view
   const toolchainProvier = new ToolchainProvider();
@@ -94,7 +94,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(CfgEditorPanel.register(context));
 
-  let projectBuilder = new Project.Builder(logger);
+  let projectBuilder = new Project.Builder();
 
   projectBuilder.init();
 


### PR DESCRIPTION
This removes passing logger as param. Instead, when `Logger`
is needed, `Logger.getInstance()` can be used.

after #662

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>