### PR TITLE
[Utils] Move MultiStepInput out of external dir

### DIFF
--- a/src/Execute/executeQuickInput.ts
+++ b/src/Execute/executeQuickInput.ts
@@ -20,7 +20,7 @@ import * as vscode from 'vscode';
 
 import {Backend} from '../Backend/API';
 import {globalBackendMap} from '../Backend/Backend';
-import {MultiStepInput} from '../Utils/external/MultiStepInput';
+import {MultiStepInput} from '../Utils/MultiStepInput';
 
 export async function runInferenceQuickInput(context: vscode.ExtensionContext) {
   interface State {

--- a/src/Utils/MultiStepInput.ts
+++ b/src/Utils/MultiStepInput.ts
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
@@ -46,7 +61,12 @@ export class MultiStepInput {
   }
 
   private current?: QuickInput;
-  private steps: InputStep[] = [];
+
+  // NOTE(jyoung)
+  // When a new quick input is shown in the progress of using MultiStepInput, it is
+  // automatically added to this steps variable. To remove unintended quick input,
+  // this variable sets to public.
+  public steps: InputStep[] = [];
 
   private async stepThrough<T>(start: InputStep) {
     let step: InputStep|void = start;

--- a/src/View/InstallQuickInput.ts
+++ b/src/View/InstallQuickInput.ts
@@ -19,7 +19,7 @@ import * as vscode from 'vscode';
 import {Toolchain} from '../Backend/Toolchain';
 import {JobCallback} from '../Project/Job';
 import {gToolchainEnvMap, ToolchainEnv} from '../Toolchain/ToolchainEnv';
-import {MultiStepInput} from '../Utils/external/MultiStepInput';
+import {MultiStepInput} from '../Utils/MultiStepInput';
 
 export async function showInstallQuickInput() {
   interface State {


### PR DESCRIPTION
This commit moves MultiStepInput class out of external dir.
This commit contains the code chage about MultiStepInput.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft PR: #699 (Big draft PR...)