### PR TITLE
[CfgEditor] Add '--save-allocations' codegen option

### DIFF
--- a/media/CfgEditor/cfgeditor.html
+++ b/media/CfgEditor/cfgeditor.html
@@ -467,6 +467,12 @@ limitations under the License.
                         Command
                     </vscode-text-field>           
                 </div>
+                <div class="option">
+                    <vscode-checkbox id="codegenSaveAllocations">
+                        Save allocations trace
+                    </vscode-checkbox>
+                    <span title="Save allocation trace as *.tracealloc.json file for supported backends" class="codicon codicon-question" style="cursor: pointer"></span>
+                </div>
             </div>
         </div>
         <div class="options" id="optionProfile">

--- a/media/CfgEditor/index.js
+++ b/media/CfgEditor/index.js
@@ -366,12 +366,24 @@ function registerCopyQuantOptions() {
 function registerCodegenOptions() {
   const codegenBackend = document.getElementById('codegenBackend');
   const codegenCommand = document.getElementById('codegenCommand');
+  const codegenSaveAllocations = document.getElementById('codegenSaveAllocations');
 
   codegenBackend.addEventListener('change', function() {
     updateCodegen();
     applyUpdates();
   });
   codegenCommand.addEventListener('change', function() {
+    updateCodegen();
+    applyUpdates();
+  });
+  codegenSaveAllocations.addEventListener('click', function() {
+    const option = '--save-allocations';
+    if (codegenCommand.value.match(new RegExp(`(?:^| )${option}(?:$| )`)) === null) {
+      codegenCommand.value += ` ${option}`;
+      codegenSaveAllocations.checked = true;
+    } else if (!codegenSaveAllocations.checked) {
+      codegenCommand.value = codegenCommand.value.replace(new RegExp(`(?:^| )${option}`), '');
+    }
     updateCodegen();
     applyUpdates();
   });


### PR DESCRIPTION
This commit adds checkbox in config editor which allows to automatically add or remove `--save-allocations` CLI codegen option in command line text field.

![image](https://user-images.githubusercontent.com/67966333/176052756-33a8b7f8-f82e-4be1-a69c-417210769a83.png)

Issue: #395 

ONE-vscode-DCO-1.0-Signed-off-by: Alexander Moiseev <a.moiseev@samsung.com>