### PR TITLE
[OneExplorer] Introduce hide command and button

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,18 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "one.explorer.hideExtra",
+        "title": "Hide Extra Files",
+        "category": "ONE",
+        "icon": "$(eye)"
+      },
+      {
+        "command": "one.explorer.unhideExtra",
+        "title": "Unhide Extra Files",
+        "category": "ONE",
+        "icon": "$(eye-closed)"
+      },
+      {
         "command": "one.explorer.createCfg",
         "title": "Create new ONE configuration",
         "category": "ONE",
@@ -193,7 +205,17 @@
         {
           "command": "one.explorer.refresh",
           "when": "view == OneExplorerView",
-          "group": "navigation"
+          "group": "navigation@0"
+        },
+        {
+          "command": "one.explorer.hideExtra",
+          "when": "view == OneExplorerView && !one.explorer:didHideExtra",
+          "group": "navigation@1"
+        },
+        {
+          "command": "one.explorer.unhideExtra",
+          "when": "view == OneExplorerView && one.explorer:didHideExtra",
+          "group": "navigation@1"
         },
         {
           "command": "one.toolchain.refresh",
@@ -319,6 +341,14 @@
         },
         {
           "command": "one.explorer.openAsText",
+          "when": "false"
+        },
+        {
+          "command": "one.explorer.hideExtra",
+          "when": "false"
+        },
+        {
+          "command": "one.explorer.unhideExtra",
           "when": "false"
         },
         {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
         "icon": "$(eye)"
       },
       {
-        "command": "one.explorer.unhideExtra",
+        "command": "one.explorer.showExtra",
         "title": "Unhide Extra Files",
         "category": "ONE",
         "icon": "$(eye-closed)"
@@ -213,7 +213,7 @@
           "group": "navigation@1"
         },
         {
-          "command": "one.explorer.unhideExtra",
+          "command": "one.explorer.showExtra",
           "when": "view == OneExplorerView && one.explorer:didHideExtra",
           "group": "navigation@1"
         },
@@ -348,7 +348,7 @@
           "when": "false"
         },
         {
-          "command": "one.explorer.unhideExtra",
+          "command": "one.explorer.showExtra",
           "when": "false"
         },
         {

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -408,7 +408,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
     this.refresh();
   }
 
-  unhideExtra(): void {
+  showExtra(): void {
     this.didHideExtra = false;
 
     vscode.commands.executeCommand('setContext', 'one.explorer:didHideExtra', this.didHideExtra);
@@ -681,7 +681,7 @@ export function initOneExplorer(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
         'one.explorer.hideExtra', () => oneTreeDataProvider.hideExtra()),
     vscode.commands.registerCommand(
-        'one.explorer.unhideExtra', () => oneTreeDataProvider.unhideExtra()),
+        'one.explorer.showExtra', () => oneTreeDataProvider.showExtra()),
     vscode.commands.registerCommand(
         'one.explorer.createCfg', (oneNode: OneNode) => oneTreeDataProvider.createCfg(oneNode)),
     vscode.commands.registerCommand(


### PR DESCRIPTION
This commit introduce hide command and button.
The nodes with canHide set as true are going to be hiden and unhiden by the toggle button

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>

-----

For #1061