### PR TITLE
[CfgEditor] one-import UI Bugfix

### DIFF
--- a/media/CfgEditor/cfgeditor.html
+++ b/media/CfgEditor/cfgeditor.html
@@ -78,7 +78,7 @@ limitations under the License.
                 <div class="option">
                     <vscode-radio-group id="importInputModelType">
                         <label slot="label">Input Model Type</label>
-                        <vscode-radio value="pb">pb</vscode-radio>
+                        <vscode-radio value="pb" checked="true">pb</vscode-radio>
                         <vscode-radio value="saved">saved_model</vscode-radio>
                         <vscode-radio value="keras">keras_model</vscode-radio>
                         <vscode-radio value="tflite">tflite</vscode-radio>

--- a/media/CfgEditor/index.js
+++ b/media/CfgEditor/index.js
@@ -105,6 +105,7 @@ function registerImportOptions() {
   importInputModelType.addEventListener('click', function() {
     updateImportUI();
     updateImportInputModelType();
+    updateSteps();
     applyUpdates();
   });
 


### PR DESCRIPTION
This commit fixes bugs relates with `one-import`, which is not updating cfg file content correctly.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #698 
Draft : #697 

---

#### Before & After

| Type | Item | Before | After |
| :---: | :---: | :---: | :---: |
| Bugfix | Import Model Type | ![input_modelT_before](https://user-images.githubusercontent.com/24720192/172770998-e566d7a7-3856-4080-97e4-81a297d95a84.gif) | ![input_modelT_after](https://user-images.githubusercontent.com/24720192/172771014-1d394db0-31cc-4ca6-8b56-6972b1e49031.gif)
| Bugfix | Import Step | ![Import_step_before](https://user-images.githubusercontent.com/24720192/172771558-50d98018-eee6-4800-b30d-3d465b04f539.gif) | ![import_step_after](https://user-images.githubusercontent.com/24720192/172771574-143b4235-3c48-4b09-a8df-832315175f13.gif)

