### PR TITLE
[OneExplorer] Add run icon inline

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,8 +118,9 @@
       },
       {
         "command": "one.explorer.runCfg",
-        "title": "Run",
-        "category": "ONE"
+        "title": "Run with the toolchain",
+        "category": "ONE",
+        "icon": "$(play)"
       },
       {
         "command": "one.explorer.rename",
@@ -223,6 +224,11 @@
           "command": "one.explorer.runCfg",
           "when": "view == OneExplorerView && viewItem == config",
           "group": "navigation"
+        },
+        {
+          "command": "one.explorer.runCfg",
+          "when": "view == OneExplorerView && viewItem == config",
+          "group": "inline"
         },
         {
           "command": "one.explorer.rename",


### PR DESCRIPTION
This commit adds run icon for each `cfg` inline.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>