### PR TITLE
[PartEditor] Exclude UI related codes from coverage analysis

### DIFF
--- a/src/PartEditor/PartEditor.ts
+++ b/src/PartEditor/PartEditor.ts
@@ -40,6 +40,7 @@ export interface PartEditorEvent {
   onEditorDispose(e: PartEditor): void;
 }
 
+/* istanbul ignore next */
 class PartEditor implements PartGraphEvent {
   private _document: vscode.TextDocument;
   private _panel: vscode.WebviewPanel;
@@ -355,6 +356,7 @@ class PartEditor implements PartGraphEvent {
   }
 }
 
+/* istanbul ignore next */
 export class PartEditorProvider implements vscode.CustomTextEditorProvider, PartEditorEvent {
   public static readonly viewType = 'onevscode.part-editor';
   public static readonly folderMediaPartEditor = 'media/PartEditor';

--- a/src/PartEditor/PartGraphSelector.ts
+++ b/src/PartEditor/PartGraphSelector.ts
@@ -46,6 +46,7 @@ export type PartGraphCmdCloseArgs = {
   docPath: string, id: number;
 };
 
+/* istanbul ignore next */
 export class PartGraphSelPanel extends CircleGraphCtrl implements CircleGraphEvent {
   public static readonly viewType = 'PartGraphSelector';
   public static readonly cmdOpen = 'one.part.openGraphSelector';


### PR DESCRIPTION
UI related codes are hard to be managed about to code quality.
This commit excludes them.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>