### PR TITLE
[OneExplorer] Add collapseAll command

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,12 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "onevscode.collapse-all",
+        "title": "Collapse All",
+        "category": "ONE",
+        "icon": "$(collapse-all)"
+      },
+      {
         "command": "onevscode.create-cfg",
         "title": "Create new ONE configuration",
         "category": "ONE",
@@ -178,6 +184,11 @@
       "view/title": [
         {
           "command": "onevscode.refresh-one-explorer",
+          "when": "view == OneExplorerView",
+          "group": "navigation"
+        },
+        {
+          "command": "onevscode.collapse-all",
           "when": "view == OneExplorerView",
           "group": "navigation"
         },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
       },
       {
         "command": "onevscode.collapse-all",
-        "title": "Collapse All",
+        "title": "Collapse Folders in ONE Explorer",
         "category": "ONE",
         "icon": "$(collapse-all)"
       },

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -163,6 +163,10 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
     this._onDidChangeTreeData.fire();
   }
 
+  collapseAll(oneNode: OneNode): void {
+    vscode.commands.executeCommand('workbench.actions.treeView.OneExplorerView.collapseAll');
+  }
+
   // TODO: Add move()
 
   openContainingFolder(oneNode: OneNode): void {
@@ -467,7 +471,9 @@ export class OneExplorer {
           (oneNode: OneNode) => oneTreeDataProvider.rename(oneNode)),
       vscode.commands.registerCommand(
           'onevscode.openContainingFolder',
-          (oneNode: OneNode) => oneTreeDataProvider.openContainingFolder(oneNode))
+          (oneNode: OneNode) => oneTreeDataProvider.openContainingFolder(oneNode)),
+      vscode.commands.registerCommand(
+          'onevscode.collapse-all', (oneNode: OneNode) => oneTreeDataProvider.collapseAll(oneNode)),
     ]);
   }
 


### PR DESCRIPTION
This commit adds Collapse All command to OneExplorer
context menu.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>