### PR TITLE
[Project] Rename commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,12 +155,12 @@
         "icon": "$(add)"
       },
       {
-        "command": "onevscode.build",
+        "command": "one.project.build",
         "title": "build",
         "category": "ONE"
       },
       {
-        "command": "onevscode.import",
+        "command": "one.project.import",
         "title": "cfg import",
         "category": "ONE"
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,13 +70,13 @@ export function activate(context: vscode.ExtensionContext) {
 
   projectBuilder.init();
 
-  let disposableOneBuild = vscode.commands.registerCommand('onevscode.build', () => {
+  let disposableOneBuild = vscode.commands.registerCommand('one.project.build', () => {
     Logger.info(tag, 'one build...');
     projectBuilder.build(context);
   });
   context.subscriptions.push(disposableOneBuild);
 
-  let disposableOneImport = vscode.commands.registerCommand('onevscode.import', () => {
+  let disposableOneImport = vscode.commands.registerCommand('one.project.import', () => {
     Logger.info(tag, 'one import...');
     projectBuilder.import(context);
   });


### PR DESCRIPTION
This commit rename commands from onevscode.* to one.project.*.

Related to #728

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>