### PR TITLE
Exclude external codes from static analysis

### DIFF
--- a/.ahub/sam/exclude.txt
+++ b/.ahub/sam/exclude.txt
@@ -1,0 +1,2 @@
+# External code
+/ONE-vscode/media/CircleGraph/external


### PR DESCRIPTION
This commit excludes netron source codes from static analysis.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>