### PR TITLE
[DeviceAPI] revisit Executor to make this use on Device API

### DIFF
--- a/src/Backend/Executor.ts
+++ b/src/Backend/Executor.ts
@@ -15,9 +15,13 @@
  */
 
 import {Command} from './Command';
+import { DeviceSpec } from './Spec';
 import {Toolchains} from './Toolchain';
 
 interface Executor {
+  // Executor unique name
+  name(): string;
+
   // exetensions of executable files
   getExecutableExt(): string[];
 
@@ -26,10 +30,17 @@ interface Executor {
 
   // TODO: use cfg path to run onecc after one-infer landed
   runInference(_modelPath: string, _options?: string[]): Command;
+  
+  // return deviceSpec that required for this Executor to run
+  require(): DeviceSpec;
 }
 
 // General excutor uses onecc so default jobs can be used
 class ExecutorBase implements Executor {
+  name(): string {
+    throw new Error('Name are not determinded.');
+  }
+
   // exetensions of executable files
   getExecutableExt(): string[] {
     throw Error('Invalid toolchains call');
@@ -41,6 +52,10 @@ class ExecutorBase implements Executor {
 
   runInference(_modelPath: string, _options?: string[]): Command {
     throw Error('Invalid inference call');
+  }
+
+  require(): DeviceSpec {
+    throw new Error('Invalid require Spec call.');
   }
 };
 

--- a/src/Backend/Executor.ts
+++ b/src/Backend/Executor.ts
@@ -31,14 +31,14 @@ interface Executor {
   // TODO: use cfg path to run onecc after one-infer landed
   runInference(_modelPath: string, _options?: string[]): Command;
 
-  // return deviceSpec that required for this Executor to run
+  // return deviceSpec required for this Executor to run
   require(): DeviceSpec;
 }
 
 // General excutor uses onecc so default jobs can be used
 class ExecutorBase implements Executor {
   name(): string {
-    throw new Error('Name are not determinded.');
+    throw new Error('Name is not determined.');
   }
 
   // exetensions of executable files
@@ -55,7 +55,7 @@ class ExecutorBase implements Executor {
   }
 
   require(): DeviceSpec {
-    throw new Error('Invalid require Spec call.');
+    throw new Error('Invalid DeviceSpec call.');
   }
 };
 

--- a/src/Backend/Executor.ts
+++ b/src/Backend/Executor.ts
@@ -55,7 +55,7 @@ class ExecutorBase implements Executor {
   }
 
   require(): DeviceSpec {
-    throw new Error('Invalid DeviceSpec call.');
+    throw new Error('NYI: need to define DeviceSpec for Executor.');
   }
 };
 

--- a/src/Backend/Executor.ts
+++ b/src/Backend/Executor.ts
@@ -15,7 +15,7 @@
  */
 
 import {Command} from './Command';
-import { DeviceSpec } from './Spec';
+import {DeviceSpec} from './Spec';
 import {Toolchains} from './Toolchain';
 
 interface Executor {
@@ -30,7 +30,7 @@ interface Executor {
 
   // TODO: use cfg path to run onecc after one-infer landed
   runInference(_modelPath: string, _options?: string[]): Command;
-  
+
   // return deviceSpec that required for this Executor to run
   require(): DeviceSpec;
 }

--- a/src/Tests/Execute/InferenceQuickInput.test.ts
+++ b/src/Tests/Execute/InferenceQuickInput.test.ts
@@ -22,6 +22,7 @@ import {backendRegistrationApi, globalBackendMap} from '../../Backend/Backend';
 import {Command} from '../../Backend/Command';
 import {Compiler, CompilerBase} from '../../Backend/Compiler';
 import {Executor, ExecutorBase} from '../../Backend/Executor';
+import { DeviceSpec } from '../../Backend/Spec';
 import {Toolchains} from '../../Backend/Toolchain';
 import {InferenceQuickInput} from '../../Execute/InferenceQuickInput';
 import {gToolchainEnvMap} from '../../Toolchain/ToolchainEnv';
@@ -39,6 +40,9 @@ class BackendMockup implements Backend {
 
   executor(): Executor|undefined {
     class MockupExecutor implements Executor {
+      name(): string{
+        return backendName;
+      }
       getExecutableExt(): string[] {
         return exts;
       }
@@ -47,6 +51,9 @@ class BackendMockup implements Backend {
       }
       runInference(_modelPath: string, _options?: string[]|undefined): Command {
         throw new Error('Method not implemented.');
+      }
+      require(): DeviceSpec {
+        return new DeviceSpec('MockupHW','MockSW',undefined);
       }
     };
     return new MockupExecutor();

--- a/src/Tests/Execute/InferenceQuickInput.test.ts
+++ b/src/Tests/Execute/InferenceQuickInput.test.ts
@@ -22,7 +22,7 @@ import {backendRegistrationApi, globalBackendMap} from '../../Backend/Backend';
 import {Command} from '../../Backend/Command';
 import {Compiler, CompilerBase} from '../../Backend/Compiler';
 import {Executor, ExecutorBase} from '../../Backend/Executor';
-import { DeviceSpec } from '../../Backend/Spec';
+import {DeviceSpec} from '../../Backend/Spec';
 import {Toolchains} from '../../Backend/Toolchain';
 import {InferenceQuickInput} from '../../Execute/InferenceQuickInput';
 import {gToolchainEnvMap} from '../../Toolchain/ToolchainEnv';
@@ -40,7 +40,7 @@ class BackendMockup implements Backend {
 
   executor(): Executor|undefined {
     class MockupExecutor implements Executor {
-      name(): string{
+      name(): string {
         return backendName;
       }
       getExecutableExt(): string[] {
@@ -53,7 +53,7 @@ class BackendMockup implements Backend {
         throw new Error('Method not implemented.');
       }
       require(): DeviceSpec {
-        return new DeviceSpec('MockupHW','MockSW',undefined);
+        return new DeviceSpec('MockupHW', 'MockSW', undefined);
       }
     };
     return new MockupExecutor();

--- a/src/Tests/Execute/InferenceRunner.test.ts
+++ b/src/Tests/Execute/InferenceRunner.test.ts
@@ -22,7 +22,7 @@ import {backendRegistrationApi, globalBackendMap} from '../../Backend/Backend';
 import {Command} from '../../Backend/Command';
 import {Compiler, CompilerBase} from '../../Backend/Compiler';
 import {Executor, ExecutorBase} from '../../Backend/Executor';
-import { DeviceSpec } from '../../Backend/Spec';
+import {DeviceSpec} from '../../Backend/Spec';
 import {Toolchains} from '../../Backend/Toolchain';
 import {InferenceRunner} from '../../Execute/InferenceRunner';
 import {gToolchainEnvMap} from '../../Toolchain/ToolchainEnv';
@@ -40,7 +40,7 @@ class BackendMockup implements Backend {
 
   executor(): Executor|undefined {
     class MockupExecutor implements Executor {
-      name(): string{
+      name(): string {
         return backendName;
       }
       getExecutableExt(): string[] {
@@ -55,7 +55,7 @@ class BackendMockup implements Backend {
         return cmd;
       }
       require(): DeviceSpec {
-        return new DeviceSpec('MockupHW','MockSW',undefined);
+        return new DeviceSpec('MockupHW', 'MockSW', undefined);
       }
     };
     return new MockupExecutor();

--- a/src/Tests/Execute/InferenceRunner.test.ts
+++ b/src/Tests/Execute/InferenceRunner.test.ts
@@ -22,6 +22,7 @@ import {backendRegistrationApi, globalBackendMap} from '../../Backend/Backend';
 import {Command} from '../../Backend/Command';
 import {Compiler, CompilerBase} from '../../Backend/Compiler';
 import {Executor, ExecutorBase} from '../../Backend/Executor';
+import { DeviceSpec } from '../../Backend/Spec';
 import {Toolchains} from '../../Backend/Toolchain';
 import {InferenceRunner} from '../../Execute/InferenceRunner';
 import {gToolchainEnvMap} from '../../Toolchain/ToolchainEnv';
@@ -39,6 +40,9 @@ class BackendMockup implements Backend {
 
   executor(): Executor|undefined {
     class MockupExecutor implements Executor {
+      name(): string{
+        return backendName;
+      }
       getExecutableExt(): string[] {
         throw new Error('Method not implemented.');
       }
@@ -49,6 +53,9 @@ class BackendMockup implements Backend {
         let args = [_modelPath].concat(_options as string[]);
         let cmd = new Command(inferenceRunner, args);
         return cmd;
+      }
+      require(): DeviceSpec {
+        return new DeviceSpec('MockupHW','MockSW',undefined);
       }
     };
     return new MockupExecutor();


### PR DESCRIPTION
This commit will revisit `Executor` for some reason

about `name()`: if we add None Backend Executor, we need to add Executor name on this.
                          otherwise, follow Backend Name.
about `require()`: to use on `satisfied()` on Device API.

ONE-vscode-DCO-1.0-Signed-off-by: struss <rrstrous@nate.com>