### PR TITLE
[PartEditor] Revise update without backend

### DIFF
--- a/src/PartEditor/PartEditor.ts
+++ b/src/PartEditor/PartEditor.ts
@@ -143,8 +143,7 @@ class PartEditor implements PartGraphEvent {
       this._webview.postMessage({command: 'updatePartition', part: content});
 
       vscode.commands.executeCommand(
-          PartGraphSelPanel.cmdUpdate, this._document.fileName, this._id, this._document.getText(),
-          this._backEndForGraph);
+          PartGraphSelPanel.cmdUpdate, this._document.fileName, this._id, this._document.getText());
     }
   }
 

--- a/src/PartEditor/PartGraphSelector.ts
+++ b/src/PartEditor/PartGraphSelector.ts
@@ -35,19 +35,17 @@ export class PartGraphSelPanel extends CircleGraphCtrl implements CircleGraphEve
 
   private _panel: vscode.WebviewPanel;
   private _disposables: vscode.Disposable[] = [];
-  private _documentPath: string;     // part file path
-  private _ownerId: number;          // id of owner
-  private _documentText: string;     // part document
-  private _modelPath: string;        // circle file path
-  private _backendFromEdit: string;  // current backend for editing
+  private _documentPath: string;  // part file path
+  private _ownerId: number;       // id of owner
+  private _documentText: string;  // part document
+  private _modelPath: string;     // circle file path
   private _partEventHandler: PartGraphEvent|undefined;
 
   public static register(context: vscode.ExtensionContext): vscode.Disposable {
     // TODO add more commands
     let disposableCmdUpdate = vscode.commands.registerCommand(
-        PartGraphSelPanel.cmdUpdate,
-        (filePath: string, id: number, docText: string, backend: string) => {
-          PartGraphSelPanel.updateByOwner(context.extensionUri, filePath, id, docText, backend);
+        PartGraphSelPanel.cmdUpdate, (filePath: string, id: number, docText: string) => {
+          PartGraphSelPanel.updateByOwner(context.extensionUri, filePath, id, docText);
         });
     context.subscriptions.push(disposableCmdUpdate);
 
@@ -108,11 +106,10 @@ export class PartGraphSelPanel extends CircleGraphCtrl implements CircleGraphEve
    * @brief called when owner has changed the document or received document has changed
    */
   public static updateByOwner(
-      extensionUri: vscode.Uri, docPath: string, id: number, docText: string, backend: string) {
+      extensionUri: vscode.Uri, docPath: string, id: number, docText: string) {
     let selPanel = PartGraphSelPanel.findSelPanel(docPath, id);
     if (selPanel) {
       selPanel._documentText = docText;
-      selPanel._backendFromEdit = backend;
       if (selPanel.isReady()) {
         selPanel.onFinishLoadModel();
       }
@@ -142,7 +139,6 @@ export class PartGraphSelPanel extends CircleGraphCtrl implements CircleGraphEve
     this._ownerId = id;
     this._documentText = docText;
     this._modelPath = fileBase + '.circle';
-    this._backendFromEdit = '';
     this._partEventHandler = handler;
 
     // Listen for when the panel is disposed


### PR DESCRIPTION
This will revise update from PartEditor to PartGraphSelector to remove
backend as it is not used anymore.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>