### PR TITLE
[Toolchain] Show canceled installation message

### DIFF
--- a/src/View/InstallQuickInput.ts
+++ b/src/View/InstallQuickInput.ts
@@ -110,6 +110,8 @@ export async function showInstallQuickInput() {
           'Prerequisites has not been set yet. Do you want to set it up now?', 'Yes', 'No');
       if (answer === 'Yes') {
         requestPrerequisites(state.toolchainEnv);
+      } else {
+        Balloon.info('Installation is canceled.');
       }
       return;
     }


### PR DESCRIPTION
This commit shows canceled installation message when user rejects
prerequisites() call.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>