### PR TITLE
Revise activation events

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,6 @@
   ],
   "extensionKind ": "workspace",
   "activationEvents": [
-    "onCommand:onevscode.build",
-    "onCommand:onevscode.import",
-    "onCommand:onevscode.json-tracer",
-    "onCommand:onevscode.configuration-settings",
-    "onCommand:onevscode.toggle-codelens",
-    "onCommand:onevscode.circle-tracer",
-    "onCustomEditor:cfg.editor",
     "onStartupFinished"
   ],
   "main": "./out/extension.js",


### PR DESCRIPTION
This commit revises activation events.

NOTE: onStartupFinished will activate our extension
some time after VS Code starts up.
The other events are redundant.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

FYI,
https://code.visualstudio.com/api/references/activation-events#onStartupFinished

We want to provide our users with our extension always. 
There are two options: '\*' and 'onStartupFinished' as activation events 'always'.
'onStartupFinished' will activate our extension some time aftser VS Code starts up, 
so that it doesn't slow down the vscode's start-up, unlike "*" will do.