### PR TITLE
[Viewer] Rename commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
         "category": "ONE"
       },
       {
-        "command": "one.viewer.circleNetron",
+        "command": "one.viewer.circleGraph",
         "title": "circle graph view",
         "category": "ONE"
       }

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
         "category": "ONE"
       },
       {
-        "command": "onevscode.json-tracer",
+        "command": "one.viewer.jsonTracer",
         "title": "json tracer",
         "category": "ONE"
       },
@@ -182,12 +182,12 @@
         "category": "ONE"
       },
       {
-        "command": "onevscode.circle-tracer",
+        "command": "one.viewer.circleTracer",
         "title": "circle tracer",
         "category": "ONE"
       },
       {
-        "command": "onevscode.circle-graphview",
+        "command": "one.viewer.circleNetron",
         "title": "circle graph view",
         "category": "ONE"
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,7 +82,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
   context.subscriptions.push(disposableOneImport);
 
-  let disposableOneJsontracer = vscode.commands.registerCommand('onevscode.json-tracer', () => {
+  let disposableOneJsontracer = vscode.commands.registerCommand('one.viewer.jsonTracer', () => {
     Logger.info(tag, 'one json tracer...');
     Jsontracer.createOrShow(context.extensionUri);
   });
@@ -114,7 +114,7 @@ export function activate(context: vscode.ExtensionContext) {
   let disposableHover = vscode.languages.registerHoverProvider('ini', hover);
   context.subscriptions.push(disposableHover);
 
-  let disposableOneCircleTracer = vscode.commands.registerCommand('onevscode.circle-tracer', () => {
+  let disposableOneCircleTracer = vscode.commands.registerCommand('one.viewer.circleTracer', () => {
     Logger.info(tag, 'one circle tracer...');
     const options: vscode.OpenDialogOptions = {
       canSelectMany: false,
@@ -134,7 +134,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(MondrianEditorProvider.register(context));
 
-  let disposableGraphPenel = vscode.commands.registerCommand('onevscode.circle-graphview', () => {
+  let disposableGraphPenel = vscode.commands.registerCommand('one.viewer.circleNetron', () => {
     CircleGraphPanel.createOrShow(context.extensionUri, undefined);
   });
   context.subscriptions.push(disposableGraphPenel);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,7 +134,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(MondrianEditorProvider.register(context));
 
-  let disposableGraphPenel = vscode.commands.registerCommand('one.viewer.circleNetron', () => {
+  let disposableGraphPenel = vscode.commands.registerCommand('one.viewer.circleGraph', () => {
     CircleGraphPanel.createOrShow(context.extensionUri, undefined);
   });
   context.subscriptions.push(disposableGraphPenel);


### PR DESCRIPTION
This commit renames commands onevscode.* to one.viewer.*

Related to #728

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>