### PR TITLE
[PartEditor] Reset Operators listbox before fill

### DIFF
--- a/media/PartEditor/index.js
+++ b/media/PartEditor/index.js
@@ -218,6 +218,8 @@ editor.Editor = class {
 
     // initial fill operators listbox with name and becode as 0
     const listbox = this.document.getElementById('circle-nodes');
+
+    listbox.options.length = 0;
     for (let idx = 0; idx < itemOpNames.length; idx++) {
       if (itemOpNames[idx].length > 0) {
         const codename = itemOpNames[idx].split(',');


### PR DESCRIPTION
This will reset Operators listbox before filling.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>