### PR TITLE
Provide welcome guide via ONE view container

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,16 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+		"viewsWelcome": [
+      {
+        "view": "OneExplorerView",
+        "contents": "Open folder which includes models and configuration files.\n[Open Folder](Command:workbench.action.files.openFolder)\nFollowing types of models will be displayed.\n- *.tflite, *pb and *.onnx\n- Additional file types which are described by backend.\n\nTo learn more about ONE-vscode extension usage [read our docs](https://github.com/Samsung/ONE-vscode/blob/main/docs/HowToUse.md)."
+      },
+      {
+        "view": "ToolchainView",
+        "contents": "Register already installed toolchain or install a new toolchain.\n[Register Toolchain](Command:one.toolchain.refresh)\n\n[Install Toolchain](Command:one.toolchain.install)"
+      }
+    ],
     "viewsContainers": {
       "activitybar": [
         {

--- a/package.json
+++ b/package.json
@@ -19,11 +19,7 @@
 		"viewsWelcome": [
       {
         "view": "OneExplorerView",
-        "contents": "Open folder which includes models and configuration files.\n[Open Folder](Command:workbench.action.files.openFolder)\nFollowing types of models will be displayed.\n- *.tflite, *pb and *.onnx\n- Additional file types which are described by backend.\n\nTo learn more about ONE-vscode extension usage [read our docs](https://github.com/Samsung/ONE-vscode/blob/main/docs/HowToUse.md)."
-      },
-      {
-        "view": "ToolchainView",
-        "contents": "Register already installed toolchain or install a new toolchain.\n[Register Toolchain](Command:one.toolchain.refresh)\n\n[Install Toolchain](Command:one.toolchain.install)"
+        "contents": "Open folder which includes models and configuration files.\n[Open Folder](Command:workbench.action.files.openFolder)\nFollowing types of models will be displayed.\n- *.tflite, *pb and *.onnx\n- Intermediate and compiled models of backend(s).\n\nTo learn more about ONE-vscode extension usage [read our docs](https://github.com/Samsung/ONE-vscode/blob/main/docs/HowToUse.md)."
       }
     ],
     "viewsContainers": {


### PR DESCRIPTION
This commit provides welcome guide via ONE view container.
OneExplorerView shows the brief description about one-explorer-view,
and guide to open a workspace which includes model files and `cfg`s.
If no backend toolchain is registered, toolchainView's welcome page
leads the user to register or install toolchain.

ONE-vscode-DCO-1.0-Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>

---

1. The link to our document will be updated after introducing better README. (since json doesn't support comment, I couldn't add todo)
2. Toolchain timing issue (https://github.com/Samsung/ONE-vscode/issues/932#issuecomment-1181320311) will be resolved in near future. 