### PR TITLE
[Backend] Add registerExecutor API on backend register

### DIFF
--- a/src/Backend/Backend.ts
+++ b/src/Backend/Backend.ts
@@ -35,7 +35,7 @@ let globalExecutorArray: Executor[] = [];
 
 function backendRegistrationApi() {
   const logTag = 'backendRegistrationApi';
-  return {
+  let registrationAPI = {
     registerBackend(backend: Backend) {
       const backendName = backend.name();
       assert(backendName.length > 0);
@@ -55,6 +55,8 @@ function backendRegistrationApi() {
       Logger.info(logTag, 'Executor', executor.name(), 'was registered into ONE-vscode.');
     }
   };
+
+  return registrationAPI;
 }
 
 export {globalBackendMap, globalExecutorArray, backendRegistrationApi};

--- a/src/Backend/Backend.ts
+++ b/src/Backend/Backend.ts
@@ -18,6 +18,7 @@ const assert = require('assert');
 import {Backend} from './API';
 import {gToolchainEnvMap, ToolchainEnv} from '../Toolchain/ToolchainEnv';
 import {Logger} from '../Utils/Logger';
+import {Executor} from './Executor';
 
 /**
  * Interface of backend map
@@ -29,10 +30,12 @@ interface BackendMap {
 
 // List of backend extensions registered
 let globalBackendMap: BackendMap = {};
+// List of Executor extensions registered
+let globalExecutorArray: Executor[] = [];
 
 function backendRegistrationApi() {
   const logTag = 'backendRegistrationApi';
-  let registrationAPI = {
+  return {
     registerBackend(backend: Backend) {
       const backendName = backend.name();
       assert(backendName.length > 0);
@@ -41,11 +44,17 @@ function backendRegistrationApi() {
       if (compiler) {
         gToolchainEnvMap[backend.name()] = new ToolchainEnv(compiler);
       }
+      const executor = backend.executor();
+      if (executor) {
+        globalExecutorArray.push(executor);
+      }
       Logger.info(logTag, 'Backend', backendName, 'was registered into ONE-vscode.');
+    },
+    registerExecutor(executor: Executor) {
+      globalExecutorArray.push(executor);
+      Logger.info(logTag, 'Executor', executor.name(), 'was registered into ONE-vscode.');
     }
   };
-
-  return registrationAPI;
 }
 
-export {globalBackendMap, backendRegistrationApi};
+export {globalBackendMap, globalExecutorArray, backendRegistrationApi};

--- a/src/Tests/Backend/Backend.test.ts
+++ b/src/Tests/Backend/Backend.test.ts
@@ -50,6 +50,7 @@ suite('Backend', function() {
       let registrationAPI = backendRegistrationApi();
 
       assert.strictEqual(Object.entries(globalBackendMap).length, 0);
+      assert.strictEqual(globalExecutorArray.length, 0);
 
       let backend = new BackendMockup();
       registrationAPI.registerBackend(backend);
@@ -60,6 +61,10 @@ suite('Backend', function() {
       for (const [key, value] of entries) {
         assert.strictEqual(key, backendName);
         assert.deepStrictEqual(value, backend);
+      }
+      assert.strictEqual(globalExecutorArray.length, 1);
+      for (const executor of globalExecutorArray) {
+        assert.deepStrictEqual(executor, backend.executor());
       }
     });
     test('registers a executor', function() {
@@ -84,6 +89,8 @@ suite('Backend', function() {
     if (gToolchainEnvMap[backendName] !== undefined) {
       delete gToolchainEnvMap[backendName];
     }
-    globalExecutorArray.length = 0;
+    while (globalExecutorArray.length > 0) {
+      globalExecutorArray.pop();
+    }
   });
 });

--- a/src/Tests/Backend/Backend.test.ts
+++ b/src/Tests/Backend/Backend.test.ts
@@ -17,7 +17,7 @@
 import {assert} from 'chai';
 
 import {Backend} from '../../Backend/API';
-import {backendRegistrationApi, globalBackendMap} from '../../Backend/Backend';
+import {backendRegistrationApi, globalBackendMap, globalExecutorArray} from '../../Backend/Backend';
 import {Compiler, CompilerBase} from '../../Backend/Compiler';
 import {Executor, ExecutorBase} from '../../Backend/Executor';
 import {gToolchainEnvMap} from '../../Toolchain/ToolchainEnv';
@@ -35,7 +35,14 @@ class BackendMockup implements Backend {
   executor(): Executor|undefined {
     return new ExecutorBase();
   }
-};
+}
+
+const executorName = 'Mockup';
+class ExecutorMockup extends ExecutorBase {
+  name(): string {
+    return executorName;
+  }
+}
 
 suite('Backend', function() {
   suite('backendRegistrationApi', function() {
@@ -55,6 +62,19 @@ suite('Backend', function() {
         assert.deepStrictEqual(value, backend);
       }
     });
+    test('registers a executor', function() {
+      let registrationAPI = backendRegistrationApi();
+
+      assert.strictEqual(globalExecutorArray.length, 0);
+      let executorMockup = new ExecutorMockup();
+      registrationAPI.registerExecutor(executorMockup);
+
+      assert.strictEqual(globalExecutorArray.length, 1);
+
+      for (const executor of globalExecutorArray) {
+        assert.deepStrictEqual(executor, executorMockup);
+      }
+    });
   });
 
   teardown(function() {
@@ -64,5 +84,6 @@ suite('Backend', function() {
     if (gToolchainEnvMap[backendName] !== undefined) {
       delete gToolchainEnvMap[backendName];
     }
+    globalExecutorArray.length = 0;
   });
 });


### PR DESCRIPTION
This commit will add `registerExcutor` API on `backendRegistrationApi`.

`registerExecutor` API will use to register executor and use this on Device API.

ONE-vscode-DCO-1.0-Signed-off-by: struss <rrstrous@nate.com>