### PR TITLE
Use Logger class and static methods

### DIFF
--- a/src/Backend/Backend.ts
+++ b/src/Backend/Backend.ts
@@ -38,9 +38,9 @@ function backendRegistrationApi() {
       globalBackendMap[backendName] = backend;
       const compiler = backend.compiler();
       if (compiler) {
-        gToolchainEnvMap[backend.name()] = new ToolchainEnv(Logger.getInstance(), compiler);
+        gToolchainEnvMap[backend.name()] = new ToolchainEnv(compiler);
       }
-      console.log(`Backend ${backendName} was registered into ONE-vscode.`);
+      Logger.outputWithTime(`Backend ${backendName} was registered into ONE-vscode.`);
     }
   };
 

--- a/src/Circlereader/util/setAttributesByOption.ts
+++ b/src/Circlereader/util/setAttributesByOption.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Logger} from '../../Utils/Logger';
 import {Operator} from '../circle-analysis/circle/operator';
 import {NodeAttributes} from '../type/types';
 
@@ -176,7 +177,7 @@ export function setAttributesByOption(
       OptionsAttribute.getWhileAttr(operator, modelAttribute);
       break;
     default:
-      console.log('This option is not supported yet.');
+      Logger.outputWithTime('This option is not supported yet.');
       break;
   }
 }

--- a/src/Editor/HoverProvider.ts
+++ b/src/Editor/HoverProvider.ts
@@ -15,6 +15,9 @@
  */
 
 import * as vscode from 'vscode';
+
+import {Logger} from '../Utils/Logger';
+
 import toolsAttr from './json/tools_attr.json';
 
 export class HoverProvider implements vscode.HoverProvider {
@@ -25,7 +28,7 @@ export class HoverProvider implements vscode.HoverProvider {
     let markdownString = new vscode.MarkdownString();
     const range = _doc.getWordRangeAtPosition(_position, new RegExp(/(.+)/g));
     if (range === undefined) {
-      console.log('getWordRangeAtPosition return undefined');
+      Logger.outputWithTime('getWordRangeAtPosition return undefined');
       return new vscode.Hover(markdownString);
     }
     const word = _doc.getText(range);

--- a/src/Execute/executeQuickInput.ts
+++ b/src/Execute/executeQuickInput.ts
@@ -21,6 +21,7 @@ import * as vscode from 'vscode';
 import {Backend} from '../Backend/API';
 import {globalBackendMap} from '../Backend/Backend';
 import {MultiStepInput} from '../Utils/external/MultiStepInput';
+import {Logger} from '../Utils/Logger';
 
 export async function runInferenceQuickInput(context: vscode.ExtensionContext) {
   interface State {
@@ -79,7 +80,7 @@ export async function runInferenceQuickInput(context: vscode.ExtensionContext) {
     if (fileUri && fileUri[0]) {
       state.modelPath = fileUri[0];
     } else {
-      console.log('No model has been selected');
+      Logger.outputWithTime('No model has been selected');
       state.error = 'No model has been selected. Please check once again.';
       state.modelPath = undefined;
       return;
@@ -123,7 +124,7 @@ export async function runInferenceQuickInput(context: vscode.ExtensionContext) {
             },
             (progress, token) => {
               token.onCancellationRequested(() => {
-                console.log('User canceled the log running operation');
+                Logger.outputWithTime('User canceled the log running operation');
               });
               const p = new Promise((resolve, reject) => {
         exec(cmd?.str() + ' > ' + outFileName, (error, stdout, stderr) => {

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -391,7 +391,7 @@ input_path=${modelName}.${extName}
    */
   private searchChildModels(node: Node) {
     console.assert(node.type === NodeType.config);
-    console.log('searchChildModels');
+    Logger.outputWithTime('searchChildModels');
     const files = fs.readdirSync(node.parent);
 
     for (const fname of files) {
@@ -418,7 +418,7 @@ export class OneExplorer {
   // TODO Support multi-root workspace
   public workspaceRoot: vscode.Uri = vscode.Uri.file(obtainWorkspaceRoot());
 
-  constructor(context: vscode.ExtensionContext, logger: Logger) {
+  constructor(context: vscode.ExtensionContext) {
     // NOTE: Fix `obtainWorksapceRoot` if non-null assertion is false
     const oneTreeDataProvider = new OneTreeDataProvider(this.workspaceRoot!);
     context.subscriptions.push(
@@ -439,7 +439,7 @@ export class OneExplorer {
       vscode.commands.registerCommand(
           'onevscode.run-cfg',
           (oneNode: OneNode) => {
-            const oneccRunner = new OneccRunner(oneNode.node.uri, logger);
+            const oneccRunner = new OneccRunner(oneNode.node.uri);
             oneccRunner.run();
           })
     ]);
@@ -460,7 +460,7 @@ class OneccRunner extends EventEmitter {
   private startRunningOnecc: string = 'START_RUNNING_ONECC';
   private finishedRunningOnecc: string = 'FINISHED_RUNNING_ONECC';
 
-  constructor(private cfgUri: vscode.Uri, private logger: Logger) {
+  constructor(private cfgUri: vscode.Uri) {
     super();
   }
 
@@ -468,7 +468,7 @@ class OneccRunner extends EventEmitter {
    * Function called when onevscode.run-cfg is called (when user clicks 'Run' on cfg file).
    */
   public run() {
-    const toolRunner = new ToolRunner(this.logger);
+    const toolRunner = new ToolRunner();
 
     this.on(this.startRunningOnecc, this.onStartRunningOnecc);
     this.on(this.finishedRunningOnecc, this.onFinishedRunningOnecc);

--- a/src/Project/Builder.ts
+++ b/src/Project/Builder.ts
@@ -26,15 +26,13 @@ import {Job} from './Job';
 import {WorkFlow} from './WorkFlow';
 
 export class Builder implements BuilderJob {
-  logger: Logger;
   workFlow: WorkFlow;  // our build WorkFlow
   currentWorkspace: string = '';
   builderCfgFile: BuilderCfgFile;
 
-  constructor(l: Logger) {
-    this.logger = l;
-    this.workFlow = new WorkFlow(l);
-    this.builderCfgFile = new BuilderCfgFile(this, l);
+  constructor() {
+    this.workFlow = new WorkFlow();
+    this.builderCfgFile = new BuilderCfgFile(this);
   }
 
   public init() {
@@ -51,8 +49,7 @@ export class Builder implements BuilderJob {
   }
 
   public finishAdd(): void {
-    console.log('Done building WorkFlow.');
-    console.log(this.workFlow.jobs);
+    Logger.outputWithTime(`Done building WorkFlow: ${this.workFlow.jobs}`);
   }
 
   // called from user interface

--- a/src/Project/BuilderCfgFile.ts
+++ b/src/Project/BuilderCfgFile.ts
@@ -112,14 +112,12 @@ const K_OPT_transform_min_relu_to_relu6: string = 'transform_min_relu_to_relu6';
  */
 export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector {
   jobOwner: BuilderJob;
-  logger: Logger;
   cfgFilePath: string = '';
   cfgFilename: string = '';
 
-  constructor(jobOwner: BuilderJob, l: Logger) {
+  constructor(jobOwner: BuilderJob) {
     super();
     this.jobOwner = jobOwner;
-    this.logger = l;
 
     this.on(K_BEGIN_IMPORT, this.onBeginImport);
   }
@@ -138,9 +136,9 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
     let inputModel = path.basename(importTF.inputPath);
     importTF.name = 'ImportTF ' + inputModel;
 
-    console.log('importTF = ', importTF);
+    Logger.outputWithTime('importTF = ' + importTF);
     this.jobOwner.addJob(importTF);
-    this.logger.outputLine('Add Import: ' + inputModel);
+    Logger.outputLine('Add Import: ' + inputModel);
   }
 
   private cfgImportTflite(prop: any) {
@@ -151,9 +149,9 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
     let inputModel = path.basename(importTFlite.inputPath);
     importTFlite.name = 'ImportTFlite ' + inputModel;
 
-    console.log('importTFlite = ', importTFlite);
+    Logger.outputWithTime('importTFlite = ' + importTFlite);
     this.jobOwner.addJob(importTFlite);
-    this.logger.outputLine('Add Import: ' + inputModel);
+    Logger.outputLine('Add Import: ' + inputModel);
   }
 
   private cfgImportOnnx(prop: any) {
@@ -166,9 +164,9 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
     let inputModel = path.basename(importONNX.inputPath);
     importONNX.name = 'Import ' + inputModel;
 
-    console.log('importOnnx = ', importONNX);
+    Logger.outputWithTime('importOnnx = ' + importONNX);
     this.jobOwner.addJob(importONNX);
-    this.logger.outputLine('Add Import: ' + inputModel);
+    Logger.outputLine('Add Import: ' + inputModel);
   }
 
   private cfgImportBcq(prop: any) {
@@ -183,9 +181,9 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
     let inputModel = path.basename(importBCQ.inputPath);
     importBCQ.name = 'ImportBCQ ' + inputModel;
 
-    console.log('importTF = ', importBCQ);
+    Logger.outputWithTime('importTF = ' + importBCQ);
     this.jobOwner.addJob(importBCQ);
-    this.logger.outputLine('Add Import: ' + inputModel);
+    Logger.outputLine('Add Import: ' + inputModel);
   }
 
   private cfgOptimize(prop: any) {
@@ -242,9 +240,9 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
     let inputModel = path.basename(optimize.inputPath);
     optimize.name = 'Optimize ' + inputModel;
 
-    console.log('optimize = ', optimize);
+    Logger.outputWithTime('optimize = ' + optimize);
     this.jobOwner.addJob(optimize);
-    this.logger.outputLine('Add Optimize: ' + inputModel);
+    Logger.outputLine('Add Optimize: ' + inputModel);
   }
 
   private cfgQuantize(prop: any) {
@@ -255,9 +253,9 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
     let inputModel = path.basename(quantize.inputPath);
     quantize.name = 'Quantize ' + inputModel;
 
-    console.log('quantize = ', quantize);
+    Logger.outputWithTime('quantize = ' + quantize);
     this.jobOwner.addJob(quantize);
-    this.logger.outputLine('Add Quantize: ' + inputModel);
+    Logger.outputLine('Add Quantize: ' + inputModel);
   }
 
   private cfgPack(prop: any) {
@@ -268,9 +266,9 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
     let inputModel = path.basename(pack.inputPath);
     pack.name = 'Pack ' + inputModel;
 
-    console.log('pack = ', pack);
+    Logger.outputWithTime('pack = ' + pack);
     this.jobOwner.addJob(pack);
-    this.logger.outputLine('Add Pack: ' + inputModel);
+    Logger.outputLine('Add Pack: ' + inputModel);
   }
 
   private cfgCodegen(prop: any) {
@@ -280,9 +278,9 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
 
     codegen.name = 'Codegen ' + codegen.backend;
 
-    console.log('Codegen = ', codegen);
+    Logger.outputWithTime('Codegen = ' + codegen);
     this.jobOwner.addJob(codegen);
-    this.logger.outputLine('Add Codegen: ' + codegen.backend);
+    Logger.outputLine('Add Codegen: ' + codegen.backend);
   }
 
   private isItemTrue(item: string): boolean {
@@ -296,21 +294,21 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
   private validateUniqueImport(cfgOne: any): boolean {
     let importCount = 0;
 
-    this.logger.outputLine('Reading configuration...');
+    Logger.outputLine('Reading configuration...');
     if (this.isItemTrue(cfgOne[K_IMPORT_TF])) {
-      this.logger.outputLine(K_IMPORT_TF + ' is True');
+      Logger.outputLine(K_IMPORT_TF + ' is True');
       importCount = importCount + 1;
     }
     if (this.isItemTrue(cfgOne[K_IMPORT_TFLITE])) {
-      this.logger.outputLine(K_IMPORT_TFLITE + ' is True');
+      Logger.outputLine(K_IMPORT_TFLITE + ' is True');
       importCount = importCount + 1;
     }
     if (this.isItemTrue(cfgOne[K_IMPORT_ONNX])) {
-      this.logger.outputLine(K_IMPORT_ONNX + ' is True');
+      Logger.outputLine(K_IMPORT_ONNX + ' is True');
       importCount = importCount + 1;
     }
     if (this.isItemTrue(cfgOne[K_IMPORT_BCQ])) {
-      this.logger.outputLine(K_IMPORT_BCQ + ' is True');
+      Logger.outputLine(K_IMPORT_BCQ + ' is True');
       importCount = importCount + 1;
     }
     return importCount === 1;
@@ -329,7 +327,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
     let importItems = [K_IMPORT_TF, K_IMPORT_TFLITE, K_IMPORT_ONNX, K_IMPORT_BCQ];
 
     for (let item of importItems) {
-      console.log('getImportItem:', item);
+      Logger.outputWithTime('getImportItem:' + item);
       if (this.isItemTrue(cfgOne[item])) {
         return item;
       }
@@ -367,7 +365,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
       Balloon.error('Invalid \'' + K_ONECC + '\' or \'' + K_ONE_BUILD + '\' section');
       return;
     }
-    console.log('Import: ', itemJob);
+    Logger.outputWithTime('Import: ' + itemJob);
     if (itemJob === K_IMPORT_TF) {
       let prop = cfgIni[itemJob];
       this.cfgImportTf(prop);
@@ -400,7 +398,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
       this.cfgCodegen(prop);
     }
 
-    this.logger.outputLine('Done import configuration.');
+    Logger.outputLine('Done import configuration.');
     this.jobOwner.finishAdd();
   }
 
@@ -410,7 +408,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
       Balloon.error('Invalid file selection');
       return;
     }
-    console.log('Selected file: ' + fileUri.fsPath);
+    Logger.outputWithTime('Selected file: ' + fileUri.fsPath);
 
     this.jobOwner.clearJobs();
     this.cfgFilePath = fileUri.fsPath;

--- a/src/Project/JobCodegen.ts
+++ b/src/Project/JobCodegen.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {Logger} from '../Utils/Logger';
+
 import {Job} from './Job';
 import {JobBase} from './JobBase';
 import {ToolArgs} from './ToolArgs';
@@ -43,7 +45,7 @@ export class JobCodegen extends JobBase {
 
   public get valid() {
     if (this.backend === '') {
-      console.log('JobCodegen: backend not set');
+      Logger.outputWithTime('JobCodegen: backend not set');
       return false;
     }
     return true;

--- a/src/Project/JobImportBCQ.ts
+++ b/src/Project/JobImportBCQ.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {Logger} from '../Utils/Logger';
+
 import {Job} from './Job';
 import {JobImport} from './JobImport';
 import {ToolArgs} from './ToolArgs';
@@ -43,7 +45,7 @@ export class JobImportBCQ extends JobImport {
     args.add('--input_shapes', this.inputShapes);
     args.add('--converter_version', this.converterVersion);
 
-    console.log('args = ', args);
+    Logger.outputWithTime('args = ' + args);
 
     return args;
   }

--- a/src/Project/JobImportONNX.ts
+++ b/src/Project/JobImportONNX.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {Logger} from '../Utils/Logger';
+
 import {Job} from './Job';
 import {JobImport} from './JobImport';
 import {ToolArgs} from './ToolArgs';
@@ -43,7 +45,7 @@ export class JobImportONNX extends JobImport {
       args.push('--save_intermediate');
     }
 
-    console.log('ONNX args = ', args);
+    Logger.outputWithTime('ONNX args = ' + args);
 
     return args;
   }

--- a/src/Project/JobImportTFLite.ts
+++ b/src/Project/JobImportTFLite.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {Logger} from '../Utils/Logger';
+
 import {Job} from './Job';
 import {JobImport} from './JobImport';
 import {ToolArgs} from './ToolArgs';
@@ -35,7 +37,7 @@ export class JobImportTFLite extends JobImport {
     args.add('--input_path', this.inputPath);
     args.add('--output_path', this.outputPath);
 
-    console.log('args = ', args);
+    Logger.outputWithTime('args = ' + args);
 
     return args;
   }

--- a/src/Project/JobRunner.ts
+++ b/src/Project/JobRunner.ts
@@ -29,7 +29,6 @@ const K_INVOKE: string = 'invoke';
 const K_CLEANUP: string = 'cleanup';
 
 export class JobRunner extends EventEmitter {
-  logger: Logger;
   jobs: WorkJobs = [];
   cwd: string = '';
   running: boolean = false;
@@ -37,10 +36,9 @@ export class JobRunner extends EventEmitter {
   private progressTimer?: NodeJS.Timeout;
   private progress?: vscode.Progress<{message?: string, increment?: number}>;
 
-  constructor(l: Logger) {
+  constructor() {
     super();
-    this.logger = l;
-    this.toolRunner = new ToolRunner(l);
+    this.toolRunner = new ToolRunner();
 
     this.on(K_INVOKE, this.onInvoke);
     this.on(K_CLEANUP, this.onCleanup);
@@ -67,7 +65,7 @@ export class JobRunner extends EventEmitter {
       tool = 'onecc';
     }
 
-    console.log('Run tool: ', tool, ' args: ', toolArgs, ' cwd: ', path, ' root: ', job.root);
+    Logger.outputWithTime(`Run tool: ${tool}, args: ${toolArgs}, cwd: ${path}, root: ${job.root}`);
     const runner = this.toolRunner.getRunner(job.name, tool, toolArgs, path, job.root);
 
     runner
@@ -90,7 +88,7 @@ export class JobRunner extends EventEmitter {
   private onInvoke() {
     let job = this.jobs.shift();
     if (job === undefined) {
-      this.logger.outputWithTime('Finish Running ONE compilers.');
+      Logger.outputWithTime('Finish Running ONE compilers.');
       this.emit(K_CLEANUP);
       return;
     }

--- a/src/Project/ToolRunner.ts
+++ b/src/Project/ToolRunner.ts
@@ -26,34 +26,28 @@ const K_DATA: string = 'data';
 const K_EXIT: string = 'exit';
 
 export class ToolRunner {
-  logger: Logger;
-
-  constructor(l: Logger) {
-    this.logger = l;
-  }
-
   private handlePromise(
       resolve: (value: string|PromiseLike<string>) => void,
       reject: (value: string|PromiseLike<string>) => void, cmd: cp.ChildProcessWithoutNullStreams) {
     // stdout
     cmd.stdout.on(K_DATA, (data: any) => {
-      this.logger.output(data.toString());
+      Logger.output(data.toString());
     });
     // stderr
     cmd.stderr.on(K_DATA, (data: any) => {
-      this.logger.output(data.toString());
+      Logger.output(data.toString());
     });
 
     cmd.on(K_EXIT, (code: any) => {
       let codestr = code.toString();
-      console.log('child process exited with code ' + codestr);
+      Logger.outputWithTime('child process exited with code ' + codestr);
       if (codestr === '0') {
-        this.logger.outputWithTime('Build Success.');
-        this.logger.outputLine('');
+        Logger.outputWithTime('Build Success.');
+        Logger.outputLine('');
         resolve(codestr);
       } else {
-        this.logger.outputWithTime('Build Failed:' + codestr);
-        this.logger.outputLine('');
+        Logger.outputWithTime('Build Failed:' + codestr);
+        Logger.outputLine('');
         let errorMsg = 'Failed with exit code: ' + codestr;
         reject(errorMsg);
       }
@@ -66,18 +60,18 @@ export class ToolRunner {
       // Use fixed installation path
       oneccPath = '/usr/share/one/bin/onecc';
     }
-    console.log('onecc path: ', oneccPath);
+    Logger.outputWithTime('onecc path: ' + oneccPath);
     // check if onecc exist
     if (!fs.existsSync(oneccPath)) {
-      console.log('Failed to find onecc file');
+      Logger.outputWithTime('Failed to find onecc file');
       return undefined;
     }
     // onecc maybe symbolic link: use fs.realpathSync to convert to real path
     let oneccRealPath = fs.realpathSync(oneccPath);
-    console.log('onecc real path: ', oneccRealPath);
+    Logger.outputWithTime('onecc real path: ' + oneccRealPath);
     // check if this onecc exist
     if (!fs.existsSync(oneccRealPath)) {
-      console.log('Failed to find onecc file');
+      Logger.outputWithTime('Failed to find onecc file');
       return undefined;
     }
     return oneccRealPath;
@@ -85,7 +79,7 @@ export class ToolRunner {
 
   public getRunner(name: string, tool: string, toolargs: ToolArgs, path: string, root?: boolean) {
     return new Promise<string>((resolve, reject) => {
-      this.logger.outputWithTime('Running: ' + name);
+      Logger.outputWithTime('Running: ' + name);
       let cmd = undefined;
       if (root) {
         // NOTE

--- a/src/Project/WorkFlow.ts
+++ b/src/Project/WorkFlow.ts
@@ -15,21 +15,18 @@
  */
 
 import {Balloon} from '../Utils/Balloon';
-import {Logger} from '../Utils/Logger';
 import {Job} from './Job';
 import {JobRunner} from './JobRunner';
 import {WorkJobs} from './WorkJobs';
 
 export class WorkFlow {
-  logger: Logger;
   workspace: string = '';
   jobs: WorkJobs;
   jobRunner: JobRunner;
 
-  constructor(logger: Logger) {
-    this.logger = logger;
+  constructor() {
     this.jobs = new WorkJobs();
-    this.jobRunner = new JobRunner(this.logger);
+    this.jobRunner = new JobRunner();
   }
 
   private validateJobs(): boolean {

--- a/src/Tests/Backend/Command.test.ts
+++ b/src/Tests/Backend/Command.test.ts
@@ -16,6 +16,7 @@
 
 import {assert} from 'chai';
 import {Command} from '../../Backend/Command';
+import {Logger} from '../../Utils/Logger';
 
 suite('Backend', function() {
   suite('Command', function() {
@@ -36,7 +37,7 @@ suite('Backend', function() {
         const optionStrs: string[] = ['-lh', '~'];
         const cmd = new Command(cmdStr, optionStrs);
         const actualStrs = cmd.strs();
-        console.log(actualStrs);
+        Logger.outputWithTime(`{actualStrs}`);
         assert.strictEqual(actualStrs.length, 1 + optionStrs.length);
         assert.deepStrictEqual(actualStrs[0], cmdStr);
         assert.deepStrictEqual(actualStrs[1], optionStrs[0]);

--- a/src/Tests/Project/Builder.test.ts
+++ b/src/Tests/Project/Builder.test.ts
@@ -21,17 +21,16 @@ import {MockJob} from '../MockJob';
 
 suite('Project', function() {
   suite('Builder', function() {
-    const logger = Logger.getInstance();
     suite('#contructor()', function() {
       test('is contructed with Logger', function() {
-        let builder = new Builder(logger);
+        let builder = new Builder();
         assert.isObject<Builder>(builder);
       });
     });
 
     suite('#init()', function() {
       test('inits members of Builder', function() {
-        let builder = new Builder(logger);
+        let builder = new Builder();
         builder.init();
         assert.equal(builder.workFlow.jobs.length, 0);
       });
@@ -39,7 +38,7 @@ suite('Project', function() {
 
     suite('#addJob()', function() {
       test('adds job', function() {
-        let builder = new Builder(logger);
+        let builder = new Builder();
         builder.init();
         assert.equal(builder.workFlow.jobs.length, 0);
         let job = new MockJob('job0');
@@ -50,7 +49,7 @@ suite('Project', function() {
 
     suite('#clearJobs()', function() {
       test('clears jobs', function() {
-        let builder = new Builder(logger);
+        let builder = new Builder();
         builder.init();
         assert.equal(builder.workFlow.jobs.length, 0);
         let job = new MockJob('job0');

--- a/src/Tests/Project/JobRunner.test.ts
+++ b/src/Tests/Project/JobRunner.test.ts
@@ -24,11 +24,10 @@ import {MockJob} from '../MockJob';
 
 suite('Project', function() {
   suite('JobRunner', function() {
-    const logger = Logger.getInstance();
     suite('@Use-onecc', function() {
       suite('#start()', function() {
         test('jobs are done', function(done) {
-          let jobRunner = new JobRunner(logger);
+          let jobRunner = new JobRunner();
           const workspaceRoot: string = obtainWorkspaceRoot();
           let workJobs = new WorkJobs();
           workJobs.push(new MockJob('mockup'));

--- a/src/Tests/Project/ToolRunner.test.ts
+++ b/src/Tests/Project/ToolRunner.test.ts
@@ -24,11 +24,10 @@ import {MockJob} from '../MockJob';
 
 suite('Project', function() {
   suite('ToolRunner', function() {
-    const logger = Logger.getInstance();
     suite('@Use-onecc', function() {
       suite('#getOneccPath()', function() {
         test('returns onecc path as string', function() {
-          let toolRunner = new ToolRunner(logger);
+          let toolRunner = new ToolRunner();
           let actual = toolRunner.getOneccPath();  // string or undefined
           // Note. `onecc` path could be changed by user
         assert.isTrue((actual === '/usr/share/one/bin/onecc') ||
@@ -38,7 +37,7 @@ suite('Project', function() {
       suite('#getRunner()', function() {
         test('returns runner as Promise<string>', function(done) {
           let job = new MockJob('mockup');
-          let toolRunner = new ToolRunner(logger);
+          let toolRunner = new ToolRunner();
           const oneccPath = toolRunner.getOneccPath();
           // oneccPath could be string or undefined. Avoid compiling error
           if (oneccPath === undefined) {

--- a/src/Tests/Project/Workflow.test.ts
+++ b/src/Tests/Project/Workflow.test.ts
@@ -21,7 +21,6 @@ import {MockJob} from '../MockJob';
 
 suite('Project', function() {
   suite('WorkFlow', function() {
-    const logger = Logger.getInstance();
     // jobs for WorkFlow
     const name0 = 'job0';
     const name1 = 'job1';
@@ -29,16 +28,15 @@ suite('Project', function() {
     const job1 = new MockJob(name1);
     suite('#contructor()', function() {
       test('is constructed as WorkFlow', function() {
-        let workFlow = new WorkFlow(logger);
+        let workFlow = new WorkFlow();
         assert.isNotNull(workFlow);
-        assert.isNotNull(workFlow.logger);
         assert.isNotNull(workFlow.jobs);
         assert.isNotNull(workFlow.jobRunner);
       });
     });
     suite('#addJob()', function() {
       test('adds jobs', function() {
-        let workFlow = new WorkFlow(logger);
+        let workFlow = new WorkFlow();
         workFlow.addJob(job0);
         workFlow.addJob(job1);
         assert.strictEqual(workFlow.jobs.length, 2);
@@ -48,7 +46,7 @@ suite('Project', function() {
     });
     suite('#clearJobs()', function() {
       test('clears jobs', function() {
-        let workFlow = new WorkFlow(logger);
+        let workFlow = new WorkFlow();
         workFlow.addJob(job0);
         workFlow.addJob(job1);
         workFlow.clearJobs();

--- a/src/Tests/Toolchain/ToolchainEnv.test.ts
+++ b/src/Tests/Toolchain/ToolchainEnv.test.ts
@@ -46,12 +46,11 @@ class MockCompiler extends CompilerBase {
 suite('Toolchain', function() {
   suite('ToolchainEnv', function() {
     const K_CLEANUP: string = 'cleanup';
-    const logger = Logger.getInstance();
     const compiler = new MockCompiler();
 
     suite('#constructor()', function() {
       test('is constructed with params', function() {
-        let env = new ToolchainEnv(logger, compiler);
+        let env = new ToolchainEnv(compiler);
         assert.equal(env.installed, undefined);
         assert.strictEqual(env.compiler, compiler);
       });
@@ -59,7 +58,7 @@ suite('Toolchain', function() {
 
     suite('#listAvailable()', function() {
       test('lists available toolchains', function() {
-        let env = new ToolchainEnv(logger, compiler);
+        let env = new ToolchainEnv(compiler);
         let toolchains = env.listAvailable();
         assert.strictEqual(toolchains, compiler.toolchains());
       });
@@ -69,7 +68,7 @@ suite('Toolchain', function() {
     suite('@Use-onecc', function() {
       suite('#confirmInstalled()', function() {
         test('confirms the toolchain is installed', function(done) {
-          let env = new ToolchainEnv(logger, compiler);
+          let env = new ToolchainEnv(compiler);
           assert.equal(env.installed, undefined);
           env.confirmInstalled();
           env.workFlow.jobRunner.on(K_CLEANUP, function() {
@@ -81,7 +80,7 @@ suite('Toolchain', function() {
 
       suite('#listInstalled()', function() {
         test('lists installed toolchain', function(done) {
-          let env = new ToolchainEnv(logger, compiler);
+          let env = new ToolchainEnv(compiler);
           env.confirmInstalled();
           env.workFlow.jobRunner.on(K_CLEANUP, function() {
             assert.notEqual(env.installed, undefined);

--- a/src/Tests/hooks.ts
+++ b/src/Tests/hooks.ts
@@ -15,17 +15,18 @@
  */
 
 import * as vscode from 'vscode';
+import {Logger} from '../Utils/Logger';
 
 // if some stuffs are needed before/after starting tests,
 export const mochaHooks = {
   suiteSetup() {
     const msg = 'All tests start!';
-    console.log(msg);
+    Logger.outputWithTime(msg);
     vscode.window.showInformationMessage(msg);
   },
   suiteTeardown() {
     const msg = 'All tests done!';
-    console.log(msg);
+    Logger.outputWithTime(msg);
     vscode.window.showInformationMessage(msg);
   }
 };

--- a/src/Toolchain/ToolchainEnv.ts
+++ b/src/Toolchain/ToolchainEnv.ts
@@ -35,8 +35,8 @@ class Env implements BuilderJob {
   currentWorkspace: string = '';
   isPrepared: boolean = false;
 
-  constructor(l: Logger) {
-    this.workFlow = new WorkFlow(l);
+  constructor() {
+    this.workFlow = new WorkFlow();
   }
 
   public init() {
@@ -54,8 +54,7 @@ class Env implements BuilderJob {
   }
 
   public finishAdd(): void {
-    console.log('Done building WorkFlow on Env');
-    console.log(this.workFlow.jobs);
+    Logger.outputWithTime(`Done building WorkFlow on Env: ${this.workFlow.jobs}`);
     this.isPrepared = true;
   }
 
@@ -78,13 +77,13 @@ class Env implements BuilderJob {
 
     const rootJobs = this.workFlow.jobs.filter(j => j.root === true);
     if (rootJobs.length > 0) {
-      console.log('Showing password prompt');
+      Logger.outputWithTime('Showing password prompt');
       showPasswordQuickInput().then(password => {
         if (password === undefined) {
-          console.log('Password dialog canceled');
+          Logger.outputWithTime('Password dialog canceled');
           return;
         }
-        console.log('Got password response');
+        Logger.outputWithTime('Got password response');
         process.env.userp = password;
         this.workFlow.start(this.currentWorkspace);
       });
@@ -99,8 +98,8 @@ class ToolchainEnv extends Env {
   installed?: Toolchain;
   compiler: Compiler;
 
-  constructor(l: Logger, compiler: Compiler) {
-    super(l);
+  constructor(compiler: Compiler) {
+    super();
     this.installed = undefined;
     this.compiler = compiler;
     this.init();

--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -17,6 +17,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import {Logger} from '../Utils/Logger';
 
 import {Balloon} from './Balloon';
 
@@ -51,7 +52,7 @@ export class RealPath {
 export function obtainWorkspaceRoot(): string {
   const workspaceFolders = vscode.workspace.workspaceFolders;
   if (!workspaceFolders) {
-    console.log('obtainWorkspaceRoot: NO workspaceFolders');
+    Logger.outputWithTime('obtainWorkspaceRoot: NO workspaceFolders');
     // TODO revise message
     throw new Error('Need workspace');
   }
@@ -63,11 +64,11 @@ export function obtainWorkspaceRoot(): string {
   }
   const workspaceRoot = workspaceFolders[0].uri.path;
   if (!workspaceRoot) {
-    console.log('obtainWorkspaceRoot: NO workspaceRoot');
+    Logger.outputWithTime('obtainWorkspaceRoot: NO workspaceRoot');
     // TODO revise message
     throw new Error('Need workspace');
   }
-  console.log('obtainWorkspaceRoot:', workspaceRoot);
+  Logger.outputWithTime('obtainWorkspaceRoot:' + workspaceRoot);
 
   return workspaceRoot;
 }

--- a/src/Utils/Logger.ts
+++ b/src/Utils/Logger.ts
@@ -17,9 +17,11 @@
 import * as vscode from 'vscode';
 
 export class Logger {
-  outputChannel: vscode.OutputChannel;
-  firstFocus: boolean;
+  static outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('ONE-VSCode');
+  static firstFocus: boolean;
 
+  // TODO Remove code in comment. These lines were commented out for easy review.
+  /*
   private static logger: Logger|null = null;
 
   private constructor() {
@@ -34,27 +36,27 @@ export class Logger {
 
     return Logger.logger;
   }
-
-  private checkShow() {
-    if (this.firstFocus) {
-      this.outputChannel.show(false);
-      this.firstFocus = false;
+*/
+  private static checkShow() {
+    if (Logger.firstFocus) {
+      Logger.outputChannel.show(false);
+      Logger.firstFocus = false;
     }
   }
 
-  public outputWithTime(msg: string) {
+  public static outputWithTime(msg: string) {
     let dateTime = new Date();
-    this.checkShow();
-    this.outputChannel.appendLine('[' + dateTime.toLocaleString() + '] ' + msg);
+    Logger.checkShow();
+    Logger.outputChannel.appendLine('[' + dateTime.toLocaleString() + '] ' + msg);
   }
 
-  public output(msg: string) {
-    this.checkShow();
-    this.outputChannel.append(msg);
+  public static output(msg: string) {
+    Logger.checkShow();
+    Logger.outputChannel.append(msg);
   }
 
-  public outputLine(msg: string) {
-    this.checkShow();
-    this.outputChannel.appendLine(msg);
+  public static outputLine(msg: string) {
+    Logger.checkShow();
+    Logger.outputChannel.appendLine(msg);
   }
 }

--- a/src/View/InstallQuickInput.ts
+++ b/src/View/InstallQuickInput.ts
@@ -18,6 +18,7 @@ import * as vscode from 'vscode';
 import {Toolchain} from '../Backend/Toolchain';
 import {gToolchainEnvMap, ToolchainEnv} from '../Toolchain/ToolchainEnv';
 import {MultiStepInput} from '../Utils/external/MultiStepInput';
+import {Logger} from '../Utils/Logger';
 
 export async function showInstallQuickInput(context: vscode.ExtensionContext) {
   interface State {
@@ -81,6 +82,6 @@ export async function showInstallQuickInput(context: vscode.ExtensionContext) {
   }
 
   const state = await collectInputs();
-  console.log(`Selected backend: ${state.backend.label}-${state.version.label}`);
+  Logger.outputWithTime(`Selected backend: ${state.backend.label}-${state.version.label}`);
   state.toolchainEnv.install(state.toolchain);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,15 +31,13 @@ import {MondrianEditorProvider} from './Mondrian/MondrianEditor';
 import {OneExplorer} from './OneExplorer/OneExplorer';
 import {Project} from './Project';
 import {ToolchainProvider} from './Toolchain/ToolchainProvider';
-import {Utils} from './Utils';
+import {Logger} from './Utils/Logger';
 import {showInstallQuickInput} from './View/InstallQuickInput';
 
 export function activate(context: vscode.ExtensionContext) {
-  const logger = Utils.Logger.getInstance();
+  Logger.outputWithTime('one-vscode activate OK');
 
-  logger.outputWithTime('one-vscode activate OK');
-
-  new OneExplorer(context, logger);
+  new OneExplorer(context);
 
   // ONE view
   const toolchainProvier = new ToolchainProvider();
@@ -52,41 +50,41 @@ export function activate(context: vscode.ExtensionContext) {
   }));
   context.subscriptions.push(
       vscode.commands.registerCommand('onevscode.uninstall-toolchain', () => {
-        console.log('uninstall-toolchain: NYI');
+        Logger.outputWithTime('uninstall-toolchain: NYI');
       }));
 
   // Target Device view
   let registerDevice = vscode.commands.registerCommand('onevscode.register-device', () => {
-    console.log('register-device: NYI');
+    Logger.outputWithTime('register-device: NYI');
   });
   context.subscriptions.push(registerDevice);
 
   let inferenceCommand = vscode.commands.registerCommand('onevscode.infer-model', () => {
-    console.log('one infer model...');
+    Logger.outputWithTime('one infer model...');
     runInferenceQuickInput(context);
   });
   context.subscriptions.push(inferenceCommand);
 
   context.subscriptions.push(CfgEditorPanel.register(context));
 
-  let projectBuilder = new Project.Builder(logger);
+  let projectBuilder = new Project.Builder();
 
   projectBuilder.init();
 
   let disposableOneBuild = vscode.commands.registerCommand('onevscode.build', () => {
-    console.log('one build...');
+    Logger.outputWithTime('one build...');
     projectBuilder.build(context);
   });
   context.subscriptions.push(disposableOneBuild);
 
   let disposableOneImport = vscode.commands.registerCommand('onevscode.import', () => {
-    console.log('one import...');
+    Logger.outputWithTime('one import...');
     projectBuilder.import(context);
   });
   context.subscriptions.push(disposableOneImport);
 
   let disposableOneJsontracer = vscode.commands.registerCommand('onevscode.json-tracer', () => {
-    console.log('one json tracer...');
+    Logger.outputWithTime('one json tracer...');
     Jsontracer.createOrShow(context.extensionUri);
   });
   context.subscriptions.push(disposableOneJsontracer);
@@ -94,7 +92,7 @@ export function activate(context: vscode.ExtensionContext) {
   let disposableOneConfigurationSettings =
       vscode.commands.registerCommand('onevscode.configuration-settings', () => {
         ConfigPanel.createOrShow(context);
-        console.log('one configuration settings...');
+        Logger.outputWithTime('one configuration settings...');
       });
   context.subscriptions.push(disposableOneConfigurationSettings);
 
@@ -118,7 +116,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(disposableHover);
 
   let disposableOneCircleTracer = vscode.commands.registerCommand('onevscode.circle-tracer', () => {
-    console.log('one circle tracer...');
+    Logger.outputWithTime('one circle tracer...');
     const options: vscode.OpenDialogOptions = {
       canSelectMany: false,
       openLabel: 'Open',


### PR DESCRIPTION
Parent issue: #662 
Previously, we tried to use singleton Logger. (#663)
However, code needs `Logger.getInstance().outputWithTime(msg)`, which seems relatively long.

Instead let's use `Logger.outputWithTime(msg)`.

This commit introduces three changes.

1. Make methods in `Logger` as `static` to shorten its usage: e.g., `Logger.outputWithTime(msg)`
2. From 1, we don't have any `logger` object. 
    - Do not pass `logger` as param any more.
    - Do not keep `logger` as object variable
3. Change `console.log()` to `Logger.outputWithTime()`.

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>