### PR TITLE
[Toolchain] Add no available version message to install quick input

### DIFF
--- a/src/View/InstallQuickInput.ts
+++ b/src/View/InstallQuickInput.ts
@@ -239,11 +239,16 @@ class InstallQuickInput {
     const versionGroups = this.getQuickPickItems(versions);
     const updateButton = new InnerButton(new vscode.ThemeIcon('refresh'), 'Update version list');
 
+    let placeholder = 'Pick toolchain version';
+    if (versions.length === 0) {
+      placeholder = 'No available toolchain version';
+    }
+
     state.selectedItem = await input.showQuickPick({
       title: this.title,
       step: InstallQuickInputStep.pickVersion,
       totalSteps: InstallQuickInputStep.pickVersion,
-      placeholder: 'Pick toolchain version',
+      placeholder: placeholder,
       items: versionGroups,
       buttons: [updateButton],
       shouldResume: shouldResume


### PR DESCRIPTION
This commit adds `No available toolchain version` message when there is
no available toolchain to install.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related PR: #1088 