### PR TITLE
[CircleGraph] clang format off of get class

### DIFF
--- a/media/CircleGraph/view.js
+++ b/media/CircleGraph/view.js
@@ -1230,10 +1230,11 @@ view.Node = class extends grapher.Node {
         this._add(this.value);
     }
 
-    get class
-    () {
+    // clang-format off
+    get class() {
         return 'graph-node';
     }
+    // clang-format on
 
     get inputs() {
         return this.value.inputs;


### PR DESCRIPTION
This will disable clang format for class method getter.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>