### PR TITLE
[CircleGraph] Revise setSelection graph traverse

### DIFF
--- a/media/CircleGraph/view.js
+++ b/media/CircleGraph/view.js
@@ -586,7 +586,8 @@ view.View = class {
             const names = selection.names;
             let scrollToSelects = [];  // elements to make visible by scroll to
 
-            this._graph.nodes.forEach((node) => {
+            for (const nodeId of this._graph.nodes.keys()) {
+                const node = this._graph.node(nodeId);
                 if (node.label.value._outputs) {
                     let found = false;
                     node.label.value._outputs.forEach((output) => {
@@ -608,7 +609,7 @@ view.View = class {
                         }
                     });
                 }
-            });
+            }
             if (this._scrollToSelected) {
                 // make elements to be visible
                 this.scrollToSelection(scrollToSelects);


### PR DESCRIPTION
This will revise setSelection method graph traverse to use nodes.keys()
for using forEach as this method is used in existing codes.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>