### PR TITLE
[Execute] Use consistent return statement

### DIFF
--- a/src/Execute/InferenceQuickInput.ts
+++ b/src/Execute/InferenceQuickInput.ts
@@ -96,11 +96,11 @@ class InferenceQuickInput {
 
     if (this.backend === undefined) {
       this.error = 'Backend to infer is not chosen. Please check once again.';
-      return undefined;
+      return;
     }
     if (this.backend.executor() === undefined) {
       this.error = 'Backend executor is not set yet. Please check once again.';
-      return undefined;
+      return;
     }
   }
 
@@ -129,7 +129,6 @@ class InferenceQuickInput {
 
     Logger.warn(logTag, 'No model has been selected');
     this.error = 'No model has been selected. Please check once again.';
-    return undefined;
   }
 
   getInputSpecKeys(): string[] {


### PR DESCRIPTION
`selectInputModel` and `pickBackend` function return two types,
one is `void` and the other is `undefined`.
This commit fixes to return `void` consistently.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>