### PR TITLE
[Mondrian] Add on-click side panel with allocation info

### DIFF
--- a/media/Mondrian/mondrianViewer.js
+++ b/media/Mondrian/mondrianViewer.js
@@ -29,6 +29,7 @@ const segmentSelect = /** @type {HTMLElement} */ document.querySelector('.mondri
 const viewerHScale = /** @type {HTMLElement} */ document.querySelector('.mondrian-viewer-h-scale');
 const viewerVScale = /** @type {HTMLElement} */ document.querySelector('.mondrian-viewer-v-scale');
 const scrollbarBtn = /** @type {HTMLElement} */ document.querySelector('.mondrian-scrollbar-btn');
+const sidePanel = /** @type {HTMLElement} */ document.querySelector('.mondrian-sidepanel');
 
 /* Limit cycle range to avoid hang-ups for large models */
 const defaultCycleLimit = 1048576;
@@ -289,13 +290,24 @@ function updateViewport(data, viewer) {
     box.style.left = (alloc.alive_from / viewport.cycles * 100) + '%';
     box.style.right = ((viewport.cycles - alloc.alive_till) / viewport.cycles * 100) + '%';
     box.style.backgroundColor = boxColors[i % boxColors.length];
-    box.addEventListener('mouseover', (event) => {
+    box.addEventListener('mouseover', () => {
       statusLineContainer.innerHTML = `<b>Origin:</b> ${
           alloc.origin.length > 32 ? alloc.origin.substring(0, 32) + '…' : alloc.origin}
           | <b>Size:</b> ${alloc.size}
           | <b>Offset:</b> ${alloc.offset}
           | <b>Lifetime:</b> ${alloc.alive_from} → ${alloc.alive_till} (${
           alloc.alive_till - alloc.alive_from})`;
+    });
+    box.addEventListener('click', (e) => {
+      sidePanel.classList.add('mondrian-sidepanel-enabled');
+      document.querySelector('.mondrian-sidepanel-origin').value = alloc.origin;
+      document.querySelector('.mondrian-sidepanel-size').value = alloc.size;
+      document.querySelector('.mondrian-sidepanel-offset').value = alloc.offset;
+      document.querySelector('.mondrian-sidepanel-allocated').value = alloc.alive_from;
+      document.querySelector('.mondrian-sidepanel-freed').value = alloc.alive_till;
+      document.querySelector('.mondrian-sidepanel-lifetime').value =
+          alloc.alive_till - alloc.alive_from;
+      e.stopPropagation();
     });
     viewerContainer.appendChild(box);
   }
@@ -351,6 +363,10 @@ const state = vscode.getState();
 if (state) {
   updateContent(state.data, state.viewer);
 }
+
+viewerContainer.parentElement.addEventListener('click', () => {
+  sidePanel.classList.remove('mondrian-sidepanel-enabled');
+});
 
 viewerVScale.children[0].addEventListener('click', () => {
   changeScale(0, 0.5);

--- a/media/Mondrian/style.css
+++ b/media/Mondrian/style.css
@@ -175,6 +175,16 @@ div.mondrian-sidepanel.mondrian-sidepanel-enabled {
   align-content: start;
 }
 
+div.mondrian-sidepanel vscode-text-area::part(label),
+div.mondrian-sidepanel vscode-text-field::part(label) {
+  cursor: auto;
+}
+
+div.mondrian-sidepanel vscode-text-area::part(control),
+div.mondrian-sidepanel vscode-text-field::part(control) {
+  cursor: text;
+}
+
 vscode-text-area.mondrian-sidepanel-origin {
   grid-column: 1 / span 2;
 }

--- a/media/Mondrian/style.css
+++ b/media/Mondrian/style.css
@@ -15,13 +15,15 @@
  */
 
 div.mondrian-layout {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  grid-template-rows: max-content 1fr max-content;
+  grid-gap: 4px;
   height: calc(100vh - 20px);
 }
 
 div.mondrian-scrollbar {
+  grid-column: 1 / span 2;
   background-color: rgba(96, 96, 96, 0.2);
   min-height: 36px;
   flex: 0;
@@ -141,7 +143,7 @@ div.mondrian-viewer-bounds-no-label div.mondrian-allocation-label {
 }
 
 div.mondrian-statusbar {
-  flex: 0;
+  grid-column: 1 / span 2;
   display: flex;
   align-items: center;
 }
@@ -158,4 +160,25 @@ div.mondrian-info {
   display: flex;
   align-items: center;
   gap: 4px;
+}
+
+div.mondrian-sidepanel {
+  overflow-y: auto;
+  padding: 0px 8px;
+  display: none;
+}
+
+div.mondrian-sidepanel.mondrian-sidepanel-enabled {
+  display: grid;
+  grid-gap: 4px 8px;
+  grid-template-columns: 1fr 1fr;
+  align-content: start;
+}
+
+vscode-text-area.mondrian-sidepanel-origin {
+  grid-column: 1 / span 2;
+}
+
+vscode-text-field.mondrian-sidepanel-lifetime {
+  grid-column: 1 / span 2;
 }

--- a/src/Mondrian/MondrianEditor.ts
+++ b/src/Mondrian/MondrianEditor.ts
@@ -94,6 +94,16 @@ export class MondrianEditorProvider implements vscode.CustomTextEditorProvider {
           <div class="mondrian-viewer-area">
             <div class="mondrian-viewer-bounds"></div>
           </div>
+          <div class="mondrian-sidepanel">
+            <vscode-text-area resize="vertical" rows="5" class="mondrian-sidepanel-origin" readonly>
+              Origin
+            </vscode-text-area>
+            <vscode-text-field class="mondrian-sidepanel-size" readonly>Size</vscode-text-field>
+            <vscode-text-field class="mondrian-sidepanel-offset" readonly>Offset</vscode-text-field>
+            <vscode-text-field class="mondrian-sidepanel-allocated" readonly>Allocated</vscode-text-field>
+            <vscode-text-field class="mondrian-sidepanel-freed" readonly>Freed</vscode-text-field>
+            <vscode-text-field class="mondrian-sidepanel-lifetime" readonly>Lifetime</vscode-text-field>
+          </div>
           <div class="mondrian-statusbar">
             <div class="mondrian-statusline"></div>
             <div class="mondrian-info">


### PR DESCRIPTION
This commit introduces on-click side panel UI, which can show longer origin names using resizable text area and provide means to select and copy allocation info. Side panels hides automatically when user clicks on empty area in memory viewer.

![20220727_sidepanel](https://user-images.githubusercontent.com/67966333/181274980-79968655-b5bb-4cea-963a-d7cdbc9683b8.png)

ONE-vscode-DCO-1.0-Signed-off-by: Alexander Moiseev <a.moiseev@samsung.com>