### PR TITLE
[Toolchain] Remove unused installed toolchain variable

### DIFF
--- a/src/Tests/Toolchain/ToolchainEnv.test.ts
+++ b/src/Tests/Toolchain/ToolchainEnv.test.ts
@@ -68,7 +68,6 @@ suite('Toolchain', function() {
     suite('#constructor()', function() {
       test('is constructed with params', function() {
         let env = new ToolchainEnv(logger, compiler);
-        assert.equal(env.installed, undefined);
         assert.strictEqual(env.compiler, compiler);
       });
     });

--- a/src/Toolchain/ToolchainEnv.ts
+++ b/src/Toolchain/ToolchainEnv.ts
@@ -96,12 +96,10 @@ class Env implements BuilderJob {
 
 class ToolchainEnv extends Env {
   // TODO(jyoung): Support multiple installed toolchains
-  installed?: Toolchain;
   compiler: Compiler;
 
   constructor(l: Logger, compiler: Compiler) {
     super(l);
-    this.installed = undefined;
     this.compiler = compiler;
     this.init();
   }
@@ -123,20 +121,8 @@ class ToolchainEnv extends Env {
   }
 
   install(toolchain: Toolchain) {
-    if (this.installed !== undefined) {
-      Balloon.error(
-          'The debian toolchain installed in your system must be one and only. Please uninstall the existing toolchain first.');
-      return;
-    }
-    if (this.installed === toolchain) {
-      Balloon.error('This toolchain is already installed.');
-      return;
-    }
     let cmd = toolchain.install();
     let job = new JobInstall(cmd);
-    job.successCallback = () => {
-      this.installed = toolchain;
-    };
     this.clearJobs();
     this.addJob(job);
     this.finishAdd();
@@ -144,12 +130,6 @@ class ToolchainEnv extends Env {
   }
 
   uninstall(toolchain: Toolchain) {
-    if (this.installed === undefined) {
-      throw Error('Any toolchain is not yet installed');
-    }
-    if (this.installed !== toolchain) {
-      throw Error('The other toolchain is installed');
-    }
     let cmd = toolchain.uninstall();
     let job = new JobUninstall(cmd);
     this.clearJobs();
@@ -159,12 +139,6 @@ class ToolchainEnv extends Env {
   }
 
   compile(cfg: string, toolchain: Toolchain) {
-    if (this.installed === undefined) {
-      throw Error('Any toolchain is not yet installed');
-    }
-    if (this.installed !== toolchain) {
-      throw Error('The other toolchain is installed');
-    }
     let cmd = this.compiler.compile(cfg);
     let job = new JobConfig(cmd);
     this.clearJobs();


### PR DESCRIPTION
This commit removes installed toolchain variable.
The installed toolchain can be multiple toolchains and
it does not have to be stored and managed.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>