### PR TITLE
[PartEditor] Exclude properties from the prototype

### DIFF
--- a/media/PartEditor/index.js
+++ b/media/PartEditor/index.js
@@ -359,12 +359,14 @@ editor.Editor = class {
     this.clearOperatorsCode();
 
     for (let name in this.partition.OPNAME) {
-      let backend = this.partition.OPNAME[name];
-      let beCode = this.backendCode(backend);
-      if (beCode !== -1) {
-        this.setOperatorBeCode(name, beCode);
-      } else {
-        this.setOperatorBeCode(name, 0);
+      if (this.partition.OPNAME.hasOwnProperty(name)) {
+        let backend = this.partition.OPNAME[name];
+        let beCode = this.backendCode(backend);
+        if (beCode !== -1) {
+          this.setOperatorBeCode(name, beCode);
+        } else {
+          this.setOperatorBeCode(name, 0);
+        }
       }
     };
   }


### PR DESCRIPTION
This commit excludes properties from the prototype of `partition.OPNAME`.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>