### PR TITLE
Hide progress when compilation error occurs

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -534,7 +534,7 @@ class OneccRunner extends EventEmitter {
         vscode.window.showWarningMessage(`Error: NYI`);
       });
 
-      const p = new Promise<void>(resolve => {
+      const p = new Promise<void>((resolve, reject) => {
         runnerPromise
             .then(value => {
               resolve();
@@ -543,6 +543,7 @@ class OneccRunner extends EventEmitter {
             .catch(value => {
               vscode.window.showWarningMessage(
                   `Error occured while running: 'onecc --config ${this.cfgUri.fsPath}'`);
+              reject();
             });
       });
 


### PR DESCRIPTION
Previously, when there's error during running onecc,
progress notification does not disappear.

This commit makes progress notification.

for https://github.com/Samsung/ONE-vscode/issues/635

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>