### PR TITLE
[Toolchain] Rename command names

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,19 +131,19 @@
         "category": "ONE"
       },
       {
-        "command": "onevscode.refresh-toolchain",
+        "command": "one.toolchain.refresh",
         "title": "Refresh",
         "category": "ONE",
         "icon": "$(refresh)"
       },
       {
-        "command": "onevscode.install-toolchain",
+        "command": "one.toolchain.install",
         "title": "Install",
         "category": "ONE",
         "icon": "$(desktop-download)"
       },
       {
-        "command": "onevscode.uninstall-toolchain",
+        "command": "one.toolchain.uninstall",
         "title": "Uninstall",
         "category": "ONE",
         "icon": "$(x)"
@@ -203,12 +203,12 @@
           "group": "navigation"
         },
         {
-          "command": "onevscode.refresh-toolchain",
+          "command": "one.toolchain.refresh",
           "when": "view == ToolchainView",
           "group": "navigation"
         },
         {
-          "command": "onevscode.install-toolchain",
+          "command": "one.toolchain.install",
           "when": "view == ToolchainView",
           "group": "navigation"
         },
@@ -245,7 +245,7 @@
           "group": "inline"
         },
         {
-          "command": "onevscode.uninstall-toolchain",
+          "command": "one.toolchain.uninstall",
           "when": "view == ToolchainView && viewItem == toolchain",
           "group": "inline"
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,12 +45,12 @@ export function activate(context: vscode.ExtensionContext) {
   const toolchainProvier = new ToolchainProvider();
   context.subscriptions.push(
       vscode.window.registerTreeDataProvider('ToolchainView', toolchainProvier));
+  context.subscriptions.push(
+      vscode.commands.registerCommand('one.toolchain.refresh', () => toolchainProvier.refresh()));
+  context.subscriptions.push(
+      vscode.commands.registerCommand('one.toolchain.install', () => toolchainProvier.install()));
   context.subscriptions.push(vscode.commands.registerCommand(
-      'onevscode.refresh-toolchain', () => toolchainProvier.refresh()));
-  context.subscriptions.push(vscode.commands.registerCommand(
-      'onevscode.install-toolchain', () => toolchainProvier.install()));
-  context.subscriptions.push(vscode.commands.registerCommand(
-      'onevscode.uninstall-toolchain', (node) => toolchainProvier.uninstall(node)));
+      'one.toolchain.uninstall', (node) => toolchainProvier.uninstall(node)));
 
   // Target Device view
   let registerDevice = vscode.commands.registerCommand('onevscode.register-device', () => {


### PR DESCRIPTION
This commit renames command names from
onevscode.* to one.toolchain.*

Related to #728

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>