### PR TITLE
[OneExplorer] Add open cfg commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,16 @@
         "category": "ONE"
       },
       {
+        "command": "onevscode.open-cfg",
+        "title": "Open with ONE Cfg Editor (default)",
+        "category": "ONE"
+      },
+      {
+        "command": "onevscode.open-cfg-as-text",
+        "title": "Open with Text Editor",
+        "category": "ONE"
+      },
+      {
         "command": "onevscode.refresh-toolchain",
         "title": "Refresh",
         "category": "ONE",
@@ -203,6 +213,16 @@
         {
           "command": "onevscode.rename-on-oneexplorer",
           "when": "view == OneExplorerView && viewItem != directory",
+          "group": "navigation"
+        },
+        {
+          "command": "onevscode.open-cfg-as-text",
+          "when": "view == OneExplorerView && viewItem == config",
+          "group": "navigation"
+        },
+        {
+          "command": "onevscode.open-cfg",
+          "when": "view == OneExplorerView && viewItem == config",
           "group": "navigation"
         },
         {

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -529,7 +529,11 @@ export class OneExplorer {
     };
 
     subscribeCommands([
-      vscode.commands.registerCommand('onevscode.open-cfg', (file) => this.openFile(file)),
+      vscode.commands.registerCommand(
+          'onevscode.open-cfg', (oneNode: OneNode) => this.openWithCfgEditor(oneNode.node)),
+      vscode.commands.registerCommand(
+          'onevscode.open-cfg-as-text',
+          (oneNode: OneNode) => this.openWithTextEditor(oneNode.node)),
       vscode.commands.registerCommand(
           'onevscode.refresh-one-explorer', () => oneTreeDataProvider.refresh()),
       vscode.commands.registerCommand(
@@ -546,8 +550,12 @@ export class OneExplorer {
     ]);
   }
 
-  private openFile(node: Node) {
+  private openWithCfgEditor(node: Node) {
     vscode.commands.executeCommand('vscode.openWith', node.uri, CfgEditorPanel.viewType);
+  }
+
+  private openWithTextEditor(node: Node) {
+    vscode.commands.executeCommand('vscode.openWith', node.uri, 'default');
   }
 }
 


### PR DESCRIPTION
This commit adds open cfg commands
- Open with Text Editor
- Open with ONE Cfg Editor (default)

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>