### PR TITLE
[OneExplorer] Rename command names

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,19 +75,19 @@
     ],
     "commands": [
       {
-        "command": "onevscode.refresh-one-explorer",
+        "command": "one.explorer.refresh",
         "title": "Refresh",
         "category": "ONE",
         "icon": "$(refresh)"
       },
       {
-        "command": "onevscode.collapse-all",
+        "command": "one.explorer.collapseAll",
         "title": "Collapse Folders in ONE Explorer",
         "category": "ONE",
         "icon": "$(collapse-all)"
       },
       {
-        "command": "onevscode.create-cfg",
+        "command": "one.explorer.createCfg",
         "title": "Create new ONE configuration",
         "category": "ONE",
         "icon": "$(add)"
@@ -111,22 +111,22 @@
         "_comment": "Run backend executor's inference command with a given model."
       },
       {
-        "command": "onevscode.run-cfg",
+        "command": "one.explorer.runCfg",
         "title": "Run",
         "category": "ONE"
       },
       {
-        "command": "onevscode.rename-on-oneexplorer",
+        "command": "one.explorer.rename",
         "title": "Rename",
         "category": "ONE"
       },
       {
-        "command": "onevscode.openContainingFolder",
+        "command": "one.explorer.openContainingFolder",
         "title": "Open Containing Folder",
         "category": "ONE"
       },
       {
-        "command": "onevscode.open-cfg-as-text",
+        "command": "one.explorer.openWithTextEditor",
         "title": "Open with Text Editor",
         "category": "ONE"
       },
@@ -193,12 +193,12 @@
     "menus": {
       "view/title": [
         {
-          "command": "onevscode.refresh-one-explorer",
+          "command": "one.explorer.refresh",
           "when": "view == OneExplorerView",
           "group": "navigation"
         },
         {
-          "command": "onevscode.collapse-all",
+          "command": "one.explorer.collapseAll",
           "when": "view == OneExplorerView",
           "group": "navigation"
         },
@@ -220,27 +220,27 @@
       ],
       "view/item/context": [
         {
-          "command": "onevscode.run-cfg",
+          "command": "one.explorer.runCfg",
           "when": "view == OneExplorerView && viewItem == config",
           "group": "navigation"
         },
         {
-          "command": "onevscode.rename-on-oneexplorer",
+          "command": "one.explorer.rename",
           "when": "view == OneExplorerView && viewItem != directory",
           "group": "navigation"
         },
         {
-          "command": "onevscode.openContainingFolder",
+          "command": "one.explorer.openContainingFolder",
           "when": "view == OneExplorerView",
           "group": "navigation"
         },
         {
-          "command": "onevscode.open-cfg-as-text",
+          "command": "one.explorer.openWithTextEditor",
           "when": "view == OneExplorerView && viewItem == config",
           "group": "navigation"
         },
         {
-          "command": "onevscode.create-cfg",
+          "command": "one.explorer.createCfg",
           "when": "view == OneExplorerView && viewItem == baseModel",
           "group": "inline"
         },

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -339,7 +339,7 @@ input_path=${modelName}.${extName}
                                            vscode.TreeItemCollapsibleState.None,
             node);
         oneNode.command = {
-          command: 'onevscode.open-cfg',
+          command: 'one.explorer.openWithCustomEditor',
           title: 'Open File',
           arguments: [oneNode.node]
         };
@@ -479,28 +479,28 @@ export class OneExplorer {
     };
 
     subscribeCommands([
-      vscode.commands.registerCommand('onevscode.open-cfg', (file) => this.openFile(file)),
       vscode.commands.registerCommand(
-          'onevscode.open-cfg-as-text',
+          'one.explorer.openWithCustomEditor', (file) => this.openFile(file)),
+      vscode.commands.registerCommand(
+          'one.explorer.openWithTextEditor',
           (oneNode: OneNode) => this.openWithTextEditor(oneNode.node)),
+      vscode.commands.registerCommand('one.explorer.refresh', () => oneTreeDataProvider.refresh()),
       vscode.commands.registerCommand(
-          'onevscode.refresh-one-explorer', () => oneTreeDataProvider.refresh()),
+          'one.explorer.createCfg', (oneNode: OneNode) => oneTreeDataProvider.createCfg(oneNode)),
       vscode.commands.registerCommand(
-          'onevscode.create-cfg', (oneNode: OneNode) => oneTreeDataProvider.createCfg(oneNode)),
-      vscode.commands.registerCommand(
-          'onevscode.run-cfg',
+          'one.explorer.runCfg',
           (oneNode: OneNode) => {
             const oneccRunner = new OneccRunner(oneNode.node.uri);
             oneccRunner.run();
           }),
       vscode.commands.registerCommand(
-          'onevscode.rename-on-oneexplorer',
-          (oneNode: OneNode) => oneTreeDataProvider.rename(oneNode)),
+          'one.explorer.rename', (oneNode: OneNode) => oneTreeDataProvider.rename(oneNode)),
       vscode.commands.registerCommand(
-          'onevscode.openContainingFolder',
+          'one.explorer.openContainingFolder',
           (oneNode: OneNode) => oneTreeDataProvider.openContainingFolder(oneNode)),
       vscode.commands.registerCommand(
-          'onevscode.collapse-all', (oneNode: OneNode) => oneTreeDataProvider.collapseAll(oneNode)),
+          'one.explorer.collapseAll',
+          (oneNode: OneNode) => oneTreeDataProvider.collapseAll(oneNode)),
     ]);
   }
 
@@ -528,7 +528,7 @@ class OneccRunner extends EventEmitter {
   }
 
   /**
-   * Function called when onevscode.run-cfg is called (when user clicks 'Run' on cfg file).
+   * Function called when one.explorer.runCfg is called (when user clicks 'Run' on cfg file).
    */
   public run() {
     const toolRunner = new ToolRunner();


### PR DESCRIPTION
This commit renames command names from
onevscode.* to one.explorer.*

Related to #728

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>