### PR TITLE
[Tests] Use forEach instead of map

### DIFF
--- a/src/Tests/Execute/InferenceQuickInput.test.ts
+++ b/src/Tests/Execute/InferenceQuickInput.test.ts
@@ -156,7 +156,7 @@ suite('Execute', function() {
         let quickInput = new InferenceQuickInput();
         let names = ['item0', 'item1'];
         let items = quickInput.getQuickPickItems(names);
-        items.map((value, index, array) => {
+        items.forEach((value, index) => {
           assert.strictEqual(value.label, names[index]);
         });
       });
@@ -176,7 +176,7 @@ suite('Execute', function() {
         const expected = exts;
         let filter = quickInput.getFilter();
         assert.strictEqual(filter.backendName.length, expected.length);
-        filter.backendName.map((value, index, array) => {
+        filter.backendName.forEach((value, index) => {
           assert.strictEqual(value, expected[index]);
         });
       });
@@ -188,7 +188,7 @@ suite('Execute', function() {
         const actual = quickInput.getInputSpecKeys();
         const expected = ['any', 'non-zero', 'positive'];
         assert.strictEqual(actual.length, expected.length);
-        actual.map((value, index, array) => {
+        actual.forEach((value, index) => {
           assert.strictEqual(value, expected[index]);
         });
       });


### PR DESCRIPTION
`map(...)` function returns new array but it is not used.
This commit will fix to use `forEach` instead of `map`.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>