### PR TITLE
[CircleGraph] Exclude UI related codes from coverage analysis

### DIFF
--- a/src/CircleGraph/CircleGraph.ts
+++ b/src/CircleGraph/CircleGraph.ts
@@ -18,6 +18,7 @@ import * as vscode from 'vscode';
 
 import {CircleGraphCtrl} from './CircleGraphCtrl';
 
+/* istanbul ignore next */
 export class CircleGraphPanel extends CircleGraphCtrl {
   public static currentPanel: CircleGraphPanel|undefined;
   public static readonly viewType = 'CircleGraphPanel';

--- a/src/CircleGraph/CircleGraphCtrl.ts
+++ b/src/CircleGraph/CircleGraphCtrl.ts
@@ -58,6 +58,7 @@ export interface CircleGraphEvent {
   onFinishLoadModel(): void;
 }
 
+/* istanbul ignore next */
 export class CircleGraphCtrl {
   protected static readonly folderMediaCircleGraph = 'media/CircleGraph';
   protected static readonly folderMediaCircleGraphExt = 'media/CircleGraph/external';

--- a/src/CircleGraph/CircleViewer.ts
+++ b/src/CircleGraph/CircleViewer.ts
@@ -22,6 +22,7 @@ import {CircleGraphCtrl} from './CircleGraphCtrl';
 /**
  * @brief Viewer control with CircleGraphCtrl
  */
+/* istanbul ignore next */
 class CircleViewer extends CircleGraphCtrl {
   private readonly _panel: vscode.WebviewPanel;
 
@@ -44,6 +45,7 @@ class CircleViewer extends CircleGraphCtrl {
  * @note  Actual content is handled by CircleGraphCtrl itself so documment
  *        only provides URI of the file
  */
+/* istanbul ignore next */
 export class CircleViewerDocument implements vscode.CustomDocument {
   private readonly _uri: vscode.Uri;
   private _circleViewer: CircleViewer[];
@@ -94,6 +96,7 @@ export class CircleViewerDocument implements vscode.CustomDocument {
 /**
  * @brief Circle model viewer readonly Provider
  */
+/* istanbul ignore next */
 export class CircleViewerProvider implements
     vscode.CustomReadonlyEditorProvider<CircleViewerDocument> {
   public static readonly viewType = 'onevscode.circleViewer';


### PR DESCRIPTION
UI related codes are hard to be managed about to code quality.
This commit excludes them.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>