### PR TITLE
Change `obtainWorkspaceRoot` log to debug log

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -619,6 +619,7 @@ export function initOneExplorer(context: vscode.ExtensionContext) {
   let workspaceRoot: vscode.Uri|undefined = undefined;
   try {
     workspaceRoot = vscode.Uri.file(obtainWorkspaceRoot());
+    Logger.info('OneExplorer', `workspace: ${workspaceRoot.fsPath}`);
   } catch (e: unknown) {
     if (e instanceof Error) {
       if (e.message === 'Need workspace') {

--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -90,7 +90,7 @@ export function obtainWorkspaceRoot(): string {
     // TODO revise message
     throw new Error('Need workspace');
   }
-  Logger.info(logTag, 'obtainWorkspaceRoot:', workspaceRoot);
+  Logger.debug(logTag, 'obtainWorkspaceRoot:', workspaceRoot);
 
   return workspaceRoot;
 }


### PR DESCRIPTION
Currently `obtainWorkspaceRoot` log is `info` log and we see this log too much.
Let's change this log to debug log.

Also, let's log workspace info once when One Explorer View is initialized.

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>