### PR TITLE
[Mondrian] Exclude UI related codes from coverage analysis

### DIFF
--- a/src/Mondrian/MondrianEditor.ts
+++ b/src/Mondrian/MondrianEditor.ts
@@ -18,6 +18,7 @@ import * as vscode from 'vscode';
 import {getNonce} from '../Utils/external/Nonce';
 import {getUri} from '../Utils/external/Uri';
 
+/* istanbul ignore next */
 export class MondrianEditorProvider implements vscode.CustomTextEditorProvider {
   public static register(context: vscode.ExtensionContext): vscode.Disposable {
     const provider = new MondrianEditorProvider(context);


### PR DESCRIPTION
UI related codes are hard to be managed about to code quality.
This commit excludes them.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>