### PR TITLE
[PartEditor] Do not check _document

### DIFF
--- a/src/PartEditor/PartEditor.ts
+++ b/src/PartEditor/PartEditor.ts
@@ -81,10 +81,7 @@ class PartEditor implements PartGraphEvent {
     });
 
     this._panel.onDidDispose(() => {
-      if (this._document) {
-        vscode.commands.executeCommand(
-            PartGraphSelPanel.cmdClose, this._document.fileName, this._id);
-      }
+      vscode.commands.executeCommand(PartGraphSelPanel.cmdClose, this._document.fileName, this._id);
 
       if (this._eventHandler) {
         this._eventHandler.onEditorDispose(this);


### PR DESCRIPTION
_document is now always valid object so there is no need to check.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>