### PR TITLE
[OneExplorer] Throw non-absolute path from LocatorRunner

### DIFF
--- a/src/OneExplorer/ArtifactLocator.ts
+++ b/src/OneExplorer/ArtifactLocator.ts
@@ -130,6 +130,12 @@ export class Locator {
    * iniObj[one-import-tflite]['input_file'] === "model.circle"
    */
   public locate(iniObj: object, dir: string): string[] {
+    if (!path.isAbsolute(dir)) {
+      // NOTE Non-absolute path cannot reach here
+      // 'dir' must be an absolute path because it's existing config file's 'RealPath'
+      throw Error('FIX CALLER: dir argument should be an absolute path');
+    }
+
     // Get file names from iniObj
     const getFileNames = (): string[] => {
       let fileNames: string[] = [];


### PR DESCRIPTION
Let's check if the directory path given to LocatorRunner.run()
is absolute path or not.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>

---


From #1064 
By adding some unit test, it's found out that the logic only allows absolute path.
Let's specify this restriction in the code.