### PR TITLE
[Backend] revisit `Backend` API to have multiple Executor

### DIFF
--- a/src/Backend/API.ts
+++ b/src/Backend/API.ts
@@ -44,15 +44,11 @@ function backendRegistrationApi() {
       if (compiler) {
         gToolchainEnvMap[backend.name()] = new ToolchainEnv(compiler);
       }
-      const executor = backend.executor();
-      if (executor) {
-        globalExecutorArray.push(executor);
+      const executors = backend.executors();
+      if (executors) {
+        globalExecutorArray.push(...executors);
       }
       Logger.info(logTag, 'Backend', backendName, 'was registered into ONE-vscode.');
-    },
-    registerExecutor(executor: Executor) {
-      globalExecutorArray.push(executor);
-      Logger.info(logTag, 'Executor', executor.name(), 'was registered into ONE-vscode.');
     }
   };
 

--- a/src/Backend/Backend.ts
+++ b/src/Backend/Backend.ts
@@ -37,5 +37,5 @@ export interface Backend {
   compiler(): Compiler|undefined;
 
   // executor specs by being filled by impl
-  executor(): Executor|undefined;
+  executors(): Executor[]|undefined;
 }

--- a/src/Execute/InferenceQuickInput.ts
+++ b/src/Execute/InferenceQuickInput.ts
@@ -30,6 +30,7 @@ interface State {
 
 class InferenceQuickInput {
   backend: Backend|undefined = undefined;
+  executor: Executor|undefined = undefined;
   modelPath: vscode.Uri|undefined = undefined;
   inputSpec: string|undefined = undefined;
   error: string|undefined = undefined;
@@ -41,6 +42,13 @@ class InferenceQuickInput {
       throw new Error('wrong calling');
     }
     return this.backend as Backend;
+  }
+
+  getExecutor(): Executor {
+    if (this.error !== undefined || this.executor === undefined) {
+      throw new Error('wrong calling');
+    }
+    return this.executor as Executor;
   }
 
   getModelPath(): vscode.Uri {
@@ -73,6 +81,17 @@ class InferenceQuickInput {
     return Object.keys(globalBackendMap);
   }
 
+  getAllExecutorNames(backend: Backend): string[] {
+    const executorList: string[] = [];
+    const executors = globalBackendMap[backend.name()].executors();
+    if (executors) {
+      for (const executor of executors) {
+        executorList.push(executor.name());
+      }
+    }
+    return executorList;
+  }
+
   getQuickPickItems(items: string[]): vscode.QuickPickItem[] {
     return items.map(label => ({label}));
   }
@@ -86,7 +105,7 @@ class InferenceQuickInput {
     state.selectedItem = await input.showQuickPick({
       title: 'Choose Executor Toolchain',
       step: 1,
-      totalSteps: 3,
+      totalSteps: 4,
       placeholder: 'Select a Backend',
       items: items,
       shouldResume: this.shouldResume
@@ -98,15 +117,36 @@ class InferenceQuickInput {
       this.error = 'Backend to infer is not chosen. Please check once again.';
       return;
     }
-    if (this.backend.executor() === undefined) {
+    if (this.backend.executors() === undefined) {
+      this.error = 'Backend executor is not set yet. Please check once again.';
+      return;
+    }
+  }
+
+  async pickExecutor(input: MultiStepInput, state: Partial<State>) {
+    const items = this.backend === undefined ?
+        [] :
+        this.getQuickPickItems(this.getAllExecutorNames(this.backend));
+    state.selectedItem = await input.showQuickPick({
+      title: 'Choose Executor Toolchain',
+      step: 2,
+      totalSteps: 4,
+      placeholder: 'Select a Backend',
+      items: items,
+      shouldResume: this.shouldResume
+    });
+    this.executor =
+        this.backend ?.executors() ?.find(executor => {
+                                      return executor.name() === state.selectedItem ?.label;
+                                    });
+    if (this.executor === undefined) {
       this.error = 'Backend executor is not set yet. Please check once again.';
       return;
     }
   }
 
   getFilter(): {[name: string]: string[]} {
-    const backend: Backend = this.backend as Backend;
-    const executor = backend.executor() as Executor;
+    const executor = this.executor as Executor;
     // List files which are filtered with executable extensions
     return {backendName: executor.getExecutableExt()};
   }
@@ -140,8 +180,8 @@ class InferenceQuickInput {
     const items = this.getQuickPickItems(this.getInputSpecKeys());
     state.selectedItem = await input.showQuickPick({
       title: 'Enter Backend Specific Options',
-      step: 3,
-      totalSteps: 3,
+      step: 4,
+      totalSteps: 4,
       placeholder: 'Select Random Input Spec',
       items: items,
       shouldResume: this.shouldResume
@@ -152,6 +192,7 @@ class InferenceQuickInput {
   async collectInputs(): Promise<void> {
     const state = {selectedItem: undefined} as Partial<State>;
     await MultiStepInput.run(input => this.pickBackend(input, state));
+    await MultiStepInput.run(input => this.pickExecutor(input, state));
     await MultiStepInput.run(input => this.selectInputModel(input, state));
     await MultiStepInput.run(input => this.selectInputSpec(input, state));
   }

--- a/src/Execute/InferenceRunner.ts
+++ b/src/Execute/InferenceRunner.ts
@@ -29,17 +29,19 @@ const logTag = 'InferenceRunner';
 
 class InferenceRunner {
   backend: Backend;
+  executor: Executor;
   modelPath: vscode.Uri;
   inputSpec: string;
 
-  constructor(backend: Backend, modelPath: vscode.Uri, inputSpec: string) {
+  constructor(backend: Backend, executor: Executor, modelPath: vscode.Uri, inputSpec: string) {
     this.backend = backend;
+    this.executor = executor;
     this.modelPath = modelPath;
     this.inputSpec = inputSpec;
   }
 
   getInferenceCmd(): Command {
-    const executor = this.backend.executor() as Executor;
+    const executor = this.executor as Executor;
     return executor.runInference(this.modelPath.path, ['--input-spec', this.inputSpec]);
   }
 

--- a/src/Execute/executeQuickInput.ts
+++ b/src/Execute/executeQuickInput.ts
@@ -30,6 +30,7 @@ export async function runInferenceQuickInput(context: vscode.ExtensionContext): 
   }
 
   const runner = new InferenceRunner(
-      quickInput.getBackend(), quickInput.getModelPath(), quickInput.getInputSpec());
+      quickInput.getBackend(), quickInput.getExecutor(), quickInput.getModelPath(),
+      quickInput.getInputSpec());
   await runner.runInference();
 }

--- a/src/Tests/Backend/Backend.test.ts
+++ b/src/Tests/Backend/Backend.test.ts
@@ -25,6 +25,10 @@ import {gToolchainEnvMap} from '../../Toolchain/ToolchainEnv';
 // TODO: Move it to Mockup
 const backendName = 'Mockup';
 class BackendMockup implements Backend {
+  executor: ExecutorMockup;
+  constructor(executor: ExecutorMockup) {
+    this.executor = executor;
+  }
   name(): string {
     return backendName;
   }
@@ -32,8 +36,8 @@ class BackendMockup implements Backend {
     return new CompilerBase();
   }
 
-  executor(): Executor|undefined {
-    return new ExecutorBase();
+  executors(): Executor[]|undefined {
+    return [this.executor];
   }
 }
 
@@ -52,7 +56,8 @@ suite('Backend', function() {
       assert.strictEqual(Object.entries(globalBackendMap).length, 0);
       assert.strictEqual(globalExecutorArray.length, 0);
 
-      let backend = new BackendMockup();
+      let executor = new ExecutorMockup();
+      let backend = new BackendMockup(executor);
       registrationAPI.registerBackend(backend);
 
       const entries = Object.entries(globalBackendMap);
@@ -63,22 +68,7 @@ suite('Backend', function() {
         assert.deepStrictEqual(value, backend);
       }
       assert.strictEqual(globalExecutorArray.length, 1);
-      for (const executor of globalExecutorArray) {
-        assert.deepStrictEqual(executor, backend.executor());
-      }
-    });
-    test('registers a executor', function() {
-      let registrationAPI = backendRegistrationApi();
-
-      assert.strictEqual(globalExecutorArray.length, 0);
-      let executorMockup = new ExecutorMockup();
-      registrationAPI.registerExecutor(executorMockup);
-
-      assert.strictEqual(globalExecutorArray.length, 1);
-
-      for (const executor of globalExecutorArray) {
-        assert.deepStrictEqual(executor, executorMockup);
-      }
+      assert.strictEqual(globalExecutorArray[0], executor);
     });
   });
 

--- a/src/Tests/Execute/InferenceQuickInput.test.ts
+++ b/src/Tests/Execute/InferenceQuickInput.test.ts
@@ -38,7 +38,7 @@ class BackendMockup implements Backend {
     return new CompilerBase();
   }
 
-  executor(): Executor|undefined {
+  executors(): Executor[]|undefined {
     class MockupExecutor implements Executor {
       name(): string {
         return backendName;
@@ -56,7 +56,7 @@ class BackendMockup implements Backend {
         return new DeviceSpec('MockupHW', 'MockSW', undefined);
       }
     };
-    return new MockupExecutor();
+    return [new MockupExecutor()];
   }
 };
 
@@ -173,6 +173,7 @@ suite('Execute', function() {
       test('gets filter', function() {
         let quickInput = new InferenceQuickInput();
         quickInput.backend = backend;
+        quickInput.executor = (backend.executors() as Executor[])[0];
         const expected = exts;
         let filter = quickInput.getFilter();
         assert.strictEqual(filter.backendName.length, expected.length);


### PR DESCRIPTION
This commit will update `Backend` API to have multiple `Executor`s.
This commit will also update some test for this.

ONE-vscode-DCO-1.0-Signed-off-by: struss <rrstrous@nate.com>