### PR TITLE
[PartEditor] USe TRIX

### DIFF
--- a/media/PartEditor/index.html
+++ b/media/PartEditor/index.html
@@ -25,7 +25,7 @@ limitations under the License.
 <script type="text/javascript" src="%index.js%" nonce="%nonce%"></script>
 </head>
 <body>
-<p><h3>Available backends: CPU / ACL_CL / NPU</h3></p>
+<p><h3>Available backends: CPU / ACL_CL / TRIX</h3></p>
 <p>NOTE: available backend list will be defined by the backend. Currently this is fixed.</p>
 <hr/>
 <p>Operators of model <i><b>%MODEL_NAME%</b></i></p>

--- a/src/PartEditor/PartEditor.ts
+++ b/src/PartEditor/PartEditor.ts
@@ -134,7 +134,7 @@ export class PartEditorProvider implements vscode.CustomTextEditorProvider, Part
 
     // TODO revise to get from backend
     // item 0 is initial default backend
-    this._backEndNames = ['CPU', 'CPU', 'ACL_CL', 'NPU'];
+    this._backEndNames = ['CPU', 'CPU', 'ACL_CL', 'TRIX'];
 
     webviewPanel.webview.options = this.getWebviewOptions(this._extensionUri),
     webviewPanel.webview.html = this.getHtmlForWebview(webviewPanel.webview);


### PR DESCRIPTION
This will use TRIX to replace NPU in backend names.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>