### PR TITLE
[Backend] Rename commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "icon": "$(go-to-file)"
       },
       {
-        "command": "onevscode.infer-model",
+        "command": "one.backend.infer",
         "title": "Infer",
         "category": "ONE",
         "_comment": "Run backend executor's inference command with a given model."

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
   context.subscriptions.push(registerDevice);
 
-  let inferenceCommand = vscode.commands.registerCommand('onevscode.infer-model', () => {
+  let inferenceCommand = vscode.commands.registerCommand('one.backend.infer', () => {
     Logger.info(tag, 'one infer model...');
     runInferenceQuickInput(context);
   });


### PR DESCRIPTION
This commit renames commands onevscode.* to one.backend.*.

Related to #728

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>