### PR TITLE
Refresh toolchain View after backend registraion

### DIFF
--- a/src/Backend/API.ts
+++ b/src/Backend/API.ts
@@ -50,6 +50,9 @@ function backendRegistrationApi() {
         globalExecutorArray.push(executor);
       }
       Logger.info(logTag, 'Backend', backendName, 'was registered into ONE-vscode.');
+      // NOTE: This might not 100% guaratee the activating extension has been done.
+      //   - link: https://github.com/Samsung/ONE-vscode/pull/1101#issuecomment-1195099002
+      // TODO: Consider better way to refresh toolchainView after backend's registration.
       vscode.commands.executeCommand('one.toolchain.refresh');
     },
     registerExecutor(executor: Executor) {

--- a/src/Backend/API.ts
+++ b/src/Backend/API.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as vscode from 'vscode';
 const assert = require('assert');
 import {Backend} from './Backend';
 import {gToolchainEnvMap, ToolchainEnv} from '../Toolchain/ToolchainEnv';
@@ -49,6 +50,7 @@ function backendRegistrationApi() {
         globalExecutorArray.push(executor);
       }
       Logger.info(logTag, 'Backend', backendName, 'was registered into ONE-vscode.');
+      vscode.commands.executeCommand('one.toolchain.refresh');
     },
     registerExecutor(executor: Executor) {
       globalExecutorArray.push(executor);


### PR DESCRIPTION
This commit refreshes toolchainView after backend registraion to prevent
showing empty toolchainView tree.

ONE-vscode-DCO-1.0-Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>

---

This will resolve `ONE-vscode` extension and backend extension timing issue. (from https://github.com/Samsung/ONE-vscode/issues/932#issuecomment-1182658014) 