### PR TITLE
[ToolRunner] Use default value instead of undefined

### DIFF
--- a/src/Project/ToolRunner.ts
+++ b/src/Project/ToolRunner.ts
@@ -157,7 +157,8 @@ export class ToolRunner {
     return oneccRealPath;
   }
 
-  public getRunner(name: string, tool: string, toolargs: ToolArgs, path: string, root?: boolean) {
+  public getRunner(
+      name: string, tool: string, toolargs: ToolArgs, path: string, root: boolean = false) {
     if (this.isRunning()) {
       const msg = `Error: Running: ${name}. Process is already running.`;
       Logger.error(this.tag, msg);
@@ -168,7 +169,7 @@ export class ToolRunner {
 
     return new Promise<SuccessResult>((resolve, reject) => {
       Logger.info(this.tag, 'Running: ' + name);
-      if (root) {
+      if (root === true) {
         // NOTE
         // To run the root command job, it must requires a password in `process.env.userp`
         // environment.


### PR DESCRIPTION
If `boolean` parameter is `undefined`, it can be interpreted as `false`.
Let's use default value instead of `undefined`.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>