### PR TITLE
[Tests] Use forEach instead of map

### DIFF
--- a/src/Tests/View/InstallQuickInput.test.ts
+++ b/src/Tests/View/InstallQuickInput.test.ts
@@ -132,7 +132,7 @@ suite('View', function() {
         let quickInput = new InstallQuickInput();
         let names = ['item0', 'item1'];
         let items = quickInput.getQuickPickItems(names);
-        items.map((value, index, array) => {
+        items.forEach((value, index) => {
           assert.strictEqual(value.label, names[index]);
         });
       });


### PR DESCRIPTION
`map(...)` function returns new array but it is not used.
This commit will fix to use `forEach` instead of `map`.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>