### PR TITLE
Make Logger to log object and accept variadic params

### DIFF
--- a/src/Backend/Backend.ts
+++ b/src/Backend/Backend.ts
@@ -17,6 +17,7 @@
 const assert = require('assert');
 import {Backend} from './API';
 import {gToolchainEnvMap, ToolchainEnv} from '../Toolchain/ToolchainEnv';
+import {Logger} from '../Utils/Logger';
 
 /**
  * Interface of backend map
@@ -30,6 +31,7 @@ interface BackendMap {
 let globalBackendMap: BackendMap = {};
 
 function backendRegistrationApi() {
+  const logTag = 'backendRegistrationApi';
   let registrationAPI = {
     registerBackend(backend: Backend) {
       const backendName = backend.name();
@@ -39,7 +41,7 @@ function backendRegistrationApi() {
       if (compiler) {
         gToolchainEnvMap[backend.name()] = new ToolchainEnv(compiler);
       }
-      console.log(`Backend ${backendName} was registered into ONE-vscode.`);
+      Logger.info(logTag, 'Backend', backendName, 'was registered into ONE-vscode.');
     }
   };
 

--- a/src/Project/BuilderCfgFile.ts
+++ b/src/Project/BuilderCfgFile.ts
@@ -150,7 +150,7 @@ export class BuilderCfgFile extends EventEmitter implements helpers.FileSelector
     let inputModel = path.basename(importTFlite.inputPath);
     importTFlite.name = 'ImportTFlite ' + inputModel;
 
-    console.log('importTFlite = ', importTFlite);
+    Logger.debug(this.tag, 'importTFlite = ', importTFlite);
     this.jobOwner.addJob(importTFlite);
     Logger.info(this.tag, 'Add Import: ' + inputModel);
   }

--- a/src/Project/JobRunner.ts
+++ b/src/Project/JobRunner.ts
@@ -66,7 +66,7 @@ export class JobRunner extends EventEmitter {
       tool = 'onecc';
     }
 
-    Logger.info(this.tag, 'Run tool:', tool, 'args:', toolArgs, 'cwd:', path, 'root: ', job.root);
+    Logger.info(this.tag, 'Run tool:', tool, 'args:', toolArgs, 'cwd:', path, 'root:', job.root);
     const runner = this.toolRunner.getRunner(job.name, tool, toolArgs, path, job.root);
 
     runner

--- a/src/Project/JobRunner.ts
+++ b/src/Project/JobRunner.ts
@@ -66,7 +66,7 @@ export class JobRunner extends EventEmitter {
       tool = 'onecc';
     }
 
-    console.log('Run tool: ', tool, ' args: ', toolArgs, ' cwd: ', path, ' root: ', job.root);
+    Logger.info(this.tag, 'Run tool:', tool, 'args:', toolArgs, 'cwd:', path, 'root: ', job.root);
     const runner = this.toolRunner.getRunner(job.name, tool, toolArgs, path, job.root);
 
     runner

--- a/src/Utils/Logger.ts
+++ b/src/Utils/Logger.ts
@@ -16,6 +16,8 @@
 
 import * as vscode from 'vscode';
 
+type MsgList = (number|boolean|string|object)[];
+
 export class Logger {
   static outputChannel = vscode.window.createOutputChannel('ONE-VSCode');
   static firstFocus: boolean;
@@ -27,7 +29,18 @@ export class Logger {
     }
   }
 
-  private static log(severity: string, tag: string, msg: string) {
+  private static log(severity: string, tag: string, ...msgs: MsgList) {
+    let logStrList = [];
+
+    for (var i = 0; i < msgs.length; i++) {
+      // ref: https://stackoverflow.com/q/5612787
+      if (typeof (msgs[i]) === 'object') {
+        logStrList.push(JSON.stringify(msgs[i]));
+      } else {
+        logStrList.push(`${msgs[i]}`);
+      }
+    }
+    const msg = logStrList.join(' ');
     const time = new Date().toLocaleString();
 
     Logger.checkShow();
@@ -35,35 +48,35 @@ export class Logger {
   }
 
   /**
-   * @brief Print log in '[time][tag][severity] msg' format where severity = 'err'
+   * @brief Print log with prefix '[time][tag][severity]' where severity = 'err'
    */
-  public static error(tag: string, msg: string) {
+  public static error(tag: string, ...msgs: MsgList) {
     const severity = 'err';
-    Logger.log(severity, tag, msg);
+    Logger.log(severity, tag, ...msgs);
   }
 
   /**
-   * @brief Print log in '[time][tag][severity] msg' format where severity = 'warn'
+   * @brief Print log with prefix '[time][tag][severity]' where severity = 'warn'
    */
-  public static warn(tag: string, msg: string) {
+  public static warn(tag: string, ...msgs: MsgList) {
     const severity = 'warn';
-    Logger.log(severity, tag, msg);
+    Logger.log(severity, tag, ...msgs);
   }
 
   /**
-   * @brief Print log in '[time][tag][severity] msg' format where severity = 'info'
+   * @brief Print log with prefix '[time][tag][severity]' where severity = 'info'
    */
-  public static info(tag: string, msg: string) {
+  public static info(tag: string, ...msgs: MsgList) {
     const severity = 'info';
-    Logger.log(severity, tag, msg);
+    Logger.log(severity, tag, ...msgs);
   }
 
   /**
-   * @brief Print log in '[time][tag][severity] msg' format where severity = 'debug'
+   * @brief Print log with prefix '[time][tag][severity]' where severity = 'debug'
    */
-  public static debug(tag: string, msg: string) {
+  public static debug(tag: string, ...msgs: MsgList) {
     const severity = 'debug';
-    Logger.log(severity, tag, msg);
+    Logger.log(severity, tag, ...msgs);
   }
 
   /**


### PR DESCRIPTION
While converting existing console.log to Logger's methods,
two changes were made.

1. Logging object type in Json format
2. Accept variadic params

This PR also has some usage cases of 1 and 2.

For https://github.com/Samsung/ONE-vscode/issues/662

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>