### PR TITLE
[Spec] revisit sdbSpec

### DIFF
--- a/res/script/sdbSpecList.sh
+++ b/res/script/sdbSpecList.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-#
-# This shell script print tizen device serial name on each line.
-#
-
-sdb devices | grep -v devices | grep device | awk '{print $1}'

--- a/res/script/sdbSpecList.sh
+++ b/res/script/sdbSpecList.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+#
+# This shell script print tizen device serial name on each line.
+#
+
+sdb devices | grep -v devices | grep device | awk '{print $1}'

--- a/script/sdbSpecList.sh
+++ b/script/sdbSpecList.sh
@@ -3,18 +3,20 @@
 #
 # This shell script prints tizen device serial name on each line.
 #
-# on `sdb devices`, it will show result below.
+# On `sdb devices`, it will show result below.
 #
 # List of devices attached 
 # 192.168.223.1:26101 	device    	0
+# emulator-1            emulator    0
 # 192.168.224.1:26101 	device    	0
 #
-# so, only imformation we need is list of -s in first column from second row to end.
-# just pass `sdb device` result except first line and grep only device and pring first column
-# this will show result below
+# First colmn is serialNumber which is unique key for device.
+# Second colmn is state.
+# Third colmn is targetName.
+# (Reference: https://docs.tizen.org/application/tizen-studio/common-tools/smart-development-bridge/#managing-targets)
 #
-# 192.168.223.1:26101
-# 192.168.224.1:26101
+# `sdb devices` will not give data that exactly we want, So we need to modify result.
+# We only need serialNumber, So use `awk` to pick serialNumber information.
 #
 
-sdb devices | awk 'NR > 1 {print}' | grep device | awk '{print $1}'
+sdb devices | awk 'NR > 1 {if ($2 == "device") print $1}'

--- a/script/sdbSpecList.sh
+++ b/script/sdbSpecList.sh
@@ -6,9 +6,9 @@
 # On `sdb devices`, it will show result below.
 #
 # List of devices attached 
-# 192.168.223.1:26101 	device    	0
-# emulator-1            emulator    0
-# 192.168.224.1:26101 	device    	0
+# 1.2.3.4:26101 	device    	0
+# emulator-1            emulator        0
+# 1.2.3.4:26101 	device    	0
 #
 # First colmn is serialNumber which is unique key for device.
 # Second colmn is state.

--- a/script/sdbSpecList.sh
+++ b/script/sdbSpecList.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+#
+# This shell script prints tizen device serial name on each line.
+#
+# on `sdb devices`, it will show result below.
+#
+# List of devices attached 
+# 192.168.223.1:26101 	device    	0
+# 192.168.224.1:26101 	device    	0
+#
+# so, only imformation we need is list of -s in first column from second row to end.
+# just pass `sdb device` result except first line and grep only device and pring first column
+# this will show result below
+#
+# 192.168.223.1:26101
+# 192.168.224.1:26101
+#
+
+sdb devices | awk 'NR > 1 {print}' | grep device | awk '{print $1}'

--- a/src/Backend/Spec.ts
+++ b/src/Backend/Spec.ts
@@ -16,6 +16,7 @@
 
 import {Command} from './Command';
 
+const resDir = process.env.PWD + '/res';
 /**
  * Spec is a bundle of information that could be used for checking whether something to require is
  * satisfied with a certain objective.
@@ -70,8 +71,7 @@ class BridgeSpec {
 }
 
 // TODO add more BridgeSpec like docker or ADB......
-const sdbSpec = new BridgeSpec(
-    'sdb', 'sdb devices | grep -v devices | grep device | awk \'{print $1}\'', 'sdb shell');
+const sdbSpec = new BridgeSpec('sdb', resDir + '/script/sdbSpecList.sh', 'sdb shell');
 
 class HostPCSpec extends DeviceSpec {
   constructor(hw: string, sw: string) {

--- a/src/Backend/Spec.ts
+++ b/src/Backend/Spec.ts
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+import * as vscode from 'vscode';
+
 import {Command} from './Command';
 
-const resDir = process.env.PWD + '/res';
+const extensionId = 'Samsung.one-vscode';
+const ext = vscode.extensions.getExtension(extensionId) as vscode.Extension<any>;
 /**
  * Spec is a bundle of information that could be used for checking whether something to require is
  * satisfied with a certain objective.
@@ -71,7 +74,7 @@ class BridgeSpec {
 }
 
 // TODO add more BridgeSpec like docker or ADB......
-const sdbSpec = new BridgeSpec('sdb', resDir + '/script/sdbSpecList.sh', 'sdb shell');
+const sdbSpec = new BridgeSpec('sdb', vscode.Uri.joinPath(ext?.extensionUri, 'res', 'script', 'sdbSpecList.sh').fsPath, 'sdb shell');
 
 class HostPCSpec extends DeviceSpec {
   constructor(hw: string, sw: string) {

--- a/src/Backend/Spec.ts
+++ b/src/Backend/Spec.ts
@@ -89,7 +89,7 @@ class TizenDeviceSpec extends DeviceSpec {
 }
 
 const supportedSpecs = new Array<DeviceSpec>(
-    new HostPCSpec('x86_64', 'Ubuntu 18') /* spec where simulator can run */,
+    new HostPCSpec('x86_64', 'Ubuntu 18.04') /* spec where simulator can run */,
     new TizenDeviceSpec('armv7l', 'Tizen 7.0.0') /* spec for Tizen TV */);
 
 export {DeviceSpec, BridgeSpec, HostPCSpec, TizenDeviceSpec, sdbSpec, supportedSpecs};

--- a/src/Backend/Spec.ts
+++ b/src/Backend/Spec.ts
@@ -74,7 +74,9 @@ class BridgeSpec {
 }
 
 // TODO add more BridgeSpec like docker or ADB......
-const sdbSpec = new BridgeSpec('sdb', vscode.Uri.joinPath(ext?.extensionUri, 'res', 'script', 'sdbSpecList.sh').fsPath, 'sdb shell');
+const sdbSpec = new BridgeSpec(
+    'sdb', vscode.Uri.joinPath(ext!.extensionUri, 'res', 'script', 'sdbSpecList.sh').fsPath,
+    'sdb shell');
 
 class HostPCSpec extends DeviceSpec {
   constructor(hw: string, sw: string) {

--- a/src/Backend/Spec.ts
+++ b/src/Backend/Spec.ts
@@ -75,8 +75,7 @@ class BridgeSpec {
 
 // TODO add more BridgeSpec like docker or ADB......
 const sdbSpec = new BridgeSpec(
-    'sdb', vscode.Uri.joinPath(ext!.extensionUri, 'res', 'script', 'sdbSpecList.sh').fsPath,
-    'sdb shell');
+    'sdb', vscode.Uri.joinPath(ext!.extensionUri, 'script', 'sdbSpecList.sh').fsPath, 'sdb shell');
 
 class HostPCSpec extends DeviceSpec {
   constructor(hw: string, sw: string) {

--- a/src/Tests/Backend/Spec.test.ts
+++ b/src/Tests/Backend/Spec.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {assert, should} from 'chai';
+import {assert} from 'chai';
 
 import {BridgeSpec, DeviceSpec, HostPCSpec, sdbSpec, TizenDeviceSpec} from '../../Backend/Spec';
 
@@ -71,11 +71,10 @@ suite('Spec', function() {
     });
   });
   suite('sdbSpec', function() {
+    const deviceListCom = process.env.PWD + '/res/script/sdbSpecList.sh';
     assert.isObject<BridgeSpec>(sdbSpec);
     assert.strictEqual(sdbSpec.name, 'sdb');
-    assert.strictEqual(
-        sdbSpec.deviceListCmd.str(),
-        'sdb devices | grep -v devices | grep device | awk \'{print $1}\'');
+    assert.strictEqual(sdbSpec.deviceListCmd.str(), deviceListCom);
     assert.strictEqual(sdbSpec.shellCmd.str(), 'sdb shell');
   });
 });

--- a/src/Tests/Backend/Spec.test.ts
+++ b/src/Tests/Backend/Spec.test.ts
@@ -74,8 +74,7 @@ suite('Spec', function() {
   suite('sdbSpec', function() {
     const extensionId = 'Samsung.one-vscode';
     const ext = vscode.extensions.getExtension(extensionId) as vscode.Extension<any>;
-    const deviceListCom =
-        vscode.Uri.joinPath(ext!.extensionUri, 'res', 'script', 'sdbSpecList.sh').fsPath;
+    const deviceListCom = vscode.Uri.joinPath(ext!.extensionUri, 'script', 'sdbSpecList.sh').fsPath;
     assert.isObject<BridgeSpec>(sdbSpec);
     assert.strictEqual(sdbSpec.name, 'sdb');
     assert.strictEqual(sdbSpec.deviceListCmd.str(), deviceListCom);

--- a/src/Tests/Backend/Spec.test.ts
+++ b/src/Tests/Backend/Spec.test.ts
@@ -15,6 +15,7 @@
  */
 
 import {assert} from 'chai';
+import * as vscode from 'vscode';
 
 import {BridgeSpec, DeviceSpec, HostPCSpec, sdbSpec, TizenDeviceSpec} from '../../Backend/Spec';
 
@@ -71,7 +72,9 @@ suite('Spec', function() {
     });
   });
   suite('sdbSpec', function() {
-    const deviceListCom = process.env.PWD + '/res/script/sdbSpecList.sh';
+    const extensionId = 'Samsung.one-vscode';
+    const ext = vscode.extensions.getExtension(extensionId) as vscode.Extension<any>;
+    const deviceListCom = vscode.Uri.joinPath(ext?.extensionUri, 'res', 'script', 'sdbSpecList.sh').fsPath;
     assert.isObject<BridgeSpec>(sdbSpec);
     assert.strictEqual(sdbSpec.name, 'sdb');
     assert.strictEqual(sdbSpec.deviceListCmd.str(), deviceListCom);

--- a/src/Tests/Backend/Spec.test.ts
+++ b/src/Tests/Backend/Spec.test.ts
@@ -74,7 +74,8 @@ suite('Spec', function() {
   suite('sdbSpec', function() {
     const extensionId = 'Samsung.one-vscode';
     const ext = vscode.extensions.getExtension(extensionId) as vscode.Extension<any>;
-    const deviceListCom = vscode.Uri.joinPath(ext?.extensionUri, 'res', 'script', 'sdbSpecList.sh').fsPath;
+    const deviceListCom =
+        vscode.Uri.joinPath(ext!.extensionUri, 'res', 'script', 'sdbSpecList.sh').fsPath;
     assert.isObject<BridgeSpec>(sdbSpec);
     assert.strictEqual(sdbSpec.name, 'sdb');
     assert.strictEqual(sdbSpec.deviceListCmd.str(), deviceListCom);


### PR DESCRIPTION
This commit revisit `sdbSpec` to use script file.
As `spawnsync()` with `shell: false` could not execute piped command, using `&&` or `|`.

ONE-vscode-DCO-1.0-Signed-off-by: struss <rrstrous@nate.com>