### PR TITLE
[CircleViewer] Disable MultipleEditorsPerDocument

### DIFF
--- a/src/CircleGraph/CircleViewer.ts
+++ b/src/CircleGraph/CircleViewer.ts
@@ -78,7 +78,7 @@ export class CircleViewerProvider implements
       webviewOptions: {
         retainContextWhenHidden: true,
       },
-      supportsMultipleEditorsPerDocument: true,
+      supportsMultipleEditorsPerDocument: false,
     };
 
     return vscode.window.registerCustomEditorProvider(


### PR DESCRIPTION
This will disable support for MultipleEditorsPerDocument.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>