### PR TITLE
[Backend] Add dummy CompilerBase unit tests

### DIFF
--- a/src/Tests/Backend/Compiler.test.ts
+++ b/src/Tests/Backend/Compiler.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {assert} from 'chai';
+import {CompilerBase} from '../../Backend/Compiler';
+
+suite('Backend', function() {
+  suite('CompilerBase', function() {
+    suite('#contructor()', function() {
+      test('Create dummy compiler', function(pass) {
+        const compiler = new CompilerBase();
+
+        pass();
+      });
+    });
+
+    suite('#getInstalledToolchains()', function() {
+      test('NEG: throws by dummy compiler base', function() {
+        const compiler = new CompilerBase();
+        assert.throw(() => compiler.getInstalledToolchains(''));
+      });
+    });
+
+    suite('#getToolchainTypes()', function() {
+      test('NEG: throws by dummy compiler base', function() {
+        const compiler = new CompilerBase();
+        assert.throw(() => compiler.getToolchainTypes());
+      });
+    });
+
+    suite('#getToolchains()', function() {
+      test('NEG: throws by dummy compiler base', function() {
+        const compiler = new CompilerBase();
+        assert.throw(() => compiler.getToolchains('', 0, 0));
+      });
+    });
+
+    suite('#prerequisitesForGetToolchains()', function() {
+      test('NEG: throws by dummy compiler base', function() {
+        const compiler = new CompilerBase();
+        assert.throw(() => compiler.prerequisitesForGetToolchains());
+      });
+    });
+  });
+});


### PR DESCRIPTION
This cocmmit adds dummy CompilerBase unit tests.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>