### PR TITLE
[OneExplorer] Validate input for rename

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -188,7 +188,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
     const validateInputPath = (newname: string): string|undefined => {
       const oldpath = oneNode.node.path;
       const dirpath = path.dirname(oneNode.node.uri.fsPath);
-      const newpath: string = path.join(${dirpath}, ${newname});
+      const newpath: string = path.join(dirpath, newname);
 
       if (path.extname(newpath) !== path.extname(oldpath)) {
         return `File ext must be (${path.extname(oldpath)})`;

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -195,7 +195,8 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
       }
 
       if (fs.existsSync(newpath)) {
-        return `A file or folder ${newpath} already exists at this location. Please choose a different name.`;
+        return `A file or folder ${
+            newpath} already exists at this location. Please choose a different name.`;
       }
     };
 

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -185,11 +185,26 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
       warningMessage = 'WARNING: Renaming may result in some unexpected changes on the tree view.';
     }
 
+    const validateInputPath = (newname: string): string|undefined => {
+      const oldpath = oneNode.node.path;
+      const dirpath = path.dirname(oneNode.node.uri.fsPath);
+      const newpath: string = `${dirpath}/${newname}`;
+
+      if (path.extname(newpath) !== path.extname(oldpath)) {
+        return `File ext must be (${path.extname(oldpath)})`;
+      }
+
+      if (fs.existsSync(newpath)) {
+        return `Invalid: Path already exists!`;
+      }
+    };
+
     vscode.window
         .showInputBox({
           title: 'Enter a file name:',
           placeHolder: `${path.basename(oneNode.node.uri.fsPath)}`,
-          prompt: warningMessage
+          prompt: warningMessage,
+          validateInput: validateInputPath
         })
         .then(newname => {
           if (newname) {

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -195,7 +195,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
       }
 
       if (fs.existsSync(newpath)) {
-        return `Invalid: Path already exists!`;
+        return `Invalid: File already exists!`;
       }
     };
 

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -195,7 +195,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
       }
 
       if (fs.existsSync(newpath)) {
-        return `Invalid: File already exists!`;
+        return `A file or folder ${newpath} already exists at this location. Please choose a different name.`;
       }
     };
 

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -188,7 +188,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
     const validateInputPath = (newname: string): string|undefined => {
       const oldpath = oneNode.node.path;
       const dirpath = path.dirname(oneNode.node.uri.fsPath);
-      const newpath: string = `${dirpath}/${newname}`;
+      const newpath: string = path.join(${dirpath}, ${newname});
 
       if (path.extname(newpath) !== path.extname(oldpath)) {
         return `File ext must be (${path.extname(oldpath)})`;


### PR DESCRIPTION
This commit validates an input for renaming.
It checks (1) ext, (2) file already exists.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>