### PR TITLE
[Backend] Use ProblemResolver to install older packages

### DIFF
--- a/src/Backend/ToolchainImpl/DebianToolchain.ts
+++ b/src/Backend/ToolchainImpl/DebianToolchain.ts
@@ -70,9 +70,14 @@ class DebianToolchain implements Toolchain {
     // According to man(8) aptitude
     // -q: suppress all incremental progress indicators
     // -y: assume that the user entered "yes"
+    // -o: Set a configuration file option directly
+    //   * Aptitude::ProblemResolver::SolutionCost
+    //        : Describes how to determine the cost of a solution.
+    //          ref: https://tools.ietf.org/doc/aptitude/html/en/ch02s03s04.html
     this.prepare();
     let cmd = new Command('aptitude');
     cmd.push('install');
+    cmd.push(`-o Aptitude::ProblemResolver::SolutionCost='100*canceled-actions,200*removals'`);
     let pkg: string = this.info.name;
     if (this.info.version !== undefined) {
       pkg = `${pkg}=${this.info.version.str()}`;

--- a/src/Tests/Backend/ToolchainImpl/DebianToolchain.test.ts
+++ b/src/Tests/Backend/ToolchainImpl/DebianToolchain.test.ts
@@ -58,7 +58,9 @@ suite('Backend', function() {
         test('', function() {
           let dt = new DebianToolchain(info);
           let cmd = dt.install();
-          const expectedStr = `sudo aptitude install ${name}=${version.str()} -q -y`;
+          const expectedStr =
+              `sudo aptitude install -o Aptitude::ProblemResolver::SolutionCost='100*canceled-actions,200*removals' ${
+                  name}=${version.str()} -q -y`;
           assert.strictEqual(cmd.str(), expectedStr);
         });
       });


### PR DESCRIPTION
This commit uses ProblemResolver to install older packages.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>