### PR TITLE
Exclude external open source from coverage analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -372,7 +372,8 @@
       ".{github,nyc_output,vscode,vscode-test}",
       "{media,infra}/**",
       "coverage/**",
-      "src/Tests/**"
+      "src/Tests/**",
+      "**/external/**"
     ],
     "include": [
       "src/**/*.ts",


### PR DESCRIPTION
External open source codes are hard to be managed about to code quality.
This commit excludes them.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>