### PR TITLE
[PartEditor] Close PartGraphSelector

### DIFF
--- a/src/PartEditor/PartEditor.ts
+++ b/src/PartEditor/PartEditor.ts
@@ -81,6 +81,9 @@ export class PartEditorProvider implements vscode.CustomTextEditorProvider, Part
     });
 
     webviewPanel.onDidDispose(() => {
+      if (this._document) {
+        vscode.commands.executeCommand(PartGraphSelPanel.cmdClose, this._document.fileName);
+      }
       changeDocumentSubscription.dispose();
     });
 


### PR DESCRIPTION
This will close PartGraphSelector when PartEditor is closed.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>