### PR TITLE
[Device] Rename commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
         "icon": "$(x)"
       },
       {
-        "command": "onevscode.register-device",
+        "command": "one.device.register",
         "title": "Register",
         "category": "ONE",
         "icon": "$(add)"
@@ -213,7 +213,7 @@
           "group": "navigation"
         },
         {
-          "command": "onevscode.register-device",
+          "command": "one.device.register",
           "when": "view == TargetDeviceView",
           "group": "navigation"
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,7 @@ export function activate(context: vscode.ExtensionContext) {
       'onevscode.uninstall-toolchain', (node) => toolchainProvier.uninstall(node)));
 
   // Target Device view
-  let registerDevice = vscode.commands.registerCommand('onevscode.register-device', () => {
+  let registerDevice = vscode.commands.registerCommand('one.device.register', () => {
     Logger.info(tag, 'register-device: NYI');
   });
   context.subscriptions.push(registerDevice);


### PR DESCRIPTION
This commit renames command onevscode.* to one.device.*.

Related to #728

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>