### PR TITLE
[OneExplorer] Exclude UI related codes from coverage analysis

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -355,6 +355,7 @@ export class OneNode extends vscode.TreeItem {
   }
 }
 
+/* istanbul ignore next */
 export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
   private _onDidChangeTreeData: vscode.EventEmitter<OneNode|undefined|void> =
       new vscode.EventEmitter<OneNode|undefined|void>();
@@ -591,6 +592,7 @@ input_path=${modelName}.${extName}
   }
 };
 
+/* istanbul ignore next */
 export function initOneExplorer(context: vscode.ExtensionContext) {
   // TODO Support multi-root workspace
   let workspaceRoot: vscode.Uri|undefined = undefined;

--- a/src/OneExplorer/OneccRunner.ts
+++ b/src/OneExplorer/OneccRunner.ts
@@ -22,6 +22,7 @@ import {ToolArgs} from '../Project/ToolArgs';
 import {SuccessResult, ToolRunner} from '../Project/ToolRunner';
 import {Balloon} from '../Utils/Balloon';
 
+/* istanbul ignore next */
 export class OneccRunner extends EventEmitter {
   private startRunningOnecc: string = 'START_RUNNING_ONECC';
   private finishedRunningOnecc: string = 'FINISHED_RUNNING_ONECC';


### PR DESCRIPTION
UI related codes are hard to be managed about to code quality.
This commit excludes them.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>