### PR TITLE
[OneExplorer] Move OneExplorer inside directory

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -20,11 +20,11 @@ import * as path from 'path';
 import {TextEncoder} from 'util';
 import * as vscode from 'vscode';
 
-import {CfgEditorPanel} from './CfgEditor/CfgEditorPanel';
-import {ToolArgs} from './Project/ToolArgs';
-import {ToolRunner} from './Project/ToolRunner';
-import {obtainWorkspaceRoot} from './Utils/Helpers';
-import {Logger} from './Utils/Logger';
+import {CfgEditorPanel} from '../CfgEditor/CfgEditorPanel';
+import {ToolArgs} from '../Project/ToolArgs';
+import {ToolRunner} from '../Project/ToolRunner';
+import {obtainWorkspaceRoot} from '../Utils/Helpers';
+import {Logger} from '../Utils/Logger';
 
 /**
  * Read an ini file

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ import {HoverProvider} from './Editor/HoverProvider';
 import {runInferenceQuickInput} from './Execute/executeQuickInput';
 import {Jsontracer} from './Jsontracer';
 import {MondrianEditorProvider} from './Mondrian/MondrianEditor';
-import {OneExplorer} from './OneExplorer';
+import {OneExplorer} from './OneExplorer/OneExplorer';
 import {Project} from './Project';
 import {ToolchainProvider} from './Toolchain/ToolchainProvider';
 import {Utils} from './Utils';


### PR DESCRIPTION
This commit creates OneExplorer directory and moves the file into it
to expand the module.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>