### PR TITLE
[PartEditor] Use color by backend

### DIFF
--- a/media/PartEditor/index.js
+++ b/media/PartEditor/index.js
@@ -22,8 +22,9 @@ const vscode = acquireVsCodeApi();
  * @brief editor.Backend stores Backend records
  */
 editor.Backend = class {
-  constructor(name) {
+  constructor(name, color) {
     this.name = name;
+    this.color = color;
   }
 };
 
@@ -83,6 +84,7 @@ editor.Editor = class {
     this.document.getElementById('circle-be').addEventListener('change', () => {
       this.updateDefaultCheckbox();
       this.updateBackend();
+      this.updateBeComboColor();
     });
 
     // change 'default' backend to current backend of combobox
@@ -141,31 +143,43 @@ editor.Editor = class {
     vscode.postMessage({command: 'updateBackend', backend: beName});
   }
 
+  updateBeComboColor() {
+    let becombobox = this.document.getElementById('circle-be');
+    let idx = becombobox.selectedIndex;
+    let beCode = becombobox.options[idx].value;
+    let color = this.backends[beCode].color;
+    becombobox.style = 'color:' + color;
+  }
+
   /**
    * @brief fill 'circle-be' combobox with backends
    */
   handleResultBackends(message) {
     const backendNames = message.backends.split(/\r?\n/);
+    const backendColors = message.colors.split(/\r?\n/);
 
     // NOTE idx 0 is default which we do not add to the list
-    this.backends.push(new editor.Backend(backendNames[0]));
+    this.backends.push(new editor.Backend(backendNames[0], backendColors[0]));
 
     // initial fill op backend listbox
     const listbox = this.document.getElementById('circle-be');
     for (let idx = 1; idx < backendNames.length; idx++) {
       const backend = backendNames[idx];
+      const becolor = backendColors[idx];
       // filter out empty string
       if (backend.length > 0) {
         let opt = this.document.createElement('option');
         opt.text = `(${idx}) ` + backend;
         opt.value = idx;
+        opt.style = 'color:' + becolor;
         listbox.options.add(opt);
 
-        this.backends.push(new editor.Backend(backend));
+        this.backends.push(new editor.Backend(backend, becolor));
         this.beToCode[backend] = idx;
       }
     };
 
+    this.updateBeComboColor();
     this.requestOpNames();
   }
 
@@ -244,6 +258,7 @@ editor.Editor = class {
         let idx = opt.value;
         opt.text = `(${beCode}) ` + this.operators[idx].name;
         this.operators[idx].becode = beCode;
+        opt.style = 'color:' + this.backends[beCode].color;
       }
     }
   }
@@ -299,6 +314,7 @@ editor.Editor = class {
       let idx = opt.value;
       let beCode = this.operators[idx].becode;
       opt.text = `(${beCode}) ` + this.operators[idx].name;
+      opt.style = 'color:' + this.backends[beCode].color;
     }
   }
 

--- a/src/PartEditor/PartEditor.ts
+++ b/src/PartEditor/PartEditor.ts
@@ -45,6 +45,7 @@ export class PartEditorProvider implements vscode.CustomTextEditorProvider, Part
   private _modelFileName: string;
   private _modelFolderPath: string;
   private _backEndNames: string[] = [];
+  private _backEndColors: string[] = [];
   private _backEndForGraph: string;
 
   public static register(context: vscode.ExtensionContext): vscode.Disposable {
@@ -135,6 +136,7 @@ export class PartEditorProvider implements vscode.CustomTextEditorProvider, Part
     // TODO revise to get from backend
     // item 0 is initial default backend
     this._backEndNames = ['CPU', 'CPU', 'ACL_CL', 'TRIX'];
+    this._backEndColors = ['#303030', '#808000', '#800000', '#008080'];
 
     webviewPanel.webview.options = this.getWebviewOptions(this._extensionUri),
     webviewPanel.webview.html = this.getHtmlForWebview(webviewPanel.webview);
@@ -174,11 +176,15 @@ export class PartEditorProvider implements vscode.CustomTextEditorProvider, Part
 
   private handleRequestBackends() {
     let backends = '';
+    let colors = '';
     this._backEndNames.forEach((item) => {
       backends = backends + item + '\n';
     });
+    this._backEndColors.forEach((item) => {
+      colors = colors + item + '\n';
+    });
     if (this._webview) {
-      this._webview.postMessage({command: 'resultBackends', backends: backends});
+      this._webview.postMessage({command: 'resultBackends', backends: backends, colors: colors});
     }
   }
 


### PR DESCRIPTION
This will revise partition editor view to show backend and nodes in
color by backend.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>