### PR TITLE
Hide `build` from command palette option

### DIFF
--- a/package.json
+++ b/package.json
@@ -314,6 +314,10 @@
           "when": "false"
         },
         {
+          "command": "one.project.build",
+          "when": "false"
+        },
+        {
           "command": "one.project.import",
           "when": "false"
         },


### PR DESCRIPTION
This commit hides `build` command from command palette option.

ONE-vscode-DCO-1.0-Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>

---

For #839 

After this PR, following commands are left in command palette.

![image](https://user-images.githubusercontent.com/50489513/176796842-3479e060-7d8d-4362-8be6-96aa8a770728.png)
