### PR TITLE
Remove `title` with progress notification

### DIFF
--- a/src/Project/JobRunner.ts
+++ b/src/Project/JobRunner.ts
@@ -110,8 +110,7 @@ export class JobRunner extends EventEmitter {
 
     Logger.show();
     vscode.window.withProgress(
-        {location: vscode.ProgressLocation.Notification, title: 'Running...', cancellable: false},
-        (progress) => {
+        {location: vscode.ProgressLocation.Notification, cancellable: false}, (progress) => {
           // TODO(jyoung): Implement to request cancel job.
           return new Promise<void>(resolve => {
             this.progress = progress;


### PR DESCRIPTION
This remvoed `title` with progerss notification since
`title` is concatenated with `message` and this sometimes makes
message with awkward wording.

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>