### PR TITLE
Revise Utils with more unittest cases

### DIFF
--- a/src/Tests/Utils/Logger.test.ts
+++ b/src/Tests/Utils/Logger.test.ts
@@ -16,7 +16,7 @@
 
 import {assert} from 'chai';
 
-import {_UT_logStr} from '../../Utils/Logger';
+import {_unit_test_logStr} from '../../Utils/Logger';
 
 suite('Utils', function() {
   suite('Logger', function() {
@@ -25,9 +25,9 @@ suite('Utils', function() {
         // One message
         {
           const severity = 'info';
-          const tag = 'ut_teset';
+          const tag = 'unit_test';
           const msg = 'one_message';
-          const actual = _UT_logStr(severity, tag, msg);
+          const actual = _unit_test_logStr(severity, tag, msg);
           assert.isTrue(actual.includes(`[${severity}]`));
           assert.isTrue(actual.includes(`[${tag}]`));
           assert.isTrue(actual.endsWith(msg));
@@ -35,10 +35,10 @@ suite('Utils', function() {
         {
           // two msgs
           const severity = 'info';
-          const tag = 'ut_teset';
+          const tag = 'unit_test';
           const msg1 = 'one_message';
           const msg2 = 'two_message';
-          const actual = _UT_logStr(severity, tag, msg1, msg2);
+          const actual = _unit_test_logStr(severity, tag, msg1, msg2);
           assert.isTrue(actual.includes(`[${severity}]`));
           assert.isTrue(actual.includes(`[${tag}]`));
           assert.isTrue(actual.endsWith(`${msg1} ${msg2}`));
@@ -50,14 +50,14 @@ suite('Utils', function() {
             }
           }
           const severity = 'info';
-          const tag = 'ut_teset';
+          const tag = 'unit_test';
           const msg1 = 'one_message';
           const msg2 = 1234;
           const msg3 = new Foo(10);
           const msg4 = new RangeError('exceed!');
-          const actual = _UT_logStr(severity, tag, msg1, msg2, msg3, msg4);
+          const actual = _unit_test_logStr(severity, tag, msg1, msg2, msg3, msg4);
           /*
-          [8/3/2022, 12:29:23 PM][ut_teset][info] one_message 1234
+          [8/3/2022, 12:29:23 PM][unit_test][info] one_message 1234
           Foo: {"bar":10}
           Error was thrown:
           - name: Error
@@ -76,8 +76,8 @@ suite('Utils', function() {
 
       test('NEG: no msg', function() {
         const severity = 'info';
-        const tag = 'ut_teset';
-        const actual = _UT_logStr(severity, tag);
+        const tag = 'unit_test';
+        const actual = _unit_test_logStr(severity, tag);
         assert.equal(actual, '');
       });
     });

--- a/src/Tests/Utils/Logger.test.ts
+++ b/src/Tests/Utils/Logger.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {assert} from 'chai';
+
+import {_UT_logStr} from '../../Utils/Logger';
+
+suite('Utils', function() {
+  suite('Logger', function() {
+    suite('#__logStr', function() {
+      test('normal', function() {
+        // One message
+        {
+          const severity = 'info';
+          const tag = 'ut_teset';
+          const msg = 'one_message';
+          const actual = _UT_logStr(severity, tag, msg);
+          assert.isTrue(actual.includes(`[${severity}]`));
+          assert.isTrue(actual.includes(`[${tag}]`));
+          assert.isTrue(actual.endsWith(msg));
+        }
+        {
+          // two msgs
+          const severity = 'info';
+          const tag = 'ut_teset';
+          const msg1 = 'one_message';
+          const msg2 = 'two_message';
+          const actual = _UT_logStr(severity, tag, msg1, msg2);
+          assert.isTrue(actual.includes(`[${severity}]`));
+          assert.isTrue(actual.includes(`[${tag}]`));
+          assert.isTrue(actual.endsWith(`${msg1} ${msg2}`));
+        }
+        {
+          // multiple msgs with number
+          class Foo {
+            constructor(public bar: number) { /* empty */
+            }
+          }
+          const severity = 'info';
+          const tag = 'ut_teset';
+          const msg1 = 'one_message';
+          const msg2 = 1234;
+          const msg3 = new Foo(10);
+          const msg4 = new RangeError('exceed!');
+          const actual = _UT_logStr(severity, tag, msg1, msg2, msg3, msg4);
+          /*
+          [8/3/2022, 12:29:23 PM][ut_teset][info] one_message 1234
+          Foo: {"bar":10}
+          Error was thrown:
+          - name: Error
+          - message: one_error
+          */
+          assert.isTrue(actual.includes(`[${severity}]`));
+          assert.isTrue(actual.includes(`[${tag}]`));
+          assert.isTrue(actual.includes(`${msg1}`));
+          assert.isTrue(actual.includes(`${msg2}`));
+          assert.isTrue(actual.includes(`Foo`));
+          assert.isTrue(actual.includes(`"bar":10`));
+          assert.isTrue(actual.includes(`RangeError`));
+          assert.isTrue(actual.includes(`exceed!`));
+        }
+      });
+
+      test('NEG: no msg', function() {
+        const severity = 'info';
+        const tag = 'ut_teset';
+        const actual = _UT_logStr(severity, tag);
+        assert.equal(actual, '');
+      });
+    });
+  });
+});

--- a/src/Utils/Balloon.ts
+++ b/src/Utils/Balloon.ts
@@ -18,6 +18,7 @@ import * as vscode from 'vscode';
 
 import {Logger} from './Logger';
 
+/* istanbul ignore next */
 export class Balloon {
   static seeLogBtn = 'See log';
 

--- a/src/Utils/Logger.ts
+++ b/src/Utils/Logger.ts
@@ -41,7 +41,6 @@ function _logStr(severity: string, tag: string, ...msgs: MsgList) {
   }
 
   for (let m of msgs) {
-    // ref: https://stackoverflow.com/q/5612787
     if (m instanceof Error) {
       const err = m as Error;
       logStrList.push(`\nError was thrown:\n- name: ${err.name}\n- message: ${err.message}`);
@@ -57,7 +56,7 @@ function _logStr(severity: string, tag: string, ...msgs: MsgList) {
   return `[${time}][${tag}][${severity}] ${msg}`;
 }
 
-// Import this only for UT
+// Import this only for unit test
 export {_logStr as _unit_test_logStr};
 
 /* istanbul ignore next */

--- a/src/Utils/Logger.ts
+++ b/src/Utils/Logger.ts
@@ -58,7 +58,7 @@ function _logStr(severity: string, tag: string, ...msgs: MsgList) {
 }
 
 // Import this only for UT
-export {_logStr as _UT_logStr};
+export {_logStr as _unit_test_logStr};
 
 /* istanbul ignore next */
 export class Logger {

--- a/src/Utils/MultiStepInput.ts
+++ b/src/Utils/MultiStepInput.ts
@@ -23,6 +23,7 @@ https://github.com/microsoft/vscode-extension-samples/blob/2556c82cb333cf65d372b
 */
 import {Disposable, QuickInput, QuickInputButton, QuickInputButtons, QuickPickItem, window} from 'vscode';
 
+/* istanbul ignore next */
 class InputFlowAction {
   static back = new InputFlowAction();
   static cancel = new InputFlowAction();
@@ -31,6 +32,7 @@ class InputFlowAction {
 
 type InputStep = (input: MultiStepInput) => Thenable<InputStep|void>;
 
+/* istanbul ignore next */
 interface QuickPickParameters<T extends QuickPickItem> {
   title: string;
   step: number;
@@ -42,6 +44,7 @@ interface QuickPickParameters<T extends QuickPickItem> {
   shouldResume: () => Thenable<boolean>;
 }
 
+/* istanbul ignore next */
 interface InputBoxParameters {
   title: string;
   step: number;
@@ -54,6 +57,7 @@ interface InputBoxParameters {
   shouldResume: () => Thenable<boolean>;
 }
 
+/* istanbul ignore next */
 class MultiStepInput {
   static async run<T>(start: InputStep) {
     const input = new MultiStepInput();

--- a/src/Utils/MultiStepInput.ts
+++ b/src/Utils/MultiStepInput.ts
@@ -32,7 +32,6 @@ class InputFlowAction {
 
 type InputStep = (input: MultiStepInput) => Thenable<InputStep|void>;
 
-/* istanbul ignore next */
 interface QuickPickParameters<T extends QuickPickItem> {
   title: string;
   step: number;
@@ -44,7 +43,6 @@ interface QuickPickParameters<T extends QuickPickItem> {
   shouldResume: () => Thenable<boolean>;
 }
 
-/* istanbul ignore next */
 interface InputBoxParameters {
   title: string;
   step: number;


### PR DESCRIPTION
This adds unit tests for 'Utils' and put `/* istanbul ignore next */` for GUI related code.

While adding unit tests, I found two more things and fixed them:
1. Logger needs to be enhanced for handing `Error` input and `object` input.
2. Extract `_logStr()` function for unit test.

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>