### PR TITLE
[OneExplorer] Add 'Open with Text Editor' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,11 @@
         "category": "ONE"
       },
       {
+        "command": "onevscode.open-cfg-as-text",
+        "title": "Open with Text Editor",
+        "category": "ONE"
+      },
+      {
         "command": "onevscode.refresh-toolchain",
         "title": "Refresh",
         "category": "ONE",
@@ -203,6 +208,11 @@
         {
           "command": "onevscode.rename-on-oneexplorer",
           "when": "view == OneExplorerView && viewItem != directory",
+          "group": "navigation"
+        },
+        {
+          "command": "onevscode.open-cfg-as-text",
+          "when": "view == OneExplorerView && viewItem == config",
           "group": "navigation"
         },
         {

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -531,6 +531,9 @@ export class OneExplorer {
     subscribeCommands([
       vscode.commands.registerCommand('onevscode.open-cfg', (file) => this.openFile(file)),
       vscode.commands.registerCommand(
+          'onevscode.open-cfg-as-text',
+          (oneNode: OneNode) => this.openWithTextEditor(oneNode.node)),
+      vscode.commands.registerCommand(
           'onevscode.refresh-one-explorer', () => oneTreeDataProvider.refresh()),
       vscode.commands.registerCommand(
           'onevscode.create-cfg', (oneNode: OneNode) => oneTreeDataProvider.createCfg(oneNode)),
@@ -548,6 +551,10 @@ export class OneExplorer {
 
   private openFile(node: Node) {
     vscode.commands.executeCommand('vscode.openWith', node.uri, CfgEditorPanel.viewType);
+  }
+
+  private openWithTextEditor(node: Node) {
+    vscode.commands.executeCommand('vscode.openWith', node.uri, 'default');
   }
 }
 


### PR DESCRIPTION
This commit adds 'open with text editor' command for cfg files.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

----

From #730