### PR TITLE
[Mondrian] Declare variable with const

### DIFF
--- a/media/Mondrian/mondrianViewer.js
+++ b/media/Mondrian/mondrianViewer.js
@@ -203,7 +203,7 @@ function updateContent(data, viewer) {
   }
   segmentSelect.value = viewer.activeSegment;
 
-  for (alloc of data.segments[viewer.activeSegment].allocations) {
+  for (const alloc of data.segments[viewer.activeSegment].allocations) {
     if (alloc.alive_till > totalCycles) {
       totalCycles = alloc.alive_till;
     }


### PR DESCRIPTION
`alloc` variable is declared without any qualifier.
This commit adds it with `const`.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>