### PR TITLE
[Toolchain] Add runCfg command in toolchain provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,10 @@
         "icon": "$(x)"
       },
       {
+        "command": "one.toolchain.runCfg",
+        "title": "Run"
+      },
+      {
         "command": "one.device.register",
         "title": "Register",
         "category": "ONE",
@@ -264,6 +268,12 @@
           "group": "navigation",
           "when": "resourceExtname == .cfg && cfg.editor",
           "_comment": "NYI"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "one.toolchain.runCfg",
+          "when": "false"
         }
       ]
     },

--- a/src/Toolchain/ToolchainProvider.ts
+++ b/src/Toolchain/ToolchainProvider.ts
@@ -119,4 +119,8 @@ export class ToolchainProvider implements vscode.TreeDataProvider<ToolchainNode>
       this.refresh();
     });
   }
+
+  run(cfg: string) {
+    throw Error('Not implemented yet');
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,6 +52,8 @@ export function activate(context: vscode.ExtensionContext) {
       vscode.commands.registerCommand('one.toolchain.install', () => toolchainProvier.install()));
   context.subscriptions.push(vscode.commands.registerCommand(
       'one.toolchain.uninstall', (node) => toolchainProvier.uninstall(node)));
+  context.subscriptions.push(
+      vscode.commands.registerCommand('one.toolchain.runCfg', (cfg) => toolchainProvier.run(cfg)));
 
   // Target Device view
   let registerDevice = vscode.commands.registerCommand('one.device.register', () => {


### PR DESCRIPTION
This commit adds runCfg command in toolchain provider.
And it hides this command from command palette because it can't
work without cfg file.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft PR: #818 