### PR TITLE
[Job] Add context related to job running status

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,8 @@
         "command": "one.toolchain.install",
         "title": "Toolchain Install",
         "category": "ONE",
-        "icon": "$(add)"
+        "icon": "$(add)",
+        "enablement": "!one.job:running"
       },
       {
         "command": "one.toolchain.uninstall",
@@ -210,7 +211,7 @@
         },
         {
           "command": "one.toolchain.install",
-          "when": "view == ToolchainView",
+          "when": "view == ToolchainView && !one.job:running",
           "group": "navigation"
         },
         {
@@ -257,12 +258,12 @@
         },
         {
           "command": "one.toolchain.setDefaultToolchain",
-          "when": "view == ToolchainView && viewItem == toolchain",
+          "when": "view == ToolchainView && viewItem == toolchain && !one.job:running",
           "group": "inline"
         },
         {
           "command": "one.toolchain.uninstall",
-          "when": "view == ToolchainView && viewItem =~ /toolchain/",
+          "when": "view == ToolchainView && viewItem =~ /toolchain/ && !one.job:running",
           "group": "inline"
         }
       ],

--- a/src/Job/JobRunner.ts
+++ b/src/Job/JobRunner.ts
@@ -38,6 +38,7 @@ export class JobRunner extends EventEmitter {
 
   constructor() {
     super();
+    vscode.commands.executeCommand('setContext', 'one.job:running', this.running);
     this.toolRunner = new ToolRunner();
 
     this.on(K_INVOKE, this.onInvoke);
@@ -93,6 +94,7 @@ export class JobRunner extends EventEmitter {
 
   private onCleanup() {
     this.running = false;
+    vscode.commands.executeCommand('setContext', 'one.job:running', this.running);
     process.env.userp = '';
   }
 
@@ -133,6 +135,7 @@ export class JobRunner extends EventEmitter {
         });
 
     this.running = true;
+    vscode.commands.executeCommand('setContext', 'one.job:running', this.running);
     this.jobs = jobs;
     this.emit(K_INVOKE);
   }


### PR DESCRIPTION
This commit add `when clause context` related to job running status.
This context shows and hides toolchain related buttons and command.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>