### PR TITLE
[PartEditor] Set view mode to selector

### DIFF
--- a/src/PartEditor/PartGraphSelector.ts
+++ b/src/PartEditor/PartGraphSelector.ts
@@ -157,6 +157,7 @@ export class PartGraphSelPanel extends CircleGraphCtrl implements CircleGraphEve
     }, null, this._disposables);
 
     this.initGraphCtrl(this._modelPath, this);
+    this.setMode('selector');
   }
 
   public dispose() {


### PR DESCRIPTION
This will revise to set CircleGraphCtrl view mode to selector for
PartEditorSelector.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>