### PR TITLE
[OneExplorer] Rename DerivedModel to Product

### DIFF
--- a/src/OneExplorer/ConfigObject.ts
+++ b/src/OneExplorer/ConfigObject.ts
@@ -185,7 +185,7 @@ export class LocatorRunner {
 }
 
 /**
- * @brief A helper class to get parsed artifacts (baseModels, derivedModels)
+ * @brief A helper class to get parsed artifacts (baseModels, products)
  *        The paths in the artifacts are all resolved. (No '..' in the path)
 
  * ```
@@ -196,7 +196,7 @@ export class LocatorRunner {
  * const configObj = createConfigObj(uri);
  *
  * const baseModels = configObj.getBaseModelsExists;
- * const derivedModels = configObj.getDerivedModelsExists;
+ * const products = configObj.getProductsExists;
  * ```
  */
 export class ConfigObj {
@@ -215,15 +215,15 @@ export class ConfigObj {
    */
   obj: {
     baseModels: Artifact[],
-    derivedModels: Artifact[],
+    products: Artifact[],
   };
 
   get getBaseModels() {
     return this.obj.baseModels;
   }
 
-  get getDerivedModels() {
-    return this.obj.derivedModels;
+  get getProducts() {
+    return this.obj.products;
   }
 
   /**
@@ -234,10 +234,10 @@ export class ConfigObj {
   }
 
   /**
-   * Returns only the derivedModels which exists in file system
+   * Returns only the products which exists in file system
    */
-  get getDerivedModelsExists() {
-    return this.obj.derivedModels.filter(artifact => RealPath.exists(artifact.path));
+  get getProductsExists() {
+    return this.obj.products.filter(artifact => RealPath.exists(artifact.path));
   }
 
   /**
@@ -255,7 +255,7 @@ export class ConfigObj {
     this.rawObj = rawObj;
     this.obj = {
       baseModels: ConfigObj.parseBaseModels(uri.fsPath, rawObj),
-      derivedModels: ConfigObj.parseDerivedModels(uri.fsPath, rawObj)
+      products: ConfigObj.parseProducts(uri.fsPath, rawObj)
     };
   }
 
@@ -350,7 +350,7 @@ export class ConfigObj {
    *
    * @param uri cfg uri is required to calculate absolute path
    */
-  private static parseDerivedModels = (filePath: string, iniObj: object): Artifact[] => {
+  private static parseProducts = (filePath: string, iniObj: object): Artifact[] => {
     const dir = path.dirname(filePath);
 
     let locatorRunner = new LocatorRunner();

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -39,7 +39,7 @@ import {OneccRunner} from './OneccRunner';
  *   ∟ baseModel      (1)
  * ----------------------
  *      ∟ config      (2)
- *         ∟ derivedModel (2)
+ *         ∟ product (2)
  *
  * RELATIONS
  *
@@ -48,9 +48,10 @@ import {OneccRunner} from './OneccRunner';
  *    Directories without any base model will not show up.
  *
  * (2) Config Contents
- *    Configuration files(.cfg) and derivedModels appear as how they are specified in the cfg file.
- *    Config files will be shown under the base model, whose path is specified in the config file.
- *    derivedModels will be shown under the config whose path is specified in the config file.
+ *    Configuration files(.cfg) and product files(output model, log, ..) appear as how they are
+ * specified in the cfg file. Config files will be shown under the base model, whose path is
+ * specified in the config file. products will be shown under the config whose path is specified in
+ * the config file.
  *
  */
 enum NodeType {
@@ -75,10 +76,8 @@ enum NodeType {
    * All the result files obtained by running ONE config.
    *
    * EXAMPLE: .circle, .tvn, .log
-   *
-   * TODO Rename to more inclusive term
    */
-  derivedModel,
+  product,
 }
 
 class Node {
@@ -131,7 +130,7 @@ export class OneNode extends vscode.TreeItem {
       this.iconPath = vscode.ThemeIcon.Folder;
     } else if (node.type === NodeType.baseModel) {
       this.iconPath = vscode.ThemeIcon.File;
-    } else if (node.type === NodeType.derivedModel) {
+    } else if (node.type === NodeType.product) {
       this.iconPath = vscode.ThemeIcon.File;
     }
 
@@ -188,7 +187,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
   }
 
   /**
-   * Rename a file of all types of nodes (baseModel, derivedModel, config) excepts for directory.
+   * Rename a file of all types of nodes (baseModel, product, config) excepts for directory.
    * It only alters the file name, not the path.
    */
   rename(oneNode: OneNode): void {
@@ -199,7 +198,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
       warningMessage = `WARNING! ${
           oneNode.node.childNodes.map(node => `'${node.name}'`)
               .toString()} will disappear from the view.`;
-    } else if (oneNode.node.type === NodeType.derivedModel) {
+    } else if (oneNode.node.type === NodeType.product) {
       // TODO automatically change the corresponding files
       warningMessage = `WARNING! '${oneNode.node.name}' may disappear from the view.`;
     }
@@ -359,7 +358,7 @@ input_path=${modelName}.${extName}
     const toOneNode = (node: Node): OneNode => {
       if (node.type === NodeType.directory) {
         return new OneNode(node.name, vscode.TreeItemCollapsibleState.Expanded, node);
-      } else if (node.type === NodeType.derivedModel) {
+      } else if (node.type === NodeType.product) {
         return new OneNode(node.name, vscode.TreeItemCollapsibleState.None, node);
       } else if (node.type === NodeType.baseModel) {
         return new OneNode(
@@ -491,20 +490,19 @@ input_path=${modelName}.${extName}
         continue;
       }
 
-      const pairNode = this.createConfigNode(cfg, cfgObj.getDerivedModelsExists);
+      const pairNode = this.createConfigNode(cfg, cfgObj.getProductsExists);
 
       baseModelNode.childNodes.push(pairNode);
     }
   }
 
-  private createConfigNode(conf: string, derivedModels: Artifact[]): Node {
+  private createConfigNode(conf: string, products: Artifact[]): Node {
     const pairNode = new Node(NodeType.config, [], vscode.Uri.file(conf));
 
-    Logger.debug('OneExplorer', `DerivedModels : ${derivedModels}`);
+    Logger.debug('OneExplorer', `Products : ${products}`);
 
-    derivedModels.forEach(derivedModel => {
-      pairNode.childNodes.push(
-          new Node(NodeType.derivedModel, [], vscode.Uri.file(derivedModel.path)));
+    products.forEach(product => {
+      pairNode.childNodes.push(new Node(NodeType.product, [], vscode.Uri.file(product.path)));
     });
 
 

--- a/src/Tests/OneExplorer/ConfigObject.test.ts
+++ b/src/Tests/OneExplorer/ConfigObject.test.ts
@@ -125,20 +125,20 @@ input_path=${modelName}
           assert.isObject(configObj!.rawObj);
           assert.isObject(configObj!.obj);
           assert.isArray(configObj!.obj.baseModels);
-          assert.isArray(configObj!.obj.derivedModels);
+          assert.isArray(configObj!.obj.products);
 
           assert.strictEqual(configObj!.obj.baseModels.length, 1);
-          assert.strictEqual(configObj!.obj.derivedModels.length, 0);
+          assert.strictEqual(configObj!.obj.products.length, 0);
 
           assert.strictEqual(configObj!.obj.baseModels[0].path, modelPath);
         }
       });
 
-      test('Returns parsed object with derivedModels', function() {
+      test('Returns parsed object with products', function() {
         const configName = 'model.cfg';
         const baseModelName = 'model.tflite';
-        const derivedModelName1 = 'model.circle';
-        const derivedModelName2 = 'model.q8.circle';
+        const productName1 = 'model.circle';
+        const productName2 = 'model.q8.circle';
 
         const content = `
 [onecc]
@@ -146,10 +146,10 @@ one-import-tflite=True
 one-quantize=True
 [one-import-tflite]
 input_path=${baseModelName}
-output_path=${derivedModelName1}
+output_path=${productName1}
 [one-quantize]
-input_path=${derivedModelName1}
-output_path=${derivedModelName2}
+input_path=${productName1}
+output_path=${productName2}
         `;
 
         // Write a file inside a temp directory
@@ -158,8 +158,8 @@ output_path=${derivedModelName2}
         // Get file paths inside the temp directory
         const configPath = testBuilder.getPath(configName);
         const baseModelPath = testBuilder.getPath(baseModelName);
-        const derivedModelPath1 = testBuilder.getPath(derivedModelName1);
-        const derivedModelPath2 = testBuilder.getPath(derivedModelName2);
+        const productPath1 = testBuilder.getPath(productName1);
+        const productPath2 = testBuilder.getPath(productName2);
 
         const configObj = ConfigObj.createConfigObj(vscode.Uri.file(configPath));
 
@@ -172,26 +172,26 @@ output_path=${derivedModelName2}
           assert.isObject(configObj!.rawObj);
           assert.isObject(configObj!.obj);
           assert.isArray(configObj!.obj.baseModels);
-          assert.isArray(configObj!.obj.derivedModels);
+          assert.isArray(configObj!.obj.products);
 
           assert.strictEqual(configObj!.obj.baseModels.length, 1);
 
           assert.strictEqual(configObj!.obj.baseModels[0].path, baseModelPath);
 
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
-                            .includes(derivedModelPath1));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
-                            .includes(derivedModelPath2));
+          assert.isTrue(
+              configObj!.obj.products.map(product => product.path).includes(productPath1));
+          assert.isTrue(
+              configObj!.obj.products.map(product => product.path).includes(productPath2));
         }
       });
 
-      test('Returns parsed object with derivedModels and check logs', function() {
+      test('Returns parsed object with products and check logs', function() {
         const configName = 'model.cfg';
         const baseModelName = 'model.tflite';
-        const derivedModelName1 = 'model.circle';
-        const derivedModelName2 = 'model.q8.circle';
-        const derivedModelName3 = 'model.circle.log';
-        const derivedModelName4 = 'model.q8.circle.log';
+        const productName1 = 'model.circle';
+        const productName2 = 'model.q8.circle';
+        const productName3 = 'model.circle.log';
+        const productName4 = 'model.q8.circle.log';
 
         const content = `
 [onecc]
@@ -199,10 +199,10 @@ one-import-tflite=True
 one-quantize=True
 [one-import-tflite]
 input_path=${baseModelName}
-output_path=${derivedModelName1}
+output_path=${productName1}
 [one-quantize]
-input_path=${derivedModelName1}
-output_path=${derivedModelName2}
+input_path=${productName1}
+output_path=${productName2}
         `;
 
         // Write a file inside a temp directory
@@ -211,10 +211,10 @@ output_path=${derivedModelName2}
         // Get file paths inside the temp directory
         const configPath = testBuilder.getPath(configName);
         const baseModelPath = testBuilder.getPath(baseModelName);
-        const derivedModelPath1 = testBuilder.getPath(derivedModelName1);
-        const derivedModelPath2 = testBuilder.getPath(derivedModelName2);
-        const derivedModelPath3 = testBuilder.getPath(derivedModelName3);
-        const derivedModelPath4 = testBuilder.getPath(derivedModelName4);
+        const productPath1 = testBuilder.getPath(productName1);
+        const productPath2 = testBuilder.getPath(productName2);
+        const productPath3 = testBuilder.getPath(productName3);
+        const productPath4 = testBuilder.getPath(productName4);
 
         const configObj = ConfigObj.createConfigObj(vscode.Uri.file(configPath));
 
@@ -227,28 +227,28 @@ output_path=${derivedModelName2}
           assert.isObject(configObj!.rawObj);
           assert.isObject(configObj!.obj);
           assert.isArray(configObj!.obj.baseModels);
-          assert.isArray(configObj!.obj.derivedModels);
+          assert.isArray(configObj!.obj.products);
 
           assert.strictEqual(configObj!.obj.baseModels.length, 1);
 
           assert.strictEqual(configObj!.obj.baseModels[0].path, baseModelPath);
 
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
-                            .includes(derivedModelPath1));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
-                            .includes(derivedModelPath2));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
-                            .includes(derivedModelPath3));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
-                            .includes(derivedModelPath4));
+          assert.isTrue(
+              configObj!.obj.products.map(product => product.path).includes(productPath1));
+          assert.isTrue(
+              configObj!.obj.products.map(product => product.path).includes(productPath2));
+          assert.isTrue(
+              configObj!.obj.products.map(product => product.path).includes(productPath3));
+          assert.isTrue(
+              configObj!.obj.products.map(product => product.path).includes(productPath4));
         }
       });
 
       test('Parse config with detouring paths', function() {
         const configName = 'model.cfg';
         const baseModelName = 'model.tflite';
-        const derivedModelName1 = 'model.circle';
-        const derivedModelName2 = 'model.q8.circle';
+        const productName1 = 'model.circle';
+        const productName2 = 'model.q8.circle';
 
         // Detouring paths
         const content = `
@@ -257,10 +257,10 @@ one-import-tflite=True
 one-quantize=True
 [one-import-tflite]
 input_path=dummy/dummy/../../${baseModelName}
-output_path=dummy/dummy/../../${derivedModelName1}
+output_path=dummy/dummy/../../${productName1}
 [one-quantize]
-input_path=${derivedModelName1}
-output_path=dummy/dummy/../..//${derivedModelName2}
+input_path=${productName1}
+output_path=dummy/dummy/../..//${productName2}
         `;
 
         // Write a file inside a temp directory
@@ -269,8 +269,8 @@ output_path=dummy/dummy/../..//${derivedModelName2}
         // Get file paths inside the temp directory
         const configPath = testBuilder.getPath(configName);
         const baseModelPath = testBuilder.getPath(baseModelName);
-        const derivedModelPath1 = testBuilder.getPath(derivedModelName1);
-        const derivedModelPath2 = testBuilder.getPath(derivedModelName2);
+        const productPath1 = testBuilder.getPath(productName1);
+        const productPath2 = testBuilder.getPath(productName2);
 
         const configObj = ConfigObj.createConfigObj(vscode.Uri.file(configPath));
 
@@ -280,18 +280,18 @@ output_path=dummy/dummy/../..//${derivedModelName2}
 
           assert.strictEqual(configObj!.obj.baseModels[0].path, baseModelPath);
 
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
-                            .includes(derivedModelPath1));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
-                            .includes(derivedModelPath2));
+          assert.isTrue(
+              configObj!.obj.products.map(product => product.path).includes(productPath1));
+          assert.isTrue(
+              configObj!.obj.products.map(product => product.path).includes(productPath2));
         }
       });
 
       test('NEG: Parse config with detouring paths with faulty absolute path', function() {
         const configName = 'model.cfg';
         const baseModelName = 'model.tflite';
-        const derivedModelName1 = 'model.circle';
-        const derivedModelName2 = 'model.q8.circle';
+        const productName1 = 'model.circle';
+        const productName2 = 'model.q8.circle';
 
         // Detouring paths with faulty absolute path
         // NOTE that path starts with '/' will be interpreted as an absolute path
@@ -301,10 +301,10 @@ one-import-tflite=True
 one-quantize=True
 [one-import-tflite]
 input_path=/dummy/dummy/../../${baseModelName}
-output_path=/dummy/dummy/../../${derivedModelName1}
+output_path=/dummy/dummy/../../${productName1}
 [one-quantize]
-input_path=/${derivedModelName1}
-output_path=/dummy/dummy/../..//${derivedModelName2}
+input_path=/${productName1}
+output_path=/dummy/dummy/../..//${productName2}
         `;
 
         // Write a file inside a temp directory
@@ -313,8 +313,8 @@ output_path=/dummy/dummy/../..//${derivedModelName2}
         // Get file paths inside the temp directory
         const configPath = testBuilder.getPath(configName);
         const baseModelPath = testBuilder.getPath(baseModelName);
-        const derivedModelPath1 = testBuilder.getPath(derivedModelName1);
-        const derivedModelPath2 = testBuilder.getPath(derivedModelName2);
+        const productPath1 = testBuilder.getPath(productName1);
+        const productPath2 = testBuilder.getPath(productName2);
 
         const configObj = ConfigObj.createConfigObj(vscode.Uri.file(configPath));
 
@@ -324,10 +324,10 @@ output_path=/dummy/dummy/../..//${derivedModelName2}
 
           assert.notStrictEqual(configObj!.obj.baseModels[0].path, baseModelPath);
 
-          assert.isFalse(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
-                             .includes(derivedModelPath1));
-          assert.isFalse(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
-                             .includes(derivedModelPath2));
+          assert.isFalse(
+              configObj!.obj.products.map(product => product.path).includes(productPath1));
+          assert.isFalse(
+              configObj!.obj.products.map(product => product.path).includes(productPath2));
           ;
         }
       });
@@ -336,14 +336,14 @@ output_path=/dummy/dummy/../..//${derivedModelName2}
       test('Parse config with absolute paths', function() {
         const configName = 'model.cfg';
         const baseModelName = 'model.tflite';
-        const derivedModelName1 = 'model.circle';
-        const derivedModelName2 = 'model.q8.circle';
+        const productName1 = 'model.circle';
+        const productName2 = 'model.q8.circle';
 
         // Get file paths inside the temp directory
         const configPath = testBuilder.getPath(configName);
         const baseModelPath = testBuilder.getPath(baseModelName);
-        const derivedModelPath1 = testBuilder.getPath(derivedModelName1);
-        const derivedModelPath2 = testBuilder.getPath(derivedModelName2);
+        const productPath1 = testBuilder.getPath(productName1);
+        const productPath2 = testBuilder.getPath(productName2);
 
         // Detouring paths
         const content = `
@@ -352,10 +352,10 @@ one-import-tflite=True
 one-quantize=True
 [one-import-tflite]
 input_path=/${baseModelPath}
-output_path=/${derivedModelPath1}
+output_path=/${productPath1}
 [one-quantize]
-input_path=/${derivedModelPath1}
-output_path=/${derivedModelPath2}
+input_path=/${productPath1}
+output_path=/${productPath2}
         `;
 
         // Write a file inside a temp directory
@@ -371,10 +371,10 @@ output_path=/${derivedModelPath2}
           assert.strictEqual(
               configObj!.obj.baseModels[0].path, baseModelPath, configObj!.obj.baseModels[0].path);
 
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
-                            .includes(derivedModelPath1));
-          assert.isTrue(configObj!.obj.derivedModels.map(derivedModel => derivedModel.path)
-                            .includes(derivedModelPath2));
+          assert.isTrue(
+              configObj!.obj.products.map(product => product.path).includes(productPath1));
+          assert.isTrue(
+              configObj!.obj.products.map(product => product.path).includes(productPath2));
         }
       });
     });


### PR DESCRIPTION
This commit renames derivedModel to product,
to use more inclusive term as it now include not only output models
but also logs.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>

---

For #1011