### PR TITLE
Remove deprecated `toolchains()` method

### DIFF
--- a/src/Backend/Compiler.ts
+++ b/src/Backend/Compiler.ts
@@ -29,12 +29,6 @@ import {Toolchains} from './Toolchain';
 // 2. CompilerEnv runs the job with workflow
 interface Compiler {
   /**
-   * @Deprecated Use toolchainTypes() and getToolchains()
-   */
-  // defined/available toolchains by backend supporter
-  toolchains(): Toolchains;
-
-  /**
    * Function to get the type of toolchain. E.g., ['official', 'nightly']
    */
   getToolchainTypes(): string[];
@@ -82,10 +76,6 @@ interface Compiler {
 
 // General compiler uses onecc so default jobs can be used
 class CompilerBase implements Compiler {
-  toolchains(): Toolchains {
-    throw Error('Invalid toolchains call');
-  }
-
   getToolchainTypes(): string[] {
     throw Error('Invalid getToolchainTypes call');
   }

--- a/src/Tests/Toolchain/ToolchainEnv.test.ts
+++ b/src/Tests/Toolchain/ToolchainEnv.test.ts
@@ -35,10 +35,6 @@ class MockCompiler extends CompilerBase {
     this.availableToolchain = new DebianToolchain(
         new ToolchainInfo('nodejs', 'Node.js event-based server-side javascript engine'));
   }
-  // NOTE: Deprecated API
-  toolchains(): Toolchains {
-    throw Error('Deprecated API: toolchains()');
-  }
   getToolchainTypes(): string[] {
     return [mocCompilerType];
   }


### PR DESCRIPTION
This removes deprecated `toolchains()` method in Compiler.ts.

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>