### PR TITLE
[PartEditor] Use consistent return statement

### DIFF
--- a/src/PartEditor/PartEditor.ts
+++ b/src/PartEditor/PartEditor.ts
@@ -396,7 +396,7 @@ export class PartEditorProvider implements vscode.CustomTextEditorProvider, Part
     this._partEditors.forEach((editor, index) => {
       if (e === editor) {
         this._partEditors.splice(index, 1);
-        return true;
+        return;
       }
     });
   }

--- a/src/PartEditor/PartEditor.ts
+++ b/src/PartEditor/PartEditor.ts
@@ -396,7 +396,6 @@ export class PartEditorProvider implements vscode.CustomTextEditorProvider, Part
     this._partEditors.forEach((editor, index) => {
       if (e === editor) {
         this._partEditors.splice(index, 1);
-        return;
       }
     });
   }

--- a/src/PartEditor/PartGraphSelector.ts
+++ b/src/PartEditor/PartGraphSelector.ts
@@ -135,7 +135,6 @@ export class PartGraphSelPanel extends CircleGraphCtrl implements CircleGraphEve
     PartGraphSelPanel.panels.forEach((selpan) => {
       if (docPath === selpan._documentPath && id === selpan._ownerId) {
         result = selpan;
-        return;  // break forEach
       }
     });
     return result;
@@ -224,7 +223,6 @@ export class PartGraphSelPanel extends CircleGraphCtrl implements CircleGraphEve
     PartGraphSelPanel.panels.forEach((selPan, index) => {
       if (this._documentPath === selPan._documentPath && this._ownerId === selPan._ownerId) {
         PartGraphSelPanel.panels.splice(index, 1);
-        return;  // break forEach
       }
     });
 

--- a/src/PartEditor/PartGraphSelector.ts
+++ b/src/PartEditor/PartGraphSelector.ts
@@ -135,7 +135,7 @@ export class PartGraphSelPanel extends CircleGraphCtrl implements CircleGraphEve
     PartGraphSelPanel.panels.forEach((selpan) => {
       if (docPath === selpan._documentPath && id === selpan._ownerId) {
         result = selpan;
-        return true;  // break forEach
+        return;  // break forEach
       }
     });
     return result;
@@ -224,7 +224,7 @@ export class PartGraphSelPanel extends CircleGraphCtrl implements CircleGraphEve
     PartGraphSelPanel.panels.forEach((selPan, index) => {
       if (this._documentPath === selPan._documentPath && this._ownerId === selPan._ownerId) {
         PartGraphSelPanel.panels.splice(index, 1);
-        return true;  // break forEach
+        return;  // break forEach
       }
     });
 


### PR DESCRIPTION
Some functions were returning two types,
one is `true` and the other is `void`.
This commit fixes this to use consistent return statement.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>