### PR TITLE
[Toolchain] Allow empty toolchain list on install quick input

### DIFF
--- a/src/View/InstallQuickInput.ts
+++ b/src/View/InstallQuickInput.ts
@@ -61,7 +61,7 @@ export async function showInstallQuickInput(context: vscode.ExtensionContext) {
     const types = state.toolchainEnv.getToolchainTypes();
     if (types.length === 1) {
       state.toolchainType = types[0];
-    } else if (types.length > 1) {
+    } else {
       const typeGroups: vscode.QuickPickItem[] = types.map((label) => ({label}));
       const type = await input.showQuickPick({
         title,


### PR DESCRIPTION
This commit allows empty toolchain list on install quick input.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>