### PR TITLE
Apply static logger

### DIFF
--- a/src/Backend/Backend.ts
+++ b/src/Backend/Backend.ts
@@ -17,7 +17,6 @@
 const assert = require('assert');
 import {Backend} from './API';
 import {gToolchainEnvMap, ToolchainEnv} from '../Toolchain/ToolchainEnv';
-import {Logger} from '../Utils/Logger';
 
 /**
  * Interface of backend map
@@ -38,7 +37,7 @@ function backendRegistrationApi() {
       globalBackendMap[backendName] = backend;
       const compiler = backend.compiler();
       if (compiler) {
-        gToolchainEnvMap[backend.name()] = new ToolchainEnv(Logger.getInstance(), compiler);
+        gToolchainEnvMap[backend.name()] = new ToolchainEnv(compiler);
       }
       console.log(`Backend ${backendName} was registered into ONE-vscode.`);
     }

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -24,7 +24,6 @@ import {CfgEditorPanel} from '../CfgEditor/CfgEditorPanel';
 import {ToolArgs} from '../Project/ToolArgs';
 import {ToolRunner} from '../Project/ToolRunner';
 import {obtainWorkspaceRoot} from '../Utils/Helpers';
-import {Logger} from '../Utils/Logger';
 
 /**
  * Read an ini file
@@ -418,7 +417,7 @@ export class OneExplorer {
   // TODO Support multi-root workspace
   public workspaceRoot: vscode.Uri = vscode.Uri.file(obtainWorkspaceRoot());
 
-  constructor(context: vscode.ExtensionContext, logger: Logger) {
+  constructor(context: vscode.ExtensionContext) {
     // NOTE: Fix `obtainWorksapceRoot` if non-null assertion is false
     const oneTreeDataProvider = new OneTreeDataProvider(this.workspaceRoot!);
     context.subscriptions.push(
@@ -439,7 +438,7 @@ export class OneExplorer {
       vscode.commands.registerCommand(
           'onevscode.run-cfg',
           (oneNode: OneNode) => {
-            const oneccRunner = new OneccRunner(oneNode.node.uri, logger);
+            const oneccRunner = new OneccRunner(oneNode.node.uri);
             oneccRunner.run();
           })
     ]);
@@ -460,7 +459,7 @@ class OneccRunner extends EventEmitter {
   private startRunningOnecc: string = 'START_RUNNING_ONECC';
   private finishedRunningOnecc: string = 'FINISHED_RUNNING_ONECC';
 
-  constructor(private cfgUri: vscode.Uri, private logger: Logger) {
+  constructor(private cfgUri: vscode.Uri) {
     super();
   }
 
@@ -468,7 +467,7 @@ class OneccRunner extends EventEmitter {
    * Function called when onevscode.run-cfg is called (when user clicks 'Run' on cfg file).
    */
   public run() {
-    const toolRunner = new ToolRunner(this.logger);
+    const toolRunner = new ToolRunner();
 
     this.on(this.startRunningOnecc, this.onStartRunningOnecc);
     this.on(this.finishedRunningOnecc, this.onFinishedRunningOnecc);

--- a/src/Project/Builder.ts
+++ b/src/Project/Builder.ts
@@ -18,7 +18,6 @@ import * as vscode from 'vscode';
 
 import {Balloon} from '../Utils/Balloon';
 import * as helpers from '../Utils/Helpers';
-import {Logger} from '../Utils/Logger';
 
 import {BuilderCfgFile} from './BuilderCfgFile';
 import {BuilderJob} from './BuilderJob';
@@ -26,15 +25,13 @@ import {Job} from './Job';
 import {WorkFlow} from './WorkFlow';
 
 export class Builder implements BuilderJob {
-  logger: Logger;
   workFlow: WorkFlow;  // our build WorkFlow
   currentWorkspace: string = '';
   builderCfgFile: BuilderCfgFile;
 
-  constructor(l: Logger) {
-    this.logger = l;
-    this.workFlow = new WorkFlow(l);
-    this.builderCfgFile = new BuilderCfgFile(this, l);
+  constructor() {
+    this.workFlow = new WorkFlow();
+    this.builderCfgFile = new BuilderCfgFile(this);
   }
 
   public init() {

--- a/src/Project/BuilderCfgFile.ts
+++ b/src/Project/BuilderCfgFile.ts
@@ -152,7 +152,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
 
     console.log('importTFlite = ', importTFlite);
     this.jobOwner.addJob(importTFlite);
-    Logger.append('Add Import: ' + inputModel);
+    Logger.info(this.tag, 'Add Import: ' + inputModel);
   }
 
   private cfgImportOnnx(prop: any) {
@@ -167,7 +167,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
 
     console.log('importOnnx = ', importONNX);
     this.jobOwner.addJob(importONNX);
-    Logger.append('Add Import: ' + inputModel);
+    Logger.info(this.tag, 'Add Import: ' + inputModel);
   }
 
   private cfgImportBcq(prop: any) {
@@ -184,7 +184,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
 
     console.log('importTF = ', importBCQ);
     this.jobOwner.addJob(importBCQ);
-    Logger.append('Add Import: ' + inputModel);
+    Logger.info(this.tag, 'Add Import: ' + inputModel);
   }
 
   private cfgOptimize(prop: any) {
@@ -243,7 +243,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
 
     console.log('optimize = ', optimize);
     this.jobOwner.addJob(optimize);
-    Logger.append('Add Optimize: ' + inputModel);
+    Logger.info(this.tag, 'Add Optimize: ' + inputModel);
   }
 
   private cfgQuantize(prop: any) {
@@ -256,7 +256,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
 
     console.log('quantize = ', quantize);
     this.jobOwner.addJob(quantize);
-    Logger.append('Add Quantize: ' + inputModel);
+    Logger.info(this.tag, 'Add Quantize: ' + inputModel);
   }
 
   private cfgPack(prop: any) {
@@ -269,7 +269,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
 
     console.log('pack = ', pack);
     this.jobOwner.addJob(pack);
-    Logger.append('Add Pack: ' + inputModel);
+    Logger.info(this.tag, 'Add Pack: ' + inputModel);
   }
 
   private cfgCodegen(prop: any) {
@@ -281,7 +281,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
 
     console.log('Codegen = ', codegen);
     this.jobOwner.addJob(codegen);
-    Logger.append('Add Codegen: ' + codegen.backend);
+    Logger.info(this.tag, 'Add Codegen: ' + codegen.backend);
   }
 
   private isItemTrue(item: string): boolean {
@@ -295,21 +295,21 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
   private validateUniqueImport(cfgOne: any): boolean {
     let importCount = 0;
 
-    Logger.append('Reading configuration...');
+    Logger.info(this.tag, 'Reading configuration...');
     if (this.isItemTrue(cfgOne[K_IMPORT_TF])) {
-      Logger.append(K_IMPORT_TF + ' is True');
+      Logger.info(this.tag, K_IMPORT_TF + ' is True');
       importCount = importCount + 1;
     }
     if (this.isItemTrue(cfgOne[K_IMPORT_TFLITE])) {
-      Logger.append(K_IMPORT_TFLITE + ' is True');
+      Logger.info(this.tag, K_IMPORT_TFLITE + ' is True');
       importCount = importCount + 1;
     }
     if (this.isItemTrue(cfgOne[K_IMPORT_ONNX])) {
-      Logger.append(K_IMPORT_ONNX + ' is True');
+      Logger.info(this.tag, K_IMPORT_ONNX + ' is True');
       importCount = importCount + 1;
     }
     if (this.isItemTrue(cfgOne[K_IMPORT_BCQ])) {
-      Logger.append(K_IMPORT_BCQ + ' is True');
+      Logger.info(this.tag, K_IMPORT_BCQ + ' is True');
       importCount = importCount + 1;
     }
     return importCount === 1;
@@ -399,7 +399,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
       this.cfgCodegen(prop);
     }
 
-    Logger.append('Done import configuration.');
+    Logger.info(this.tag, 'Done import configuration.');
     this.jobOwner.finishAdd();
   }
 

--- a/src/Project/BuilderCfgFile.ts
+++ b/src/Project/BuilderCfgFile.ts
@@ -111,15 +111,14 @@ const K_OPT_transform_min_relu_to_relu6: string = 'transform_min_relu_to_relu6';
  * @brief onecc/one-build cfg importer
  */
 export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector {
+  tag = this.constructor.name;
   jobOwner: BuilderJob;
-  logger: Logger;
   cfgFilePath: string = '';
   cfgFilename: string = '';
 
-  constructor(jobOwner: BuilderJob, l: Logger) {
+  constructor(jobOwner: BuilderJob) {
     super();
     this.jobOwner = jobOwner;
-    this.logger = l;
 
     this.on(K_BEGIN_IMPORT, this.onBeginImport);
   }
@@ -140,7 +139,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
 
     console.log('importTF = ', importTF);
     this.jobOwner.addJob(importTF);
-    this.logger.outputLine('Add Import: ' + inputModel);
+    Logger.info(this.tag, 'Add Import: ' + inputModel);
   }
 
   private cfgImportTflite(prop: any) {
@@ -153,7 +152,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
 
     console.log('importTFlite = ', importTFlite);
     this.jobOwner.addJob(importTFlite);
-    this.logger.outputLine('Add Import: ' + inputModel);
+    Logger.append('Add Import: ' + inputModel);
   }
 
   private cfgImportOnnx(prop: any) {
@@ -168,7 +167,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
 
     console.log('importOnnx = ', importONNX);
     this.jobOwner.addJob(importONNX);
-    this.logger.outputLine('Add Import: ' + inputModel);
+    Logger.append('Add Import: ' + inputModel);
   }
 
   private cfgImportBcq(prop: any) {
@@ -185,7 +184,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
 
     console.log('importTF = ', importBCQ);
     this.jobOwner.addJob(importBCQ);
-    this.logger.outputLine('Add Import: ' + inputModel);
+    Logger.append('Add Import: ' + inputModel);
   }
 
   private cfgOptimize(prop: any) {
@@ -244,7 +243,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
 
     console.log('optimize = ', optimize);
     this.jobOwner.addJob(optimize);
-    this.logger.outputLine('Add Optimize: ' + inputModel);
+    Logger.append('Add Optimize: ' + inputModel);
   }
 
   private cfgQuantize(prop: any) {
@@ -257,7 +256,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
 
     console.log('quantize = ', quantize);
     this.jobOwner.addJob(quantize);
-    this.logger.outputLine('Add Quantize: ' + inputModel);
+    Logger.append('Add Quantize: ' + inputModel);
   }
 
   private cfgPack(prop: any) {
@@ -270,7 +269,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
 
     console.log('pack = ', pack);
     this.jobOwner.addJob(pack);
-    this.logger.outputLine('Add Pack: ' + inputModel);
+    Logger.append('Add Pack: ' + inputModel);
   }
 
   private cfgCodegen(prop: any) {
@@ -282,7 +281,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
 
     console.log('Codegen = ', codegen);
     this.jobOwner.addJob(codegen);
-    this.logger.outputLine('Add Codegen: ' + codegen.backend);
+    Logger.append('Add Codegen: ' + codegen.backend);
   }
 
   private isItemTrue(item: string): boolean {
@@ -296,21 +295,21 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
   private validateUniqueImport(cfgOne: any): boolean {
     let importCount = 0;
 
-    this.logger.outputLine('Reading configuration...');
+    Logger.append('Reading configuration...');
     if (this.isItemTrue(cfgOne[K_IMPORT_TF])) {
-      this.logger.outputLine(K_IMPORT_TF + ' is True');
+      Logger.append(K_IMPORT_TF + ' is True');
       importCount = importCount + 1;
     }
     if (this.isItemTrue(cfgOne[K_IMPORT_TFLITE])) {
-      this.logger.outputLine(K_IMPORT_TFLITE + ' is True');
+      Logger.append(K_IMPORT_TFLITE + ' is True');
       importCount = importCount + 1;
     }
     if (this.isItemTrue(cfgOne[K_IMPORT_ONNX])) {
-      this.logger.outputLine(K_IMPORT_ONNX + ' is True');
+      Logger.append(K_IMPORT_ONNX + ' is True');
       importCount = importCount + 1;
     }
     if (this.isItemTrue(cfgOne[K_IMPORT_BCQ])) {
-      this.logger.outputLine(K_IMPORT_BCQ + ' is True');
+      Logger.append(K_IMPORT_BCQ + ' is True');
       importCount = importCount + 1;
     }
     return importCount === 1;
@@ -400,7 +399,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
       this.cfgCodegen(prop);
     }
 
-    this.logger.outputLine('Done import configuration.');
+    Logger.append('Done import configuration.');
     this.jobOwner.finishAdd();
   }
 

--- a/src/Project/JobRunner.ts
+++ b/src/Project/JobRunner.ts
@@ -29,7 +29,7 @@ const K_INVOKE: string = 'invoke';
 const K_CLEANUP: string = 'cleanup';
 
 export class JobRunner extends EventEmitter {
-  logger: Logger;
+  tag = this.constructor.name;  // logging tag
   jobs: WorkJobs = [];
   cwd: string = '';
   running: boolean = false;
@@ -37,10 +37,9 @@ export class JobRunner extends EventEmitter {
   private progressTimer?: NodeJS.Timeout;
   private progress?: vscode.Progress<{message?: string, increment?: number}>;
 
-  constructor(l: Logger) {
+  constructor() {
     super();
-    this.logger = l;
-    this.toolRunner = new ToolRunner(l);
+    this.toolRunner = new ToolRunner();
 
     this.on(K_INVOKE, this.onInvoke);
     this.on(K_CLEANUP, this.onCleanup);
@@ -90,7 +89,7 @@ export class JobRunner extends EventEmitter {
   private onInvoke() {
     let job = this.jobs.shift();
     if (job === undefined) {
-      this.logger.outputWithTime('Finish Running ONE compilers.');
+      Logger.info(this.tag, 'Finish Running ONE compilers.');
       this.emit(K_CLEANUP);
       return;
     }

--- a/src/Project/ToolRunner.ts
+++ b/src/Project/ToolRunner.ts
@@ -25,35 +25,32 @@ const which = require('which');
 const K_DATA: string = 'data';
 const K_EXIT: string = 'exit';
 
-export class ToolRunner {
-  logger: Logger;
 
-  constructor(l: Logger) {
-    this.logger = l;
-  }
+export class ToolRunner {
+  tag = this.constructor.name;  // logging tag
 
   private handlePromise(
       resolve: (value: string|PromiseLike<string>) => void,
       reject: (value: string|PromiseLike<string>) => void, cmd: cp.ChildProcessWithoutNullStreams) {
     // stdout
     cmd.stdout.on(K_DATA, (data: any) => {
-      this.logger.output(data.toString());
+      Logger.append(data.toString());
     });
     // stderr
     cmd.stderr.on(K_DATA, (data: any) => {
-      this.logger.output(data.toString());
+      Logger.append(data.toString());
     });
 
     cmd.on(K_EXIT, (code: any) => {
       let codestr = code.toString();
       console.log('child process exited with code ' + codestr);
       if (codestr === '0') {
-        this.logger.outputWithTime('Build Success.');
-        this.logger.outputLine('');
+        Logger.info(this.tag, 'Build Success.');
+        Logger.appendLine('');
         resolve(codestr);
       } else {
-        this.logger.outputWithTime('Build Failed:' + codestr);
-        this.logger.outputLine('');
+        Logger.info(this.tag, 'Build Failed:' + codestr);
+        Logger.appendLine('');
         let errorMsg = 'Failed with exit code: ' + codestr;
         reject(errorMsg);
       }
@@ -85,7 +82,7 @@ export class ToolRunner {
 
   public getRunner(name: string, tool: string, toolargs: ToolArgs, path: string, root?: boolean) {
     return new Promise<string>((resolve, reject) => {
-      this.logger.outputWithTime('Running: ' + name);
+      Logger.info(this.tag, 'Running: ' + name);
       let cmd = undefined;
       if (root) {
         // NOTE

--- a/src/Project/WorkFlow.ts
+++ b/src/Project/WorkFlow.ts
@@ -15,21 +15,18 @@
  */
 
 import {Balloon} from '../Utils/Balloon';
-import {Logger} from '../Utils/Logger';
 import {Job} from './Job';
 import {JobRunner} from './JobRunner';
 import {WorkJobs} from './WorkJobs';
 
 export class WorkFlow {
-  logger: Logger;
   workspace: string = '';
   jobs: WorkJobs;
   jobRunner: JobRunner;
 
-  constructor(logger: Logger) {
-    this.logger = logger;
+  constructor() {
     this.jobs = new WorkJobs();
-    this.jobRunner = new JobRunner(this.logger);
+    this.jobRunner = new JobRunner();
   }
 
   private validateJobs(): boolean {

--- a/src/Tests/Project/Builder.test.ts
+++ b/src/Tests/Project/Builder.test.ts
@@ -16,22 +16,20 @@
 
 import {assert} from 'chai';
 import {Builder} from '../../Project/Builder';
-import {Logger} from '../../Utils/Logger';
 import {MockJob} from '../MockJob';
 
 suite('Project', function() {
   suite('Builder', function() {
-    const logger = Logger.getInstance();
     suite('#contructor()', function() {
       test('is contructed with Logger', function() {
-        let builder = new Builder(logger);
+        let builder = new Builder();
         assert.isObject<Builder>(builder);
       });
     });
 
     suite('#init()', function() {
       test('inits members of Builder', function() {
-        let builder = new Builder(logger);
+        let builder = new Builder();
         builder.init();
         assert.equal(builder.workFlow.jobs.length, 0);
       });
@@ -39,7 +37,7 @@ suite('Project', function() {
 
     suite('#addJob()', function() {
       test('adds job', function() {
-        let builder = new Builder(logger);
+        let builder = new Builder();
         builder.init();
         assert.equal(builder.workFlow.jobs.length, 0);
         let job = new MockJob('job0');
@@ -50,7 +48,7 @@ suite('Project', function() {
 
     suite('#clearJobs()', function() {
       test('clears jobs', function() {
-        let builder = new Builder(logger);
+        let builder = new Builder();
         builder.init();
         assert.equal(builder.workFlow.jobs.length, 0);
         let job = new MockJob('job0');

--- a/src/Tests/Project/JobRunner.test.ts
+++ b/src/Tests/Project/JobRunner.test.ts
@@ -19,16 +19,14 @@ import {assert} from 'chai';
 import {JobRunner} from '../../Project/JobRunner';
 import {WorkJobs} from '../../Project/WorkJobs';
 import {obtainWorkspaceRoot} from '../../Utils/Helpers';
-import {Logger} from '../../Utils/Logger';
 import {MockJob} from '../MockJob';
 
 suite('Project', function() {
   suite('JobRunner', function() {
-    const logger = Logger.getInstance();
     suite('@Use-onecc', function() {
       suite('#start()', function() {
         test('jobs are done', function(done) {
-          let jobRunner = new JobRunner(logger);
+          let jobRunner = new JobRunner();
           const workspaceRoot: string = obtainWorkspaceRoot();
           let workJobs = new WorkJobs();
           workJobs.push(new MockJob('mockup'));

--- a/src/Tests/Project/ToolRunner.test.ts
+++ b/src/Tests/Project/ToolRunner.test.ts
@@ -19,16 +19,14 @@ import {join} from 'path';
 
 import {ToolRunner} from '../../Project/ToolRunner';
 import {obtainWorkspaceRoot} from '../../Utils/Helpers';
-import {Logger} from '../../Utils/Logger';
 import {MockJob} from '../MockJob';
 
 suite('Project', function() {
   suite('ToolRunner', function() {
-    const logger = Logger.getInstance();
     suite('@Use-onecc', function() {
       suite('#getOneccPath()', function() {
         test('returns onecc path as string', function() {
-          let toolRunner = new ToolRunner(logger);
+          let toolRunner = new ToolRunner();
           let actual = toolRunner.getOneccPath();  // string or undefined
           // Note. `onecc` path could be changed by user
         assert.isTrue((actual === '/usr/share/one/bin/onecc') ||
@@ -38,7 +36,7 @@ suite('Project', function() {
       suite('#getRunner()', function() {
         test('returns runner as Promise<string>', function(done) {
           let job = new MockJob('mockup');
-          let toolRunner = new ToolRunner(logger);
+          let toolRunner = new ToolRunner();
           const oneccPath = toolRunner.getOneccPath();
           // oneccPath could be string or undefined. Avoid compiling error
           if (oneccPath === undefined) {

--- a/src/Tests/Project/Workflow.test.ts
+++ b/src/Tests/Project/Workflow.test.ts
@@ -16,12 +16,10 @@
 
 import {assert} from 'chai';
 import {WorkFlow} from '../../Project/WorkFlow';
-import {Logger} from '../../Utils/Logger';
 import {MockJob} from '../MockJob';
 
 suite('Project', function() {
   suite('WorkFlow', function() {
-    const logger = Logger.getInstance();
     // jobs for WorkFlow
     const name0 = 'job0';
     const name1 = 'job1';
@@ -29,16 +27,15 @@ suite('Project', function() {
     const job1 = new MockJob(name1);
     suite('#contructor()', function() {
       test('is constructed as WorkFlow', function() {
-        let workFlow = new WorkFlow(logger);
+        let workFlow = new WorkFlow();
         assert.isNotNull(workFlow);
-        assert.isNotNull(workFlow.logger);
         assert.isNotNull(workFlow.jobs);
         assert.isNotNull(workFlow.jobRunner);
       });
     });
     suite('#addJob()', function() {
       test('adds jobs', function() {
-        let workFlow = new WorkFlow(logger);
+        let workFlow = new WorkFlow();
         workFlow.addJob(job0);
         workFlow.addJob(job1);
         assert.strictEqual(workFlow.jobs.length, 2);
@@ -48,7 +45,7 @@ suite('Project', function() {
     });
     suite('#clearJobs()', function() {
       test('clears jobs', function() {
-        let workFlow = new WorkFlow(logger);
+        let workFlow = new WorkFlow();
         workFlow.addJob(job0);
         workFlow.addJob(job1);
         workFlow.clearJobs();

--- a/src/Tests/Toolchain/ToolchainEnv.test.ts
+++ b/src/Tests/Toolchain/ToolchainEnv.test.ts
@@ -20,7 +20,6 @@ import {CompilerBase} from '../../Backend/Compiler';
 import {ToolchainInfo, Toolchains} from '../../Backend/Toolchain';
 import {DebianToolchain} from '../../Backend/ToolchainImpl/DebianToolchain';
 import {ToolchainEnv} from '../../Toolchain/ToolchainEnv';
-import {Logger} from '../../Utils/Logger';
 
 const mocCompilerType: string = 'test';
 
@@ -62,19 +61,18 @@ class MockCompiler extends CompilerBase {
 suite('Toolchain', function() {
   suite('ToolchainEnv', function() {
     const K_CLEANUP: string = 'cleanup';
-    const logger = Logger.getInstance();
     const compiler = new MockCompiler();
 
     suite('#constructor()', function() {
       test('is constructed with params', function() {
-        let env = new ToolchainEnv(logger, compiler);
+        let env = new ToolchainEnv(compiler);
         assert.strictEqual(env.compiler, compiler);
       });
     });
 
     suite('#getToolchainType()', function() {
       test('get toolchain types', function() {
-        let env = new ToolchainEnv(logger, compiler);
+        let env = new ToolchainEnv(compiler);
         const types = env.getToolchainTypes();
         assert.deepEqual(types, compiler.getToolchainTypes());
       });
@@ -82,7 +80,7 @@ suite('Toolchain', function() {
 
     suite('#listAvailable()', function() {
       test('lists available toolchains', function() {
-        let env = new ToolchainEnv(logger, compiler);
+        let env = new ToolchainEnv(compiler);
         const types = env.getToolchainTypes();
         let toolchains = env.listAvailable(types[0], 0, 1);
         assert.deepEqual(toolchains, [compiler.availableToolchain]);
@@ -91,7 +89,7 @@ suite('Toolchain', function() {
 
     suite('#listInstalled()', function() {
       test('lists installed toolchain', function() {
-        let env = new ToolchainEnv(logger, compiler);
+        let env = new ToolchainEnv(compiler);
         let toolchains = env.listInstalled();
         assert.deepEqual(toolchains, [compiler.installedToolchain]);
       });
@@ -103,7 +101,7 @@ suite('Toolchain', function() {
     // suite('@Use-onecc', function() {
     //   suite('#install()', function() {
     //     test('installes the toolchain', function(done) {
-    //       let env = new ToolchainEnv(logger, compiler);
+    //       let env = new ToolchainEnv(compiler);
     //       env.install(compiler.availableToolchain);
     //       env.workFlow.jobRunner.on(K_CLEANUP, function() {
     //         assert.notEqual(env.installed, undefined);
@@ -116,7 +114,7 @@ suite('Toolchain', function() {
 
     //   suite('#uninstall()', function() {
     //     test('uninstalles the toolchain', function(done) {
-    //       let env = new ToolchainEnv(logger, compiler);
+    //       let env = new ToolchainEnv(compiler);
     //       env.uninstall(compiler.installedToolchain);
     //       env.workFlow.jobRunner.on(K_CLEANUP, function() {
     //         assert.equal(env.installed, undefined);

--- a/src/Toolchain/ToolchainEnv.ts
+++ b/src/Toolchain/ToolchainEnv.ts
@@ -27,7 +27,6 @@ import {JobUninstall} from '../Project/JobUninstall';
 import {WorkFlow} from '../Project/WorkFlow';
 import {Balloon} from '../Utils/Balloon';
 import * as helpers from '../Utils/Helpers';
-import {Logger} from '../Utils/Logger';
 import {showPasswordQuickInput} from '../View/PasswordQuickInput';
 
 class Env implements BuilderJob {
@@ -35,8 +34,8 @@ class Env implements BuilderJob {
   currentWorkspace: string = '';
   isPrepared: boolean = false;
 
-  constructor(l: Logger) {
-    this.workFlow = new WorkFlow(l);
+  constructor() {
+    this.workFlow = new WorkFlow();
   }
 
   public init() {
@@ -98,8 +97,8 @@ class ToolchainEnv extends Env {
   // TODO(jyoung): Support multiple installed toolchains
   compiler: Compiler;
 
-  constructor(l: Logger, compiler: Compiler) {
-    super(l);
+  constructor(compiler: Compiler) {
+    super();
     this.compiler = compiler;
     this.init();
   }

--- a/src/Utils/Logger.ts
+++ b/src/Utils/Logger.ts
@@ -17,87 +17,63 @@
 import * as vscode from 'vscode';
 
 export class Logger {
-  outputChannel: vscode.OutputChannel;
-  firstFocus: boolean;
+  static outputChannel = vscode.window.createOutputChannel('ONE-VSCode');
+  static firstFocus: boolean;
 
-  private static logger: Logger|null = null;
-
-  private constructor() {
-    this.outputChannel = vscode.window.createOutputChannel('ONE-VSCode');
-    this.firstFocus = true;
-  }
-
-  public static getInstance(): Logger {
-    if (Logger.logger === null) {
-      Logger.logger = new Logger();
-    }
-
-    return Logger.logger;
-  }
-
-  private checkShow() {
-    if (this.firstFocus) {
-      this.outputChannel.show(false);
-      this.firstFocus = false;
+  private static checkShow() {
+    if (Logger.firstFocus) {
+      Logger.outputChannel.show(false);
+      Logger.firstFocus = false;
     }
   }
 
-  // deprecate. replace to error(), warning(), info, or debug()
-  public outputWithTime(msg: string) {
-    let dateTime = new Date();
-    this.checkShow();
-    this.outputChannel.appendLine('[' + dateTime.toLocaleString() + '] ' + msg);
-  }
-
-  // deprecate. replace to append()
-  public output(msg: string) {
-    this.checkShow();
-    this.outputChannel.append(msg);
-  }
-
-  // deprecate
-  public outputLine(msg: string) {
-    this.checkShow();
-    this.outputChannel.appendLine(msg);
-  }
-
-  private log(severity: string, tag: string, msg: string) {
+  private static log(severity: string, tag: string, msg: string) {
     const time = new Date().toLocaleString();
 
-    this.checkShow();
-    this.outputChannel.appendLine(`[${time}][${tag}][${severity}] ${msg}`);
+    Logger.checkShow();
+    Logger.outputChannel.appendLine(`[${time}][${tag}][${severity}] ${msg}`);
   }
 
   /**
    * @brief Print log in '[time][tag][severity] msg' format where severity = 'err'
    */
-  public error(tag: string, msg: string) {
+  public static error(tag: string, msg: string) {
     const severity = 'err';
-    this.log(severity, tag, msg);
+    Logger.log(severity, tag, msg);
   }
 
   /**
    * @brief Print log in '[time][tag][severity] msg' format where severity = 'warn'
    */
-  public warn(tag: string, msg: string) {
+  public static warn(tag: string, msg: string) {
     const severity = 'warn';
-    this.log(severity, tag, msg);
+    Logger.log(severity, tag, msg);
   }
 
   /**
    * @brief Print log in '[time][tag][severity] msg' format where severity = 'info'
    */
-  public info(tag: string, msg: string) {
+  public static info(tag: string, msg: string) {
     const severity = 'info';
-    this.log(severity, tag, msg);
+    Logger.log(severity, tag, msg);
   }
 
   /**
    * @brief Print log in '[time][tag][severity] msg' format where severity = 'debug'
    */
-  public debug(tag: string, msg: string) {
+  public static debug(tag: string, msg: string) {
     const severity = 'debug';
-    this.log(severity, tag, msg);
+    Logger.log(severity, tag, msg);
+  }
+
+  /**
+   * @brief Print msg and a line feed character without adding '[time][tag][severity]'
+   * @detail When log is long and need to be splitted into many chunks, append() could be used
+   *         after the first chunk.
+   */
+  public static appendLine(msg: string) {
+    Logger.checkShow();
+    Logger.outputChannel.appendLine(msg);
   }
 
   /**
@@ -105,8 +81,8 @@ export class Logger {
    * @detail When log is long and need to be splitted into many chunks, append() could be used
    *         after the first chunk.
    */
-  public append(msg: string) {
-    this.checkShow();
-    this.outputChannel.appendLine(msg);
+  public static append(msg: string) {
+    Logger.checkShow();
+    Logger.outputChannel.append(msg);
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,15 +31,15 @@ import {MondrianEditorProvider} from './Mondrian/MondrianEditor';
 import {OneExplorer} from './OneExplorer/OneExplorer';
 import {Project} from './Project';
 import {ToolchainProvider} from './Toolchain/ToolchainProvider';
-import {Utils} from './Utils';
+import {Logger} from './Utils/Logger';
 import {showInstallQuickInput} from './View/InstallQuickInput';
 
 export function activate(context: vscode.ExtensionContext) {
-  const logger = Utils.Logger.getInstance();
+  const tag = 'activate';
 
-  logger.outputWithTime('one-vscode activate OK');
+  Logger.info(tag, 'one-vscode activate OK');
 
-  new OneExplorer(context, logger);
+  new OneExplorer(context);
 
   // ONE view
   const toolchainProvier = new ToolchainProvider();
@@ -69,7 +69,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(CfgEditorPanel.register(context));
 
-  let projectBuilder = new Project.Builder(logger);
+  let projectBuilder = new Project.Builder();
 
   projectBuilder.init();
 


### PR DESCRIPTION
This applies static logger.

1. Make all class var and method as static.
2. Remove `logger` param being passed around and `import` 
3. Remove deprecated methods
4. Classes now have logging tag

While doing the above, one method `appendLine` was added into Logger
because ToolRunner needs both `append` and `appendLine`.

For #662 

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>