### PR TITLE
Enable 'Cancel' button of progressive notification

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -508,8 +508,6 @@ import {EventEmitter} from 'events';
 import {ExitCode, SelfKilled, ToolRunner} from '../Project/ToolRunner';
 
 class OneccRunner extends EventEmitter {
-  private logTag = this.constructor.name;
-
   private startRunningOnecc: string = 'START_RUNNING_ONECC';
   private finishedRunningOnecc: string = 'FINISHED_RUNNING_ONECC';
 

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -571,7 +571,7 @@ class OneccRunner extends EventEmitter {
     if (val === exitCodeSuccess) {
       vscode.window.showInformationMessage(`Successfully completed.`);
     } else if (val === 'SelfKilled') {
-      vscode.window.showInformationMessage(`Successfully teminated.`);
+      vscode.window.showInformationMessage(`The job was cancelled.`);
     } else {
       throw Error('unexpected value onFinishedRunningOnecc');
     }

--- a/src/Project/ToolRunner.ts
+++ b/src/Project/ToolRunner.ts
@@ -26,6 +26,7 @@ const K_DATA: string = 'data';
 const K_EXIT: string = 'exit';
 
 // successfully killed by calling kill() method
+export type ExitCode = string;
 export type SelfKilled = 'SelfKilled';
 
 export class ToolRunner {
@@ -39,8 +40,8 @@ export class ToolRunner {
   private killedByMe = false;
 
   private handlePromise(
-      resolve: (value: string|SelfKilled|PromiseLike<string>) => void,
-      reject: (value: string|NodeJS.Signals|PromiseLike<string>) => void) {
+      resolve: (value: ExitCode|SelfKilled|PromiseLike<string>) => void,
+      reject: (value: ExitCode|NodeJS.Signals|PromiseLike<string>) => void) {
     // stdout
     this.child!.stdout.on(K_DATA, (data: any) => {
       Logger.append(data.toString());
@@ -50,7 +51,7 @@ export class ToolRunner {
       Logger.append(data.toString());
     });
 
-    this.child!.on(K_EXIT, (code: number|null, signal: NodeJS.Signals|null) => {
+    this.child!.on(K_EXIT, (code: ExitCode|null, signal: NodeJS.Signals|null) => {
       this.child = undefined;
 
       // From https://nodejs.org/api/child_process.html#event-exit


### PR DESCRIPTION
Previously 'Cancel' button of progressive notification
while running onecc showed NYI error.

With this commit, 'Cancel' button actually terminates
onecc progress.

for For https://github.com/Samsung/ONE-vscode/issues/715
draft #716 

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>