### PR TITLE
[Backend] Add `executors()` API on `Backend`.

### DIFF
--- a/src/Backend/Backend.ts
+++ b/src/Backend/Backend.ts
@@ -38,4 +38,9 @@ export interface Backend {
 
   // executor specs by being filled by impl
   executor(): Executor|undefined;
+
+  // TODO: This API will replace `executor()` and update Comment.
+  // this will return array only contains executor() result.
+  // if `executor()` return undefined, return [].
+  executors(): Executor[];
 }

--- a/src/Tests/Backend/Backend.test.ts
+++ b/src/Tests/Backend/Backend.test.ts
@@ -35,6 +35,13 @@ class BackendMockup implements Backend {
   executor(): Executor|undefined {
     return new ExecutorBase();
   }
+  executors(): Executor[] {
+    const exec = this.executor();
+    if (exec) {
+      return [exec];
+    }
+    return [];
+  }
 }
 
 const executorName = 'Mockup';
@@ -66,6 +73,7 @@ suite('Backend', function() {
       for (const executor of globalExecutorArray) {
         assert.deepStrictEqual(executor, backend.executor());
       }
+      assert.deepStrictEqual(backend.executors(), globalExecutorArray);
     });
     test('registers a executor', function() {
       let registrationAPI = backendRegistrationApi();

--- a/src/Tests/Execute/InferenceQuickInput.test.ts
+++ b/src/Tests/Execute/InferenceQuickInput.test.ts
@@ -21,7 +21,7 @@ import {backendRegistrationApi, globalBackendMap} from '../../Backend/API';
 import {Backend} from '../../Backend/Backend';
 import {Command} from '../../Backend/Command';
 import {Compiler, CompilerBase} from '../../Backend/Compiler';
-import {Executor, ExecutorBase} from '../../Backend/Executor';
+import {Executor} from '../../Backend/Executor';
 import {DeviceSpec} from '../../Backend/Spec';
 import {Toolchains} from '../../Backend/Toolchain';
 import {InferenceQuickInput} from '../../Execute/InferenceQuickInput';
@@ -57,6 +57,13 @@ class BackendMockup implements Backend {
       }
     };
     return new MockupExecutor();
+  }
+  executors(): Executor[] {
+    const exec = this.executor();
+    if (exec) {
+      return [exec];
+    }
+    return [];
   }
 };
 

--- a/src/Tests/Execute/InferenceRunner.test.ts
+++ b/src/Tests/Execute/InferenceRunner.test.ts
@@ -21,7 +21,7 @@ import {backendRegistrationApi, globalBackendMap} from '../../Backend/API';
 import {Backend} from '../../Backend/Backend';
 import {Command} from '../../Backend/Command';
 import {Compiler, CompilerBase} from '../../Backend/Compiler';
-import {Executor, ExecutorBase} from '../../Backend/Executor';
+import {Executor} from '../../Backend/Executor';
 import {DeviceSpec} from '../../Backend/Spec';
 import {Toolchains} from '../../Backend/Toolchain';
 import {InferenceRunner} from '../../Execute/InferenceRunner';
@@ -59,6 +59,13 @@ class BackendMockup implements Backend {
       }
     };
     return new MockupExecutor();
+  }
+  executors(): Executor[] {
+    const exec = this.executor();
+    if (exec) {
+      return [exec];
+    }
+    return [];
   }
 };
 


### PR DESCRIPTION
For [#1094 ](https://github.com/Samsung/ONE-vscode/pull/1094#discussion_r928561673)

This commit will add `executors()` on `Backend`.

ONE-vscode-DCO-1.0-Signed-off-by: struss <rrstrous@nate.com>
