### PR TITLE
Show text editor when cfg file is clicked in vscode explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
             "filenamePattern": "*.cfg"
           }
         ],
-        "priority": "default"
+        "priority": "option"
       },
       {
         "viewType": "onevscode.mondrianViewer",


### PR DESCRIPTION
This commit shows text editor when cfg file is clicked in vscode explorer.

(In ONE explorer, our GUI editor is shown.)

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>