### PR TITLE
[Jsontracer] Exclude UI related codes from coverage analysis

### DIFF
--- a/src/Jsontracer.ts
+++ b/src/Jsontracer.ts
@@ -20,6 +20,7 @@ import * as vscode from 'vscode';
 import {getWebviewOptions} from './Jsontracer/GetWebviewOptions';
 import {getNonce} from './Utils/external/Nonce';
 
+/* istanbul ignore next */
 export class Jsontracer {
   /**
    * Track the current panel. Only allow a single panel to exist at a time.

--- a/src/Jsontracer/GetWebviewOptions.ts
+++ b/src/Jsontracer/GetWebviewOptions.ts
@@ -16,6 +16,7 @@
 
 import * as vscode from 'vscode';
 
+/* istanbul ignore next */
 export function getWebviewOptions(extensionUri: vscode.Uri): vscode.WebviewOptions {
   return {
     // Enable javascript in the webview


### PR DESCRIPTION
UI related codes are hard to be managed about to code quality.
This commit excludes them.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>