### PR TITLE
[Logger] Show output log during running job runner

### DIFF
--- a/src/Project/JobRunner.ts
+++ b/src/Project/JobRunner.ts
@@ -108,6 +108,7 @@ export class JobRunner extends EventEmitter {
       return;
     }
 
+    Logger.show();
     vscode.window.withProgress(
         {location: vscode.ProgressLocation.Notification, title: 'Running...', cancellable: false},
         (progress) => {

--- a/src/Utils/Logger.ts
+++ b/src/Utils/Logger.ts
@@ -98,4 +98,8 @@ export class Logger {
     Logger.checkShow();
     Logger.outputChannel.append(msg);
   }
+
+  public static show() {
+    Logger.outputChannel.show(true);
+  }
 }


### PR DESCRIPTION
This commit shows output log during running job runner.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>