### PR TITLE
Remove Samsung Copyright in external source codes

### DIFF
--- a/infra/copyright/copyright-checker.ts
+++ b/infra/copyright/copyright-checker.ts
@@ -25,8 +25,10 @@ const fileFormatsToCheck = "ts,js,css,html";
 
 const ignorePathList = [
     "**/node_modules/**",
+    "**/out/**",
     "**/media/Circletracer/external/**",
-    "**/media/CircleGraph/external/**"
+    "**/media/CircleGraph/external/**",
+    "**/src/Utils/external/**",
 ];
 
 glob("**/*.{" + fileFormatsToCheck + "}",

--- a/src/Utils/external/MultiStepInput.ts
+++ b/src/Utils/external/MultiStepInput.ts
@@ -1,18 +1,3 @@
-/*
- * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.

--- a/src/Utils/external/Nonce.ts
+++ b/src/Utils/external/Nonce.ts
@@ -1,19 +1,4 @@
 /*
- * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-/*
  * Copyright (c) Microsoft Corporation
  *
  * All rights reserved.

--- a/src/Utils/external/Uri.ts
+++ b/src/Utils/external/Uri.ts
@@ -1,19 +1,4 @@
 /*
- * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-/*
  * Copyright (c) Microsoft Corporation
  *
  * All rights reserved.


### PR DESCRIPTION
This commit removes Samsung Copyright which was in external source codes.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>