### PR TITLE
Hide unnecessary commands from command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -277,6 +277,30 @@
       ],
       "commandPalette": [
         {
+          "command": "one.backend.infer",
+          "when": "false"
+        },
+        {
+          "command": "one.device.register",
+          "when": "false"
+        },
+        {
+          "command": "one.editor.openCfg",
+          "when": "false"
+        },
+        {
+          "command": "one.editor.openCfgAsText",
+          "when": "false"
+        },
+        {
+          "command": "one.editor.openCfgWithLegacyEditor",
+          "when": "false"
+        },
+        {
+          "command": "one.editor.toggleCodelens",
+          "when": "false"
+        },
+        {
           "command": "one.explorer.refresh",
           "when": "false"
         },
@@ -305,11 +329,23 @@
           "when": "false"
         },
         {
+          "command": "one.project.import",
+          "when": "false"
+        },
+        {
           "command": "one.toolchain.uninstall",
           "when": "false"
         },
         {
           "command": "one.toolchain.runCfg",
+          "when": "false"
+        },
+        {
+          "command": "one.viewer.circleTracer",
+          "when": "false"
+        },
+        {
+          "command": "one.viewer.jsonTracer",
           "when": "false"
         }
       ]


### PR DESCRIPTION
This commit hides unnecessary commands from command palette.
The hidden commands may not need to exposed to end user since it
could make the user confused.

ONE-vscode-DCO-1.0-Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>

---

for: #839 

With this PR, the following commands will be remained. 

![image](https://user-images.githubusercontent.com/50489513/176067402-72553491-c4c8-4b7c-9a4b-0557b7427f19.png)
