### PR TITLE
[CfgEditor] Fix resolveDeprecated function with negative TC

### DIFF
--- a/src/CfgEditor/CfgData.ts
+++ b/src/CfgEditor/CfgData.ts
@@ -61,13 +61,16 @@ export class CfgData {
     this.resolveDeprecated();
   }
 
-  resolveDeprecated(): void {
+  private resolveDeprecated(): void {
     // NOTE 'one-build' will be deprecated.
     //      Therefore, when only 'one-build' is used, it will be replaced to 'onecc'.
-    if (this._oneConfig['onecc'] === undefined && this._oneConfig['one-build'] !== undefined) {
-      this._oneConfig['onecc'] = ini.parse(ini.stringify(this._oneConfig['one-build']));
+    if (this._oneConfig['one-build'] !== undefined) {
+      if (this._oneConfig['onecc'] === undefined) {
+        this._oneConfig['onecc'] = ini.parse(ini.stringify(this._oneConfig['one-build']));
+      }
       delete this._oneConfig['one-build'];
     }
+
     // NOTE 'input_dtype' is deprecated.
     //      Therefore, when only 'input_dtype' is used, it will be replaced to 'onecc'.
     if (this._oneConfig['one-quantize']?.['input_dtype'] !== undefined) {


### PR DESCRIPTION
Behavior of `resolveDeprecated` function was different for `one-build` and `input_dtype`.
This commit fixes the error with negative TCs.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>