### PR TITLE
Show `See log` button in Balloon

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -522,6 +522,7 @@ export class OneExplorer {
 //
 
 import {EventEmitter} from 'events';
+import {Balloon} from '../Utils/Balloon';
 
 class OneccRunner extends EventEmitter {
   private startRunningOnecc: string = 'START_RUNNING_ONECC';
@@ -572,8 +573,7 @@ class OneccRunner extends EventEmitter {
               this.emit(this.finishedRunningOnecc, value);
             })
             .catch(value => {
-              vscode.window.showErrorMessage(
-                  `Error occured while running: 'onecc --config ${this.cfgUri.fsPath}'`);
+              Balloon.error(`Error occured while running: 'onecc --config ${this.cfgUri.fsPath}'`);
               reject();
             });
       });
@@ -584,9 +584,9 @@ class OneccRunner extends EventEmitter {
 
   private onFinishedRunningOnecc(val: SuccessResult) {
     if (val.exitCode !== undefined && val.exitCode === 0) {
-      vscode.window.showInformationMessage(`Successfully completed.`);
+      Balloon.info(`Successfully completed.`);
     } else if (val.intentionallyKilled !== undefined && val.intentionallyKilled === true) {
-      vscode.window.showInformationMessage(`The job was cancelled.`);
+      Balloon.info(`The job was cancelled.`);
     } else {
       throw Error('unexpected value onFinishedRunningOnecc');
     }

--- a/src/Utils/Balloon.ts
+++ b/src/Utils/Balloon.ts
@@ -19,7 +19,7 @@ import * as vscode from 'vscode';
 import {Logger} from './Logger';
 
 export class Balloon {
-  static seeLogBtn = 'See logs';
+  static seeLogBtn = 'See log';
 
   static handleBtn(selection: string|undefined) {
     if (selection === Balloon.seeLogBtn) {
@@ -28,15 +28,33 @@ export class Balloon {
     // Ignore 'OK' button
   }
 
-  static error(msg: string) {
-    vscode.window.showErrorMessage(msg, 'OK', Balloon.seeLogBtn).then(Balloon.handleBtn);
+  // Error notification message shows 'See log' button by default
+  static error(msg: string, showSeeLogBtn: boolean = true) {
+    let func = vscode.window.showErrorMessage;
+    if (showSeeLogBtn) {
+      func(msg, 'OK', Balloon.seeLogBtn).then(Balloon.handleBtn);
+    } else {
+      func(msg, 'OK');
+    }
   }
 
-  static info(msg: string) {
-    vscode.window.showInformationMessage(msg, 'OK', Balloon.seeLogBtn).then(Balloon.handleBtn);
+  // Info notification message does not show 'See log' button by default
+  static info(msg: string, showSeeLogBtn: boolean = false) {
+    let func = vscode.window.showInformationMessage;
+    if (showSeeLogBtn) {
+      func(msg, 'OK', Balloon.seeLogBtn).then(Balloon.handleBtn);
+    } else {
+      func(msg, 'OK');
+    }
   }
 
-  static warning(msg: string) {
-    vscode.window.showWarningMessage(msg, 'OK', Balloon.seeLogBtn).then(Balloon.handleBtn);
+  // Warning notification message shows 'See log' button by default
+  static warning(msg: string, showSeeLogBtn: boolean = true) {
+    let func = vscode.window.showWarningMessage;
+    if (showSeeLogBtn) {
+      func(msg, 'OK', Balloon.seeLogBtn).then(Balloon.handleBtn);
+    } else {
+      func(msg, 'OK');
+    }
   }
 }

--- a/src/Utils/Balloon.ts
+++ b/src/Utils/Balloon.ts
@@ -16,16 +16,27 @@
 
 import * as vscode from 'vscode';
 
+import {Logger} from './Logger';
+
 export class Balloon {
+  static seeLogBtn = 'See logs';
+
+  static handleBtn(selection: string|undefined) {
+    if (selection === Balloon.seeLogBtn) {
+      Logger.show();
+    }
+    // Ignore 'OK' button
+  }
+
   static error(msg: string) {
-    vscode.window.showErrorMessage(msg);
+    vscode.window.showErrorMessage(msg, 'OK', Balloon.seeLogBtn).then(Balloon.handleBtn);
   }
 
   static info(msg: string) {
-    vscode.window.showInformationMessage(msg);
+    vscode.window.showInformationMessage(msg, 'OK', Balloon.seeLogBtn).then(Balloon.handleBtn);
   }
 
   static warning(msg: string) {
-    vscode.window.showWarningMessage(msg);
+    vscode.window.showWarningMessage(msg, 'OK', Balloon.seeLogBtn).then(Balloon.handleBtn);
   }
 }


### PR DESCRIPTION
This adds 'OK' and 'See log' button in methods in Balloon.
When 'See log' button is pressed, log window will be opened.

This also changes some methods in OneExplorer.ts
to show this new Balloon. (as a demonstration)

for #823

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>