### PR TITLE
Use aptitude for backend API

### DIFF
--- a/src/Backend/ToolchainImpl/DebianToolchain.ts
+++ b/src/Backend/ToolchainImpl/DebianToolchain.ts
@@ -60,14 +60,27 @@ class DebianToolchain implements Toolchain {
 
   // impl of Toolchain
   install(): Command {
+    // NOTE (Issue #30)
+    // Install command uses `aptitude` tool because this tool resolves
+    // package dependency issues automatically unlike `apt-get`.
+    //
+    // Command:
+    // $ aptitude install triv2-toolchain-latest=1.1.0~22050320 -q -y
+    //
+    // According to man(8) aptitude
+    // -q: suppress all incremental progress indicators
+    // -y: assume that the user entered "yes"
     this.prepare();
-    let cmd = new Command('apt-get');
+    let cmd = new Command('aptitude');
     cmd.push('install');
     let pkg: string = this.info.name;
     if (this.info.version !== undefined) {
       pkg = `${pkg}=${this.info.version.str()}`;
     }
     cmd.push(pkg);
+    cmd.push('-q');
+    cmd.push('-y');
+    cmd.setRoot();
     return cmd;
   }
   uninstall(): Command {
@@ -79,6 +92,7 @@ class DebianToolchain implements Toolchain {
       pkg = `${pkg}=${this.info.version.str()}`;
     }
     cmd.push(pkg);
+    cmd.setRoot();
     return cmd;
   }
   installed(): Command {
@@ -90,6 +104,8 @@ class DebianToolchain implements Toolchain {
       pkg = `${pkg}=${this.info.version.str()}`;
     }
     cmd.push(pkg);
+    cmd.push('&&');
+    cmd.push('echo $?');
     return cmd;
   }
 };

--- a/src/Tests/Backend/ToolchainImpl/DebianToolchain.test.ts
+++ b/src/Tests/Backend/ToolchainImpl/DebianToolchain.test.ts
@@ -58,7 +58,7 @@ suite('Backend', function() {
         test('', function() {
           let dt = new DebianToolchain(info);
           let cmd = dt.install();
-          const expectedStr = 'apt-get install ' + name + '=' + version.str();
+          const expectedStr = `sudo aptitude install ${name}=${version.str()} -q -y`;
           assert.strictEqual(cmd.str(), expectedStr);
         });
       });
@@ -67,7 +67,7 @@ suite('Backend', function() {
         test('', function() {
           let dt = new DebianToolchain(info);
           let cmd = dt.uninstall();
-          const expectedStr = 'apt-get purge ' + name + '=' + version.str();
+          const expectedStr = 'sudo apt-get purge ' + name + '=' + version.str();
           assert.strictEqual(cmd.str(), expectedStr);
         });
       });
@@ -76,7 +76,7 @@ suite('Backend', function() {
         test('', function() {
           let dt = new DebianToolchain(info);
           let cmd = dt.installed();
-          const expectedStr = 'dpkg-query --show ' + name + '=' + version.str();
+          const expectedStr = `dpkg-query --show ${name}=${version.str()} && echo $?`;
           assert.strictEqual(cmd.str(), expectedStr);
         });
       });


### PR DESCRIPTION
This uses aptitude for installation of debian toolchain.

This was copied from backend repo.

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>