### PR TITLE
[OneExplorer] Handle no workspace opened case

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -158,7 +158,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
 
   private tree: Node|undefined;
 
-  constructor(private workspaceRoot: vscode.Uri) {
+  constructor(private workspaceRoot: vscode.Uri|undefined) {
     const fileWatchersEvents =
         [this.fileWatcher.onDidCreate, this.fileWatcher.onDidChange, this.fileWatcher.onDidDelete];
 
@@ -524,8 +524,7 @@ export function initOneExplorer(context: vscode.ExtensionContext) {
     }
   }
 
-  // NOTE: Fix `obtainWorksapceRoot` if non-null assertion is false
-  const oneTreeDataProvider = new OneTreeDataProvider(workspaceRoot!);
+  const oneTreeDataProvider = new OneTreeDataProvider(workspaceRoot);
 
   let treeView: vscode.TreeView<OneNode|undefined>|undefined = vscode.window.createTreeView(
       'OneExplorerView',

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -20,6 +20,7 @@ import {TextEncoder} from 'util';
 import * as vscode from 'vscode';
 
 import {CfgEditorPanel} from '../CfgEditor/CfgEditorPanel';
+import {Balloon} from '../Utils/Balloon';
 import {obtainWorkspaceRoot, RealPath} from '../Utils/Helpers';
 import {Logger} from '../Utils/Logger';
 
@@ -518,9 +519,14 @@ export function initOneExplorer(context: vscode.ExtensionContext) {
     workspaceRoot = vscode.Uri.file(obtainWorkspaceRoot());
   } catch (e: unknown) {
     if (e instanceof Error) {
-      Logger.error('OneExplorer', e.message);
+      if (e.message === 'Need workspace') {
+        Logger.info('OneExplorer', e.message);
+      } else {
+        Logger.error('OneExplorer', e.message);
+        Balloon.error('Something goes wrong while setting workspace.', true);
+      }
     } else {
-      throw e;
+      Logger.error('OneExplorer', 'Unknown error has been thrown.');
     }
   }
 

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -344,7 +344,6 @@ input_path=${modelName}.${extName}
 
   getChildren(element?: OneNode): OneNode[]|Thenable<OneNode[]> {
     if (!this.workspaceRoot) {
-      vscode.window.showInformationMessage('Cannot find workspace root');
       return Promise.resolve([]);
     }
 
@@ -514,7 +513,17 @@ input_path=${modelName}.${extName}
 
 export function initOneExplorer(context: vscode.ExtensionContext) {
   // TODO Support multi-root workspace
-  let workspaceRoot: vscode.Uri = vscode.Uri.file(obtainWorkspaceRoot());
+  let workspaceRoot: vscode.Uri|undefined = undefined;
+  try {
+    workspaceRoot = vscode.Uri.file(obtainWorkspaceRoot());
+  } catch (e: unknown) {
+    if (e instanceof Error) {
+      Logger.error('OneExplorer', e.message);
+    } else {
+      throw e;
+    }
+  }
+
   // NOTE: Fix `obtainWorksapceRoot` if non-null assertion is false
   const oneTreeDataProvider = new OneTreeDataProvider(workspaceRoot!);
 


### PR DESCRIPTION
This commit modifies OneExplorer to handle no workspace opened cases.
To introduce welcome view, showing pop-up message to user should be deprecated.

ONE-vscode-DCO-1.0-Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>

---

draft: #953 