### PR TITLE
[Backend] Add dummy ExecutorBase unit tests

### DIFF
--- a/src/Tests/Backend/Executor.test.ts
+++ b/src/Tests/Backend/Executor.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {assert} from 'chai';
+import {ExecutorBase} from '../../Backend/Executor';
+
+suite('Backend', function() {
+  suite('ExecutorBase', function() {
+    suite('#contructor()', function() {
+      test('Create dummy executor', function(pass) {
+        const executor = new ExecutorBase();
+
+        pass();
+      });
+    });
+
+    suite('#name()', function() {
+      test('NEG: throws by dummy executor base', function() {
+        const executor = new ExecutorBase();
+        assert.throw(() => executor.name());
+      });
+    });
+
+    suite('#getExecutableExt()', function() {
+      test('NEG: throws by dummy executor base', function() {
+        const executor = new ExecutorBase();
+        assert.throw(() => executor.getExecutableExt());
+      });
+    });
+
+    suite('#require()', function() {
+      test('NEG: throws by dummy executor base', function() {
+        const executor = new ExecutorBase();
+        assert.throw(() => executor.require());
+      });
+    });
+
+    suite('#runInference()', function() {
+      test('NEG: throws by dummy executor base', function() {
+        const executor = new ExecutorBase();
+        assert.throw(() => executor.runInference(''));
+      });
+    });
+
+    suite('#toolchains()', function() {
+      test('NEG: throws by dummy executor base', function() {
+        const executor = new ExecutorBase();
+        assert.throw(() => executor.toolchains());
+      });
+    });
+  });
+});


### PR DESCRIPTION
This commit adds dummy ExecutorBase unit tests.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>