### PR TITLE
[ToolRunner] Use Promise.prototype.catch instead of try-catch

### DIFF
--- a/src/Tests/Project/ToolRunner.test.ts
+++ b/src/Tests/Project/ToolRunner.test.ts
@@ -104,12 +104,10 @@ suite('Project', function() {
         for (let i = 0; i < simultaneousTrials; i++) {
           let args = new ToolArgs();
           args.push('1');  // 1 sec
-          try {
-            toolRunner.getRunner('sleep', 'sleep', args, '.');
-          } catch (err) {
-            // cannot make process
+          const runner = toolRunner.getRunner('sleep', 'sleep', args, '.');
+          runner.then((val: SuccessResult) => {}).catch(exitcode => {
             errCount++;
-          }
+          });
         }
 
         assert.equal(errCount, errorAmongTrials);


### PR DESCRIPTION
To correctly test `Promise`, we should use `await` or `Promise.prototype.*`.
However, since other testcases are already using `Promise.prototype.*`,
let's use it.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>