### PR TITLE
[OneExplorer] Rewrite ConfigObject 

### DIFF
--- a/src/OneExplorer/ConfigObject.ts
+++ b/src/OneExplorer/ConfigObject.ts
@@ -223,7 +223,7 @@ export class ConfigObj {
   }
 
   get getDerivedModels() {
-    return this.obj.baseModels;
+    return this.obj.derivedModels;
   }
 
   /**

--- a/src/OneExplorer/ConfigObject.ts
+++ b/src/OneExplorer/ConfigObject.ts
@@ -41,7 +41,7 @@ interface Artifact {
   /**
    * A full path in file system
    */
-  path?: string;
+  path: string;
 }
 
 /**
@@ -144,7 +144,7 @@ export class Locator {
 
 // TODO Move to backend side with some modification
 export class LocatorRunner {
-  private artifactLocators: {artifact: Artifact, locator: Locator}[] = [];
+  private artifactLocators: {artifactAttr: {type: string, ext: string}, locator: Locator}[] = [];
 
   /**
    * A helper function to grep a filename ends with 'ext' within the given 'content' string.
@@ -158,7 +158,7 @@ export class LocatorRunner {
     return fileNames;
   };
 
-  public register(artifactLocator: {artifact: Artifact, locator: Locator}) {
+  public register(artifactLocator: {artifactAttr: {type: string, ext: string}, locator: Locator}) {
     this.artifactLocators.push(artifactLocator);
   }
 
@@ -172,13 +172,11 @@ export class LocatorRunner {
     let artifacts: Artifact[] = [];
 
     // Get Artifacts with {type, ext, path}
-    this.artifactLocators.forEach(({artifact, locator}) => {
+    this.artifactLocators.forEach(({artifactAttr, locator}) => {
       let filePaths: string[] = locator.locate(iniObj, dir);
       filePaths.forEach(filePath => {
-        // Clone this.artifact
-        let newArtifact: Artifact = Object.assign({}, artifact);
-        newArtifact.path = filePath;
-        artifacts.push(newArtifact);
+        let artifact: Artifact = {type: artifactAttr.type, ext: artifactAttr.ext, path: filePath};
+        artifacts.push(artifact);
       });
     });
 
@@ -232,22 +230,22 @@ export class ConfigObj {
    * Returns only the baseModels which exists in file system
    */
   get getBaseModelsExists() {
-    return this.obj.baseModels.filter(artifact => RealPath.exists(artifact.path!));
+    return this.obj.baseModels.filter(artifact => RealPath.exists(artifact.path));
   }
 
   /**
    * Returns only the derivedModels which exists in file system
    */
   get getDerivedModelsExists() {
-    return this.obj.derivedModels.filter(artifact => RealPath.exists(artifact.path!));
+    return this.obj.derivedModels.filter(artifact => RealPath.exists(artifact.path));
   }
 
   /**
    * Return true if the `baseModelPath` is included in `baseModels`
    */
   public isChildOf(baseModelPath: string): boolean {
-    const found = this.obj.baseModels.map(artifact => artifact.path!)
-                      .find(path => RealPath.areEqual(baseModelPath, path!));
+    const found = this.obj.baseModels.map(artifact => artifact.path)
+                      .find(path => RealPath.areEqual(baseModelPath, path));
 
     return found ? true : false;
   }
@@ -315,17 +313,17 @@ export class ConfigObj {
     let locatorRunner = new LocatorRunner();
 
     locatorRunner.register({
-      artifact: {type: 'model', ext: '.tflite'},
+      artifactAttr: {type: 'model', ext: '.tflite'},
       locator: new Locator((value: string) => LocatorRunner.searchWithExt('.tflite', value))
     });
 
     locatorRunner.register({
-      artifact: {type: 'model', ext: '.pb'},
+      artifactAttr: {type: 'model', ext: '.pb'},
       locator: new Locator((value: string) => LocatorRunner.searchWithExt('.pb', value))
     });
 
     locatorRunner.register({
-      artifact: {type: 'model', ext: '.onnx'},
+      artifactAttr: {type: 'model', ext: '.onnx'},
       locator: new Locator((value: string) => LocatorRunner.searchWithExt('.onnx', value))
     });
 
@@ -358,17 +356,17 @@ export class ConfigObj {
     let locatorRunner = new LocatorRunner();
 
     locatorRunner.register({
-      artifact: {type: 'model', ext: '.circle'},
+      artifactAttr: {type: 'model', ext: '.circle'},
       locator: new Locator((value: string) => LocatorRunner.searchWithExt('.circle', value))
     });
 
     locatorRunner.register({
-      artifact: {type: 'model', ext: '.tvn'},
+      artifactAttr: {type: 'model', ext: '.tvn'},
       locator: new Locator((value: string) => LocatorRunner.searchWithExt('.tvn', value))
     });
 
     locatorRunner.register({
-      artifact: {type: 'log', ext: '.circle.log'},
+      artifactAttr: {type: 'log', ext: '.circle.log'},
       locator: new Locator((value: string) => {
         return LocatorRunner.searchWithExt('.circle', value)
             .map(filepath => filepath.replace('.circle', '.circle.log'));

--- a/src/OneExplorer/ConfigObject.ts
+++ b/src/OneExplorer/ConfigObject.ts
@@ -174,7 +174,7 @@ export class LocatorRunner {
     // Get Artifacts with {type, ext, path}
     this.artifactLocators.forEach(({artifact, locator}) => {
       let filePaths: string[] = locator.locate(iniObj, dir);
-      filePaths.map(filePath => {
+      filePaths.forEach(filePath => {
         // Clone this.artifact
         let newArtifact: Artifact = Object.assign({}, artifact);
         newArtifact.path = filePath;

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -470,31 +470,32 @@ input_path=${modelName}.${extName}
         readdirSyncRecursive(this.workspaceRoot!.fsPath).filter(val => val.endsWith('.cfg'));
 
     for (const conf of confs) {
-      const parsedObj = ConfigObj.parse(vscode.Uri.file(conf));
-      if (!parsedObj) {
+      const cfgObj = ConfigObj.createConfigObj(vscode.Uri.file(conf));
+
+      if (!cfgObj) {
         Logger.info('OneExplorer', `Failed to open file ${conf}`);
         continue;
       }
 
-      const {baseModels, derivedModels} = parsedObj;
-
-      for (const baseModel of baseModels) {
-        if (this.comparePath(baseModel.fsPath, baseModelNode.path)) {
-          const pairNode = new Node(NodeType.config, [], vscode.Uri.file(conf));
-          Logger.debug('OneExplorer', `DerivedModels : ${derivedModels}`);
-
-          derivedModels ?.forEach(derivedModel => {
-                           // Display only the existing node
-                           const realPath = RealPath.createRealPath(derivedModel.fsPath);
-                           if (realPath) {
-                             pairNode.childNodes.push(new Node(
-                                 NodeType.derivedModel, [], vscode.Uri.file(realPath.absPath)));
-                           }
-                         });
-
-          baseModelNode.childNodes.push(pairNode);
-        }
+      if (!cfgObj.isChildOf(baseModelNode.path)) {
+        continue;
       }
+
+      const {baseModels, derivedModels} = cfgObj.obj;
+
+      const pairNode = new Node(NodeType.config, [], vscode.Uri.file(conf));
+      Logger.debug('OneExplorer', `DerivedModels : ${derivedModels}`);
+
+      derivedModels ?.forEach(derivedModel => {
+                       // Display only the existing node
+                       const realPath = RealPath.createRealPath(derivedModel.path!);
+                       if (realPath) {
+                         pairNode.childNodes.push(new Node(
+                             NodeType.derivedModel, [], vscode.Uri.file(realPath.absPath)));
+                       }
+                     });
+
+      baseModelNode.childNodes.push(pairNode);
     }
   }
 }

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -15,7 +15,6 @@
  */
 
 import * as fs from 'fs';
-import * as ini from 'ini';
 import * as path from 'path';
 import {TextEncoder} from 'util';
 import * as vscode from 'vscode';
@@ -488,7 +487,7 @@ input_path=${modelName}.${extName}
 
       derivedModels ?.forEach(derivedModel => {
                        // Display only the existing node
-                       const realPath = RealPath.createRealPath(derivedModel.path!);
+                       const realPath = RealPath.createRealPath(derivedModel.path);
                        if (realPath) {
                          pairNode.childNodes.push(new Node(
                              NodeType.derivedModel, [], vscode.Uri.file(realPath.absPath)));

--- a/src/Tests/OneExplorer/ConfigObject.test.ts
+++ b/src/Tests/OneExplorer/ConfigObject.test.ts
@@ -130,7 +130,7 @@ input_path=${modelName}
           assert.strictEqual(configObj!.obj.baseModels.length, 1);
           assert.strictEqual(configObj!.obj.derivedModels.length, 0);
 
-          assert.strictEqual(configObj!.obj.baseModels[0].fsPath, modelPath);
+          assert.strictEqual(configObj!.obj.baseModels[0].path!, modelPath);
         }
       });
 
@@ -176,11 +176,11 @@ output_path=${derivedModelName2}
 
           assert.strictEqual(configObj!.obj.baseModels.length, 1);
 
-          assert.strictEqual(configObj!.obj.baseModels[0].fsPath, baseModelPath);
+          assert.strictEqual(configObj!.obj.baseModels[0].path!, baseModelPath);
 
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.fsPath)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
                             .includes(derivedModelPath1));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.fsPath)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
                             .includes(derivedModelPath2));
         }
       });
@@ -231,15 +231,15 @@ output_path=${derivedModelName2}
 
           assert.strictEqual(configObj!.obj.baseModels.length, 1);
 
-          assert.strictEqual(configObj!.obj.baseModels[0].fsPath, baseModelPath);
+          assert.strictEqual(configObj!.obj.baseModels[0].path!, baseModelPath);
 
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.fsPath)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
                             .includes(derivedModelPath1));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.fsPath)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
                             .includes(derivedModelPath2));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.fsPath)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
                             .includes(derivedModelPath3));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.fsPath)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
                             .includes(derivedModelPath4));
         }
       });
@@ -278,11 +278,11 @@ output_path=dummy/dummy/../..//${derivedModelName2}
         {
           assert.strictEqual(configObj!.obj.baseModels.length, 1);
 
-          assert.strictEqual(configObj!.obj.baseModels[0].fsPath, baseModelPath);
+          assert.strictEqual(configObj!.obj.baseModels[0].path!, baseModelPath);
 
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.fsPath)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
                             .includes(derivedModelPath1));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.fsPath)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
                             .includes(derivedModelPath2));
         }
       });
@@ -322,11 +322,11 @@ output_path=/dummy/dummy/../..//${derivedModelName2}
         {
           assert.strictEqual(configObj!.obj.baseModels.length, 1);
 
-          assert.notStrictEqual(configObj!.obj.baseModels[0].fsPath, baseModelPath);
+          assert.notStrictEqual(configObj!.obj.baseModels[0].path!, baseModelPath);
 
-          assert.isFalse(configObj!.obj.derivedModels.map(derivedModel => derivedModel.fsPath)
+          assert.isFalse(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
                              .includes(derivedModelPath1));
-          assert.isFalse(configObj!.obj.derivedModels.map(derivedModel => derivedModel.fsPath)
+          assert.isFalse(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
                              .includes(derivedModelPath2));
           ;
         }
@@ -369,12 +369,12 @@ output_path=/${derivedModelPath2}
           assert.strictEqual(configObj!.obj.baseModels.length, 1);
 
           assert.strictEqual(
-              configObj!.obj.baseModels[0].fsPath, baseModelPath,
-              configObj!.obj.baseModels[0].fsPath);
+              configObj!.obj.baseModels[0].path!, baseModelPath, configObj!.obj.baseModels[0].path!
+          );
 
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.fsPath)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
                             .includes(derivedModelPath1));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.fsPath)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
                             .includes(derivedModelPath2));
         }
       });

--- a/src/Tests/OneExplorer/ConfigObject.test.ts
+++ b/src/Tests/OneExplorer/ConfigObject.test.ts
@@ -130,7 +130,7 @@ input_path=${modelName}
           assert.strictEqual(configObj!.obj.baseModels.length, 1);
           assert.strictEqual(configObj!.obj.derivedModels.length, 0);
 
-          assert.strictEqual(configObj!.obj.baseModels[0].path!, modelPath);
+          assert.strictEqual(configObj!.obj.baseModels[0].path, modelPath);
         }
       });
 
@@ -176,11 +176,11 @@ output_path=${derivedModelName2}
 
           assert.strictEqual(configObj!.obj.baseModels.length, 1);
 
-          assert.strictEqual(configObj!.obj.baseModels[0].path!, baseModelPath);
+          assert.strictEqual(configObj!.obj.baseModels[0].path, baseModelPath);
 
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
                             .includes(derivedModelPath1));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
                             .includes(derivedModelPath2));
         }
       });
@@ -231,15 +231,15 @@ output_path=${derivedModelName2}
 
           assert.strictEqual(configObj!.obj.baseModels.length, 1);
 
-          assert.strictEqual(configObj!.obj.baseModels[0].path!, baseModelPath);
+          assert.strictEqual(configObj!.obj.baseModels[0].path, baseModelPath);
 
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
                             .includes(derivedModelPath1));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
                             .includes(derivedModelPath2));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
                             .includes(derivedModelPath3));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
                             .includes(derivedModelPath4));
         }
       });
@@ -278,11 +278,11 @@ output_path=dummy/dummy/../..//${derivedModelName2}
         {
           assert.strictEqual(configObj!.obj.baseModels.length, 1);
 
-          assert.strictEqual(configObj!.obj.baseModels[0].path!, baseModelPath);
+          assert.strictEqual(configObj!.obj.baseModels[0].path, baseModelPath);
 
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
                             .includes(derivedModelPath1));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
                             .includes(derivedModelPath2));
         }
       });
@@ -322,11 +322,11 @@ output_path=/dummy/dummy/../..//${derivedModelName2}
         {
           assert.strictEqual(configObj!.obj.baseModels.length, 1);
 
-          assert.notStrictEqual(configObj!.obj.baseModels[0].path!, baseModelPath);
+          assert.notStrictEqual(configObj!.obj.baseModels[0].path, baseModelPath);
 
-          assert.isFalse(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
+          assert.isFalse(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
                              .includes(derivedModelPath1));
-          assert.isFalse(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
+          assert.isFalse(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
                              .includes(derivedModelPath2));
           ;
         }
@@ -369,12 +369,11 @@ output_path=/${derivedModelPath2}
           assert.strictEqual(configObj!.obj.baseModels.length, 1);
 
           assert.strictEqual(
-              configObj!.obj.baseModels[0].path!, baseModelPath, configObj!.obj.baseModels[0].path!
-          );
+              configObj!.obj.baseModels[0].path, baseModelPath, configObj!.obj.baseModels[0].path);
 
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
                             .includes(derivedModelPath1));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path!)
+          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
                             .includes(derivedModelPath2));
         }
       });


### PR DESCRIPTION
This commit rewrite ConfigObject to..
(1) Return a list of Artifact instead of Uri
(2) Introduce getBase(Drived)ModelsExists function to filter existing artifacts
(3) Introduce isChildOf method and use it
(4) Remove redundant wrapper `parse` method and use `createObject`
(5) Pass string filepath instead of Uri as parameter of functions (parseDerivedModels, parseBaseModels)
(6) Replace map with forEach to remove unused variable

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>


---

#1012 must be merged first.

From #1011