### PR TITLE
[Toolchain] Change toolchain workspace as `homedir`

### DIFF
--- a/src/Toolchain/ToolchainEnv.ts
+++ b/src/Toolchain/ToolchainEnv.ts
@@ -33,7 +33,7 @@ import {showPasswordQuickInput} from '../View/PasswordQuickInput';
 class Env implements BuilderJob {
   logTag = 'Env';
   workFlow: WorkFlow;  // our build WorkFlow
-  currentWorkspace: string = '';
+  workingDirectory: string = '';
   isPrepared: boolean = false;
 
   constructor() {
@@ -64,18 +64,6 @@ class Env implements BuilderJob {
       throw Error('Env is not yet prepared');
     }
 
-    try {
-      this.currentWorkspace = helpers.obtainWorkspaceRoot();
-    } catch (e: unknown) {
-      let errmsg = 'Failed to obtain workspace root';
-      if (e instanceof Error) {
-        errmsg = e.message;
-      }
-      // TODO add more type for e if changed in obtainWorkspaceRoot
-      Balloon.error(errmsg);
-      return;
-    }
-
     const rootJobs = this.workFlow.jobs.filter(j => j.root === true);
     if (rootJobs.length > 0) {
       Logger.info(this.logTag, 'Showing password prompt');
@@ -86,10 +74,10 @@ class Env implements BuilderJob {
         }
         Logger.info(this.logTag, 'Got password response');
         process.env.userp = password;
-        this.workFlow.start(this.currentWorkspace);
+        this.workFlow.start(this.workingDirectory);
       });
     } else {
-      this.workFlow.start(this.currentWorkspace);
+      this.workFlow.start(this.workingDirectory);
     }
   }
 }
@@ -101,6 +89,10 @@ class ToolchainEnv extends Env {
   constructor(compiler: Compiler) {
     super();
     this.compiler = compiler;
+    // Jobs which are triggered by toolchainEnv are independent from
+    // working directory. It's temporarily set as home directory.
+    // TODO: Revise workflow or job to be able to set cwd as option
+    this.workingDirectory = require('os').homedir();
     this.init();
   }
 


### PR DESCRIPTION
This commit changes toolchain workspace as `hoemdir`. Since `toolchain` related
jobs are independent from vscode-workspace, it's able to set the command's workspace
as user `homedir`.

ONE-vscode-DCO-1.0-Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>

---

for: #950 