### PR TITLE
Refactor exit code and signal of ToolRunner

### DIFF
--- a/src/Project/ToolRunner.ts
+++ b/src/Project/ToolRunner.ts
@@ -25,8 +25,29 @@ const which = require('which');
 const K_DATA: string = 'data';
 const K_EXIT: string = 'exit';
 
-// successfully killed by calling kill() method
-export type SelfKilled = 'SelfKilled';
+/**
+ * Return type when a process exits without error
+ * One of exitCode or intentionallyKilled must NOT be undefined.
+ */
+export interface SuccessResult {
+  // When successful exit, exit code must be 0
+  exitCode?: number;
+  // When this process was intentionally killed by user, this must be true.
+  intentionallyKilled?: boolean;
+}
+
+/**
+ * Return type when a process exits with error
+ * One of exitCode or signal must NOT be undefined.
+ */
+export interface ErrorResult {
+  // When successful exit, exit code must be greater than 0
+  exitCode?: number;
+  // When this process was killed by, e.g., kill command from shell,
+  // this must be set to proper NodeJS.Signals.
+  signal?: NodeJS.Signals;
+}
+;
 
 export class ToolRunner {
   tag = this.constructor.name;  // logging tag
@@ -39,8 +60,8 @@ export class ToolRunner {
   private killedByMe = false;
 
   private handlePromise(
-      resolve: (value: string|SelfKilled|PromiseLike<string>) => void,
-      reject: (value: string|NodeJS.Signals|PromiseLike<string>) => void) {
+      resolve: (value: SuccessResult|PromiseLike<SuccessResult>) => void,
+      reject: (value: ErrorResult|PromiseLike<ErrorResult>) => void) {
     // stdout
     this.child!.stdout.on(K_DATA, (data: any) => {
       Logger.append(data.toString());
@@ -66,25 +87,23 @@ export class ToolRunner {
         Logger.debug(this.tag, `Child process was killed (signal: ${signal!})`);
 
         if (this.killedByMe) {
-          resolve('SelfKilled');
+          resolve({intentionallyKilled: true});
         } else {
-          reject(signal!);
+          reject({signal: signal!});
         }
         return;
       }
 
       // when child exited
-      let codestr = code.toString();
-      Logger.info(this.tag, 'child process exited with code ' + codestr);
-      if (codestr === '0') {
+      Logger.info(this.tag, 'child process exited with code', code);
+      if (code === 0) {
         Logger.info(this.tag, 'Build Success.');
         Logger.appendLine('');
-        resolve(codestr);
+        resolve({exitCode: 0});
       } else {
-        Logger.info(this.tag, 'Build Failed:' + codestr);
+        Logger.info(this.tag, 'Build Failed:', code);
         Logger.appendLine('');
-        let errorMsg = 'Failed with exit code: ' + codestr;
-        reject(errorMsg);
+        reject({exitCode: code});
       }
     });
   }
@@ -152,7 +171,7 @@ export class ToolRunner {
 
     this.killedByMe = false;
 
-    return new Promise<string>((resolve, reject) => {
+    return new Promise<SuccessResult>((resolve, reject) => {
       Logger.info(this.tag, 'Running: ' + name);
       if (root) {
         // NOTE

--- a/src/Project/ToolRunner.ts
+++ b/src/Project/ToolRunner.ts
@@ -41,13 +41,12 @@ export interface SuccessResult {
  * One of exitCode or signal must NOT be undefined.
  */
 export interface ErrorResult {
-  // When successful exit, exit code must be greater than 0
+  // Exit code must be greater than 0
   exitCode?: number;
   // When this process was killed by, e.g., kill command from shell,
   // this must be set to proper NodeJS.Signals.
   signal?: NodeJS.Signals;
 }
-;
 
 export class ToolRunner {
   tag = this.constructor.name;  // logging tag

--- a/src/Tests/Project/ToolRunner.test.ts
+++ b/src/Tests/Project/ToolRunner.test.ts
@@ -18,7 +18,7 @@ import {assert} from 'chai';
 import {join} from 'path';
 
 import {ToolArgs} from '../../Project/ToolArgs';
-import {SelfKilled, ToolRunner} from '../../Project/ToolRunner';
+import {SuccessResult, ToolRunner} from '../../Project/ToolRunner';
 import {obtainWorkspaceRoot} from '../../Utils/Helpers';
 import {MockJob} from '../MockJob';
 
@@ -47,8 +47,8 @@ suite('Project', function() {
           const runner = toolRunner.getRunner(job.name, oneccPath, job.toolArgs, workspaceRoot);
           assert.isNotNull(runner);
           runner
-              .then(function(str) {
-                assert.ok(str);
+              .then(function(res: SuccessResult) {
+                assert.ok(res.exitCode === 0);
                 done();
               })
               .catch(done);
@@ -132,8 +132,8 @@ suite('Project', function() {
 
         const runner = toolRunner.getRunner('long process', 'sleep', args, obtainWorkspaceRoot());
         runner
-            .then((val: string|SelfKilled) => {
-              assert.equal(val, 'SelfKilled');
+            .then((val: SuccessResult) => {
+              assert.equal(val.intentionallyKilled, true);
             })
             .catch(exitcode => {
               assert.fail();
@@ -158,8 +158,8 @@ suite('Project', function() {
 
         const runner = toolRunner.getRunner('long process', 'sleep', args, obtainWorkspaceRoot());
         runner
-            .then((val: string|SelfKilled) => {
-              assert.equal(val, '0');
+            .then((val: SuccessResult) => {
+              assert.equal(val.exitCode, 0);
               finished = true;
             })
             .catch(exitcode => {


### PR DESCRIPTION
Currently exit code and signal handling is kinda complex.
This commit tries to sumplify this by introducing two
interfaces.

from https://github.com/Samsung/ONE-vscode/pull/749#issuecomment-1149432151

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>