### PR TITLE
[Mondrian] Add viewport dynamic limiter bar

### DIFF
--- a/media/Mondrian/style.css
+++ b/media/Mondrian/style.css
@@ -27,6 +27,37 @@ div.mondrian-scrollbar {
   flex: 0;
 }
 
+div.mondrian-scrollbar-btn {
+  display: flex;
+  gap: 2px;
+  height: 100%;
+}
+
+div.mondrian-scrollbar-btn button {
+  display: block;
+  padding: 0px;
+  height: 100%;
+  min-width: 32px;
+  white-space: nowrap;
+  overflow: hidden;
+  color: var(--vscode-button-secondaryForeground);
+  background: var(--vscode-button-secondaryBackground);
+  border: none;
+}
+
+div.mondrian-scrollbar-btn button:hover {
+  background: var(--vscode-button-secondaryHoverBackground);
+}
+
+div.mondrian-scrollbar-btn button.mondrian-scrollbar-btn-center {
+  flex: 1;
+}
+
+div.mondrian-scrollbar-btn button.mondrian-scrollbar-btn-left,
+div.mondrian-scrollbar-btn button.mondrian-scrollbar-btn-right {
+  flex: 0;
+}
+
 div.mondrian-viewer-area {
   contain: content;
   overflow: auto;
@@ -96,6 +127,13 @@ div.mondrian-allocation-label {
 
 div.mondrian-allocation-label:hover {
   background-color: rgba(255, 255, 255, 0.2);
+}
+
+div.mondrian-allocation-limit {
+  position: absolute;
+  top: 0px;
+  bottom: 0px;
+  background-color: rgba(0, 0, 0, 0.3);
 }
 
 div.mondrian-viewer-bounds-no-label div.mondrian-allocation-label {

--- a/src/Mondrian/MondrianEditor.ts
+++ b/src/Mondrian/MondrianEditor.ts
@@ -85,9 +85,9 @@ export class MondrianEditorProvider implements vscode.CustomTextEditorProvider {
         <div class="mondrian-layout">
           <div class="mondrian-scrollbar">
             <div class="mondrian-scrollbar-btn">
-              <button class="mondrian-scrollbar-btn-left">&#9664;</button>
+              <button class="mondrian-scrollbar-btn-left">||</button>
               <button class="mondrian-scrollbar-btn-center"></button>
-              <button class="mondrian-scrollbar-btn-right">&#9658;</button>
+              <button class="mondrian-scrollbar-btn-right">||</button>
             </div>
           </div>
           <div class="mondrian-viewer-area">

--- a/src/Mondrian/MondrianEditor.ts
+++ b/src/Mondrian/MondrianEditor.ts
@@ -84,7 +84,11 @@ export class MondrianEditorProvider implements vscode.CustomTextEditorProvider {
       <body>
         <div class="mondrian-layout">
           <div class="mondrian-scrollbar">
-            <!-- TODO Model trim scrollbar is NYI -->
+            <div class="mondrian-scrollbar-btn">
+              <button class="mondrian-scrollbar-btn-left">&#9664;</button>
+              <button class="mondrian-scrollbar-btn-center"></button>
+              <button class="mondrian-scrollbar-btn-right">&#9658;</button>
+            </div>
           </div>
           <div class="mondrian-viewer-area">
             <div class="mondrian-viewer-bounds"></div>

--- a/src/Mondrian/README.md
+++ b/src/Mondrian/README.md
@@ -2,6 +2,11 @@
 
 This extension adds custom editor with reads `*.tracealloc.json` files and provides graphical viewer for allocation trace data with ability to choose a specific memory segment.
 
+### Viewer UI description
+
+* Top scrollbar allows to choose viewport boundaries by dragging its edges with a mouse. It allows to open very large models by limiting rendering to selected area.
+* Status bar shows information about memory blocks on hover: node origin, block size and lifetime. It also contains memory segment selector on the right.
+
 ### Data format specification
 
 Input data format is represented as JSON document which contains the following fields:


### PR DESCRIPTION
This commit adds viewport limiter bar which provides ability to set min/max cycle values to avoid hang-ups for a very large models.

Areas outside of active 'viewport' are marked with shadow borders.

Issue: #395 

Screenshot (shadow on left and right marks viewport limit):
![image](https://user-images.githubusercontent.com/67966333/171845911-da42f2fe-d29b-4bc4-8db7-8d52b93aa18f.png)

Signed-off-by: Alexander Moiseev <a.moiseev@samsung.com>