### PR TITLE
[OneExplorer] Do not use useless return

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -261,10 +261,10 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
         .then(ans => {
           if (ans === approval) {
             Logger.info('OneExplorer', `Delete '${oneNode.node.name}'.`);
-            vscode.workspace.fs.delete(oneNode.node.uri, {recursive: recursive, useTrash: true});
+            vscode.workspace.fs.delete(oneNode.node.uri, {recursive: recursive, useTrash: true})
+                .then(() => this.refresh());
           }
-        })
-        .then(() => this.refresh());
+        });
   }
 
   /**

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -261,8 +261,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
         .then(ans => {
           if (ans === approval) {
             Logger.info('OneExplorer', `Delete '${oneNode.node.name}'.`);
-            return vscode.workspace.fs.delete(
-                oneNode.node.uri, {recursive: recursive, useTrash: true});
+            vscode.workspace.fs.delete(oneNode.node.uri, {recursive: recursive, useTrash: true});
           }
         })
         .then(() => this.refresh());


### PR DESCRIPTION
`vscode.workspace.fs.delete` returns `Thenable<void>`, so `return` is useless.
This commit removes this.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>