### PR TITLE
[Job] Use logger instead of Balloon

### DIFF
--- a/src/Job/JobRunner.ts
+++ b/src/Job/JobRunner.ts
@@ -17,7 +17,6 @@
 import {EventEmitter} from 'events';
 import * as vscode from 'vscode';
 
-import {Balloon} from '../Utils/Balloon';
 import {Logger} from '../Utils/Logger';
 
 import {Job} from './Job';
@@ -61,7 +60,7 @@ export class JobRunner extends EventEmitter {
     runner
         .then((value) => {
           if (value.intentionallyKilled) {
-            Balloon.info('The job was cancelled.');
+            Logger.info(this.tag, 'The job was cancelled.');
             this.emit(K_CLEANUP);
             return;
           }
@@ -76,7 +75,7 @@ export class JobRunner extends EventEmitter {
           if (failure !== undefined) {
             failure();
           }
-          Balloon.error('Running ONE failed');
+          Logger.error(this.tag, 'The job was failed.');
           this.emit(K_CLEANUP);
         });
   }
@@ -84,7 +83,7 @@ export class JobRunner extends EventEmitter {
   private onInvoke() {
     let job = this.jobs.shift();
     if (job === undefined) {
-      Logger.info(this.tag, 'Finish Running ONE compilers.');
+      Logger.info(this.tag, 'All jobs have been completed.');
       this.emit(K_CLEANUP);
       return;
     }
@@ -99,7 +98,7 @@ export class JobRunner extends EventEmitter {
   public start(jobs: WorkJobs) {
     // TODO maybe there is better way to handle already running jobs
     if (this.running) {
-      Balloon.error('ONE compile in progress');
+      Logger.error(this.tag, 'The job is in progress.');
       return;
     }
 


### PR DESCRIPTION
This commit uses logger instead of Balloon.
The information messages depend on the requested job.
So it is better to handle the message where it is requested.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>