### PR TITLE
[OneExplorer] Support keybindings 

### DIFF
--- a/package.json
+++ b/package.json
@@ -244,7 +244,7 @@
         },
         {
           "command": "one.explorer.rename",
-          "when": "view == OneExplorerView && viewItem != directory",
+          "when": "view == OneExplorerView",
           "group": "navigation"
         },
         {

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -84,6 +84,7 @@ class Node {
   type: NodeType;
   childNodes: Node[];
   uri: vscode.Uri;
+  parentOneNode: OneNode | undefined;
 
   constructor(type: NodeType, childNodes: Node[], uri: vscode.Uri) {
     this.type = type;
@@ -137,6 +138,7 @@ export class OneNode extends vscode.TreeItem {
     // However, resourceExtname returns info of vscode Explorer view (not of OneExplorer).
     //    "when": "view == OneExplorerView && viewItem == config"
     this.contextValue = nodeTypeToStr(node.type);
+    Logger.info("OneExplorerContextValue", this.contextValue);
   }
 }
 
@@ -159,6 +161,10 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
     for (let event of fileWatchersEvents) {
       event(() => this.refresh());
     }
+  }
+
+  getParent(oneNode: OneNode): OneNode | undefined {
+    return oneNode.node.parentOneNode;
   }
 
   /**
@@ -185,7 +191,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
    * Rename a file of all types of nodes (baseModel, derivedModel, config) excepts for directory.
    * It only alters the file name, not the path.
    */
-  rename(oneNode: OneNode): void {
+  rename(oneNode: OneNode): Thenable<void> {
     // TODO: prohibit special characters for security ('..', '*', etc)
     let warningMessage;
     if (oneNode.node.type === NodeType.baseModel) {
@@ -217,7 +223,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
       }
     };
 
-    vscode.window
+    return vscode.window
         .showInputBox({
           title: 'Enter a file name:',
           value: `${path.basename(oneNode.node.uri.fsPath)}`,
@@ -234,8 +240,9 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
           if (newname) {
             const dirpath = path.dirname(oneNode.node.uri.fsPath);
             const newpath = `${dirpath}/${newname}`;
-            vscode.workspace.fs.rename(oneNode.node.uri, vscode.Uri.file(newpath)).then(
-              ()=>this.refresh(oneNode);
+            return vscode.workspace.fs.rename(oneNode.node.uri, vscode.Uri.file(newpath)).then(
+              // Refresh the whole tree
+              ()=>this.refresh()
             );
           }
         });
@@ -343,7 +350,10 @@ input_path=${modelName}.${extName}
     }
 
     if (element) {
-      return Promise.resolve(this.getNode(element.node));
+      return Promise.resolve(this.getNode(element.node).map(oneNode=>{
+        oneNode.node.parentOneNode=element;
+        return oneNode;
+      }));
     } else {
       return Promise.resolve(this.getNode(this.getTree(this.workspaceRoot)));
     }
@@ -512,6 +522,10 @@ export class OneExplorer {
       }
     };
 
+    this.treeView.onDidChangeSelection(()=>{
+      Logger.info("OneExplorer", this.treeView!.selection);
+    });
+
     subscribeDisposals([
       this.treeView,
       vscode.commands.registerCommand('one.explorer.open', (file) => this.openFile(file)),
@@ -527,12 +541,11 @@ export class OneExplorer {
             oneccRunner.run();
           }),
       vscode.commands.registerCommand(
-        'one.explorer.rename', () => {
-          this.treeView!.selection.forEach(oneNode=>{
-            if(oneNode) {
-              oneTreeDataProvider.rename(oneNode);
-            }
-          });
+        'one.explorer.rename',  () => {
+          // TODO Support multiselection renaming
+          if(this.treeView!.selection[0] !== undefined){
+            oneTreeDataProvider.rename(this.treeView!.selection[0]);
+          }
         }),
       vscode.commands.registerCommand(
           'one.explorer.openContainingFolder',


### PR DESCRIPTION
This commit supports keybindings 'rename' 'delete' 'refresh'
on OneExplorer.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>