### PR TITLE
[CfgEditor] Rename command names

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,13 +93,13 @@
         "icon": "$(add)"
       },
       {
-        "command": "onevscode.flip-cfg-to-gui",
+        "command": "one.editor.open",
         "title": "Open cfg in GUI",
         "category": "ONE",
         "icon": "$(go-to-file)"
       },
       {
-        "command": "onevscode.flip-cfg-to-ini",
+        "command": "one.editor.openAsText",
         "title": "Open cfg in Text Editor",
         "category": "ONE",
         "icon": "$(go-to-file)"
@@ -175,7 +175,7 @@
         "category": "ONE"
       },
       {
-        "command": "onevscode.toggle-codelens",
+        "command": "one.editor.toggleCodelens",
         "title": "toggle codelens",
         "category": "ONE"
       },
@@ -252,12 +252,12 @@
       ],
       "editor/title": [
         {
-          "command": "onevscode.flip-cfg-to-gui",
+          "command": "one.editor.open",
           "group": "navigation",
           "when": "resourceExtname == .cfg && !cfg.editor"
         },
         {
-          "command": "onevscode.flip-cfg-to-ini",
+          "command": "one.editor.openAsText",
           "group": "navigation",
           "when": "resourceExtname == .cfg && cfg.editor"
         }

--- a/package.json
+++ b/package.json
@@ -93,16 +93,18 @@
         "icon": "$(add)"
       },
       {
-        "command": "one.editor.open",
+        "command": "one.editor.openCfg",
         "title": "Open cfg in GUI",
         "category": "ONE",
-        "icon": "$(go-to-file)"
+        "icon": "$(go-to-file)",
+        "_comment": "NYI"
       },
       {
-        "command": "one.editor.openAsText",
+        "command": "one.editor.openCfgAsText",
         "title": "Open cfg in Text Editor",
         "category": "ONE",
-        "icon": "$(go-to-file)"
+        "icon": "$(go-to-file)",
+        "_comment": "NYI"
       },
       {
         "command": "onevscode.infer-model",
@@ -170,13 +172,13 @@
         "category": "ONE"
       },
       {
-        "command": "onevscode.configuration-settings",
-        "title": "configuration-settings",
+        "command": "one.editor.openCfgWithLegacyEditor",
+        "title": "Open cfg in GUI (legacy)",
         "category": "ONE"
       },
       {
         "command": "one.editor.toggleCodelens",
-        "title": "toggle codelens",
+        "title": "Toggle codelens for cfg",
         "category": "ONE"
       },
       {
@@ -252,14 +254,16 @@
       ],
       "editor/title": [
         {
-          "command": "one.editor.open",
+          "command": "one.editor.openCfg",
           "group": "navigation",
-          "when": "resourceExtname == .cfg && !cfg.editor"
+          "when": "resourceExtname == .cfg && !cfg.editor",
+          "_comment": "NYI"
         },
         {
-          "command": "one.editor.openAsText",
+          "command": "one.editor.openCfgAsText",
           "group": "navigation",
-          "when": "resourceExtname == .cfg && cfg.editor"
+          "when": "resourceExtname == .cfg && cfg.editor",
+          "_comment": "NYI"
         }
       ]
     },

--- a/src/Config/ConfigStatusBar.ts
+++ b/src/Config/ConfigStatusBar.ts
@@ -20,7 +20,7 @@ export function createStatusBarItem(context: vscode.ExtensionContext) {
   let cfgStatusBarItem: vscode.StatusBarItem;
   cfgStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
   cfgStatusBarItem.text = `$(file-add) ONE configuration Settings`;
-  cfgStatusBarItem.command = 'onevscode.configuration-settings';
+  cfgStatusBarItem.command = 'one.editor.openCfgWithLegacyEditor';
   context.subscriptions.push(cfgStatusBarItem);
   cfgStatusBarItem.show();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,7 +89,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(disposableOneJsontracer);
 
   let disposableOneConfigurationSettings =
-      vscode.commands.registerCommand('onevscode.configuration-settings', () => {
+      vscode.commands.registerCommand('one.editor.openCfgWithLegacyEditor', () => {
         ConfigPanel.createOrShow(context);
         Logger.info(tag, 'one configuration settings...');
       });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,7 +98,7 @@ export function activate(context: vscode.ExtensionContext) {
   createStatusBarItem(context);
 
   let disposableToggleCodelens =
-      vscode.commands.registerCommand('onevscode.toggle-codelens', () => {
+      vscode.commands.registerCommand('one.editor.toggleCodelens', () => {
         let codelensState =
             vscode.workspace.getConfiguration('one-vscode').get('enableCodelens', true);
         vscode.workspace.getConfiguration('one-vscode')


### PR DESCRIPTION
This commit renames command names from
onevscode.* to one.editor.* and so on.

Related to #728

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>