### PR TITLE
[CircleGraph] Use consistent return statement

### DIFF
--- a/src/CircleGraph/CircleGraph.ts
+++ b/src/CircleGraph/CircleGraph.ts
@@ -38,6 +38,7 @@ export class CircleGraphPanel extends CircleGraphCtrl {
         if (fileUri && fileUri[0]) {
           return CircleGraphPanel.createOrShowContinue(extensionUri, fileUri[0].fsPath);
         }
+        return undefined;
       });
       return undefined;
     } else {


### PR DESCRIPTION
lambda function in `createOrShow` returns both `void` and `CircleGraphPanel`.
This commit fixes to return `undefined` instead of `void`.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>