### PR TITLE
[Utils] Introduce FsWrapper

### DIFF
--- a/src/Utils/FsWrapper.ts
+++ b/src/Utils/FsWrapper.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode';
+
+/**
+ * A helper module for `vscode.workspace.fs`
+ * 
+ * WHY TO USE THIS FS WRAPPER MODULE?
+ * 
+ * VS Code extension team recommends developers to use vscode.workspace.fs instead of fs
+ * and not to use any syncronous functions to access file system.
+ * 
+ * Let's avoid using fs, especially syncronous functions.
+ * Instead, use these helper functions.
+ * 
+ * Add more helper functions as you may.
+ */
+
+export module fswrapper {
+
+  /**
+   * Replace fs.statSync
+   * 
+   * @example Check whether it's a directory
+   * ```
+   * if(await fswrapper.stat(filePath)).isDirectory){...}
+   * ```
+   */
+  function stat(fsPath: string) : Thenable<{isDirectory: boolean, isFile: boolean, isSymbolic: boolean}>{
+    return vscode.workspace.fs.stat(vscode.Uri.file(fsPath)).then(
+      (fstat)=>{
+        const isDirectory : boolean = ((fstat.type | vscode.FileType.Directory) === fstat.type);
+        const isFile : boolean = ((fstat.type | vscode.FileType.File) === fstat.type);
+        const isSymbolic : boolean = ((fstat.type | vscode.FileType.SymbolicLink) === fstat.type);
+        return {
+          isDirectory : isDirectory,
+          isFile: isFile,
+          isSymbolic: isSymbolic
+        };
+      }
+    );
+  }
+
+  /**
+   * Replace fs.readFilSync
+   */
+  async function readFile(fsPath: string) : Promise<string>{
+    return (await vscode.workspace.fs.readFile(vscode.Uri.file(fsPath))).toString();
+  }
+
+  /**
+   * Replace fs.existsSync
+   */
+  function exists(fsPath: string) : Thenable<boolean> {
+    return vscode.workspace.fs.stat(vscode.Uri.file(fsPath)).then(
+      (fstat)=>{
+        return fstat.type === vscode.FileType.Unknown ? true: false;
+      }
+    );
+  }
+
+  // Support more
+};


### PR DESCRIPTION
This commit introduces FsWrapper.
FsWrapper is a helper module for an easy use of vscode.workspace.fs

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>