### PR TITLE
[CI] Disable PR test for `PR/No Test` label

### DIFF
--- a/.github/workflows/check-commit.yml
+++ b/.github/workflows/check-commit.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   check-signed-off-by:
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'PR/NO TEST') }}
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -30,6 +32,8 @@ jobs:
           exit 1
 
   check-no-body:
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'PR/NO TEST') }}
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-copyright.yml
+++ b/.github/workflows/check-copyright.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   check-format:
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'PR/NO TEST') }}
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   license_verification:
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'PR/NO TEST') }}
+
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/check-pr-format.yml
+++ b/.github/workflows/check-pr-format.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   check-format:
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'PR/NO TEST') }}
+
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/check-pr-test.yml
+++ b/.github/workflows/check-pr-test.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   check-test:
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'PR/NO TEST') }}
+
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/check-pr-tsc.yml
+++ b/.github/workflows/check-pr-tsc.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   check-compile:
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'PR/NO TEST') }}
+
     runs-on: ubuntu-20.04
 
     steps:


### PR DESCRIPTION
This commit introduces a new feature to disable pr test if `PR/No test` label is set.

ONE-vscode-DCO-1.0-Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>

---

for: #958 

You can find how theses actions work through #963 (the pr will be closed and the `no_test` branch will be removed after this pr has been merged).