### PR TITLE
[Toolchain] Use forEach instead of map

### DIFF
--- a/src/Tests/Toolchain/ToolchainProvider.test.ts
+++ b/src/Tests/Toolchain/ToolchainProvider.test.ts
@@ -129,7 +129,7 @@ suite('Toolchain', function() {
         let bnode: BackendNode = bnodes[0];
         let tnodes = NodeBuilder.createToolchainNodes(bnode);
         assert.strictEqual(tnodes.length, 1);
-        tnodes.map((tnode) => {
+        tnodes.forEach((tnode) => {
           assert.strictEqual(tnode.backendName, backendName);
         });
       });
@@ -183,7 +183,7 @@ suite('Toolchain', function() {
         let bnode: BackendNode = bnodes[0];
         provider.getChildren(bnode).then((tnodes) => {
           assert.strictEqual(tnodes.length, 1);
-          tnodes.map((tnode) => {
+          tnodes.forEach((tnode) => {
             assert.instanceOf(tnode, ToolchainNode);
           });
           done();


### PR DESCRIPTION
`map(...)` function returns new array but it is not used.
This commit will fix to use `forEach` instead of `map`.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>