### PR TITLE
[Toolchain] Change filter of installed toolchain items

### DIFF
--- a/src/Toolchain/ToolchainProvider.ts
+++ b/src/Toolchain/ToolchainProvider.ts
@@ -108,8 +108,11 @@ export class ToolchainProvider implements vscode.TreeDataProvider<ToolchainNode>
   install() {
     showInstallQuickInput().then(
         ([toolchainEnv, toolchain]) => {
-          const installed =
-              toolchainEnv.listInstalled().filter(value => value instanceof DebianToolchain);
+          // NOTE(jyoung)
+          // The `DebianToolchain` of the backend and the `DebianToolchain` of this project
+          // are not recognized as the same object by `instanceof` function.
+          const installed = toolchainEnv.listInstalled().filter(
+              value => value.constructor.name === 'DebianToolchain');
           if (installed.length > 1) {
             Logger.error(this.tag, 'Installed debian toolchain must be unique');
             vscode.window.showErrorMessage('Installed debian toolchain must be unique');


### PR DESCRIPTION
This commit changes teh filter code of installed toolchain items.
The `DebianToolchain` of the backend and the `DebianToolchain` of this project
are not recognized as the same object by `instanceof`.
So, it is classified by classname.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>