### PR TITLE
[workflow] Update Release note file position

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -236,7 +236,7 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.tag }}
           release_name: Release ${{ github.event.inputs.tag }}
-          body_path: ./release_notes.md
+          body_path: ./infra/release/release_note.md
           draft: ${{ github.event.inputs.draft }}
           prerelease: ${{ github.event.inputs.prerelease }}
       - name: Upload artifact


### PR DESCRIPTION
This commit will change release note file position to `infra/release/release_note.md`.

ONE-vscode-DCO-1.0-Signed-off-by: struss <rrstrous@nate.com>