### PR TITLE
[CfgEditor] Replace static files as new

### DIFF
--- a/src/CfgEditor/CfgEditorPanel.ts
+++ b/src/CfgEditor/CfgEditorPanel.ts
@@ -85,7 +85,7 @@ export class CfgEditorPanel implements vscode.CustomTextEditorProvider {
     };
     vscode.commands.executeCommand('setContext', CfgEditorPanel.viewType, true);
 
-    webviewPanel.webview.html = (await this._getHtmlForWebview(webviewPanel.webview)).toString();
+    webviewPanel.webview.html = await this._getHtmlForWebview(webviewPanel.webview);
 
     const changeDocumentSubscription = vscode.workspace.onDidChangeTextDocument(e => {
       if (e.document.uri.toString() === document.uri.toString()) {


### PR DESCRIPTION
Until now, `_getHtmlForWebview` function was returning literal HTML source.
In addition, old css and js have been used.
This commit replaces static files to new ones.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent issue : #698 
Draft : #697 