### PR TITLE
[OneExplorer] Hide from command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -277,6 +277,34 @@
       ],
       "commandPalette": [
         {
+          "command": "one.explorer.refresh",
+          "when": "false"
+        },
+        {
+          "command": "one.explorer.collapseAll",
+          "when": "false"
+        },
+        {
+          "command": "one.explorer.createCfg",
+          "when": "false"
+        },
+        {
+          "command": "one.explorer.runCfg",
+          "when": "false"
+        },
+        {
+          "command": "one.explorer.rename",
+          "when": "false"
+        },
+        {
+          "command": "one.explorer.openContainingFolder",
+          "when": "false"
+        },
+        {
+          "command": "one.explorer.openAsText",
+          "when": "false"
+        },
+        {
           "command": "one.toolchain.runCfg",
           "when": "false"
         }


### PR DESCRIPTION
This commit hides unnecessary commands in command palette

Related issue #839

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>