### PR TITLE
Show debug log only when it runs in vscode debug mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,10 @@
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			],
-			"preLaunchTask": "${defaultBuildTask}"
+			"preLaunchTask": "${defaultBuildTask}",
+			"env": {
+				"VSCODE_DEBUG_MODE": "true"
+			}
 		},
 		{
 			"name": "Extension Tests",
@@ -29,7 +32,10 @@
 			"outFiles": [
 				"${workspaceFolder}/out/Tests/**/*.js"
 			],
-			"preLaunchTask": "${defaultBuildTask}"
+			"preLaunchTask": "${defaultBuildTask}",
+			"env": {
+				"VSCODE_DEBUG_MODE": "true"
+			}
 		}
 	]
 }

--- a/src/Utils/Logger.ts
+++ b/src/Utils/Logger.ts
@@ -18,6 +18,8 @@ import * as vscode from 'vscode';
 
 type MsgList = (number|boolean|string|object)[];
 
+const isDebugMode = process.env.VSCODE_DEBUG_MODE === 'true';
+
 export class Logger {
   static outputChannel = vscode.window.createOutputChannel('ONE-VSCode');
   static firstFocus: boolean;
@@ -75,8 +77,10 @@ export class Logger {
    * @brief Print log with prefix '[time][tag][severity]' where severity = 'debug'
    */
   public static debug(tag: string, ...msgs: MsgList) {
-    const severity = 'debug';
-    Logger.log(severity, tag, ...msgs);
+    if (isDebugMode) {
+      const severity = 'debug';
+      Logger.log(severity, tag, ...msgs);
+    }
   }
 
   /**


### PR DESCRIPTION
This shows debug log only when it runs in vscode debug mode.
When ONE-vscode is packaged into vsix, debug log won't be shown.

For https://github.com/Samsung/ONE-vscode/issues/870#issuecomment-1168453781

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>