### PR TITLE
[PartEditor] Relocate inital BackendNames

### DIFF
--- a/src/PartEditor/PartEditor.ts
+++ b/src/PartEditor/PartEditor.ts
@@ -97,6 +97,9 @@ export class PartEditorProvider implements vscode.CustomTextEditorProvider {
       this._modelFilePath = this._modelFolderPath + this._modelFileName;
     }
 
+    // TODO revise to get from backend
+    this._backEndNames = ['(default)', 'CPU', 'ACL_CL', 'NPU'];
+
     webviewPanel.webview.options = this.getWebviewOptions(this._extensionUri),
     webviewPanel.webview.html = this.getHtmlForWebview(webviewPanel.webview);
 
@@ -111,9 +114,6 @@ export class PartEditorProvider implements vscode.CustomTextEditorProvider {
   }
 
   private handleRequestBackends() {
-    // TODO revise to get from backend
-    this._backEndNames = ['(default)', 'CPU', 'ACL_CL', 'NPU'];
-
     let backends = '';
     this._backEndNames.forEach((item) => {
       backends = backends + item + '\n';


### PR DESCRIPTION
This will relocate initialization of _backEndNames to
resolveCustomTextEditor method as current position is called multiple
times while editing.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>