### PR TITLE
[CfgEditor] Add more condition for onDidChangeTextDocument

### DIFF
--- a/src/CfgEditor/CfgEditorPanel.ts
+++ b/src/CfgEditor/CfgEditorPanel.ts
@@ -88,7 +88,7 @@ export class CfgEditorPanel implements vscode.CustomTextEditorProvider {
     webviewPanel.webview.html = await this._getHtmlForWebview(webviewPanel.webview);
 
     const changeDocumentSubscription = vscode.workspace.onDidChangeTextDocument(e => {
-      if (e.document.uri.toString() === document.uri.toString()) {
+      if (e.contentChanges.length > 0 && e.document.uri.toString() === document.uri.toString()) {
         this.updateWebview(document, webviewPanel);
       }
     });


### PR DESCRIPTION
Because of VSCode design, `onDidChangeTextDocument` can be called even when there are no changes.
It is not intended behavior that `updateWebview` is called even if document is not changed.
This commit will fix it by checking whether there are actual document changes.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #698 
Draft : #697 