### PR TITLE
[CfgEditor] Add member variable for CfgEditorPanel

### DIFF
--- a/src/CfgEditor/CfgEditorPanel.ts
+++ b/src/CfgEditor/CfgEditorPanel.ts
@@ -72,10 +72,7 @@ export class CfgEditorPanel implements vscode.CustomTextEditorProvider {
       delete this._oneConfig['one-build'];
     }
 
-    webviewPanel.webview.postMessage({
-      type: 'displayCfgToEditor',
-      text: ini.parse(document.getText()),
-    });
+    webviewPanel.webview.postMessage({type: 'displayCfgToEditor', text: this._oneConfig});
   };
 
   public async resolveCustomTextEditor(


### PR DESCRIPTION
Until now, content of cfg file is not saved but parsed every time.
To apply changes at cfg editor and save resources,
this commit introduces member variable `_oneConfig` to hold it.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #698 
Draft : #697 