### PR TITLE
Remove flatbuffers from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@vscode/codicons": "^0.0.29",
         "@vscode/webview-ui-toolkit": "^0.9.3",
         "configparser": "^0.3.9",
-        "flatbuffers": "^2.0.3",
         "ini": "^2.0.0",
         "which": "^2.0.2"
       },
@@ -2532,11 +2531,6 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
-    },
-    "node_modules/flatbuffers": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-2.0.3.tgz",
-      "integrity": "sha512-lTN0GS4FjwPY6h8BDDuq8f2ZORIyRgI4pHXzIt7GBsTgyCt2z9OAPiWNaeEaNcjrmuLLzFagEDwpYiqGv5BEWg=="
     },
     "node_modules/flatted": {
       "version": "3.2.5",
@@ -8058,11 +8052,6 @@
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
       }
-    },
-    "flatbuffers": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-2.0.3.tgz",
-      "integrity": "sha512-lTN0GS4FjwPY6h8BDDuq8f2ZORIyRgI4pHXzIt7GBsTgyCt2z9OAPiWNaeEaNcjrmuLLzFagEDwpYiqGv5BEWg=="
     },
     "flatted": {
       "version": "3.2.5",

--- a/package.json
+++ b/package.json
@@ -434,7 +434,6 @@
     "@vscode/codicons": "^0.0.29",
     "@vscode/webview-ui-toolkit": "^0.9.3",
     "configparser": "^0.3.9",
-    "flatbuffers": "^2.0.3",
     "ini": "^2.0.0",
     "which": "^2.0.2"
   }


### PR DESCRIPTION
`flatbuffers` are no more used anywhere.
This commit removes `flatbuffers` from `package.json`.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>