### PR TITLE
[CircleGraph] Use consistent return statement

### DIFF
--- a/src/CircleGraph/CircleViewer.ts
+++ b/src/CircleGraph/CircleViewer.ts
@@ -83,7 +83,7 @@ class CircleViewerDocument implements vscode.CustomDocument {
         if (view.owner(panel)) {
           view.disposeGraphCtrl();
           this._circleViewer.splice(index, 1);
-          return true;  // break forEach
+          return;  // break forEach
         }
       });
     });

--- a/src/CircleGraph/CircleViewer.ts
+++ b/src/CircleGraph/CircleViewer.ts
@@ -83,7 +83,6 @@ class CircleViewerDocument implements vscode.CustomDocument {
         if (view.owner(panel)) {
           view.disposeGraphCtrl();
           this._circleViewer.splice(index, 1);
-          return;  // break forEach
         }
       });
     });


### PR DESCRIPTION
`openView` function was returning two types,
one is `true` and the other is `void`.
This commit fixes this to use consistent return statement.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>