### PR TITLE
[Profile] Introduce JsonTracer as CustomTextEditorProvider

### DIFF
--- a/media/Jsontracer/index.js
+++ b/media/Jsontracer/index.js
@@ -46,7 +46,7 @@
 // https://github.com/catapult-project/catapult/tree/444aba89e1c30edf348c611a9df79e2376178ba8/tracing
 
 import dynamicGraduation from './dynamicGraduation.js';
-import openFileSelector from './processData.js';
+import {openFileSelector,processText} from './processData.js';
 
 const graph = document.querySelector('.graph');
 const sliderMaxLimit = 6400;
@@ -161,3 +161,30 @@ function initData() {
     detail.remove();
   }
 }
+
+// Handle messages sent from the extension to the webview
+window.addEventListener('message', event => {
+  const message = event.data;  // The json data that the extension sent
+  switch (message.type) {
+    case 'update': {
+      const data = parseText(message.text);
+      if (!data) {
+        return;
+      }
+
+      console.log("processingText");
+      processText(data);
+
+      // const viewer = new Viewer();
+
+      // // Update our webview's content
+      // updateContent(data, viewer);
+
+      // // Persist state information.
+      // // This state is returned in the call to `vscode.getState` below when a webview is reloaded.
+      // vscode.setState({data, viewer});
+
+      return;
+    }
+  }
+});

--- a/media/Jsontracer/processData.js
+++ b/media/Jsontracer/processData.js
@@ -66,6 +66,15 @@ function setFileName(name) {
   fileName.innerText = name;
 }
 
+export function processText(text) {
+  console.log("processText");
+  const data = JSON.parse(text);
+  processData(data.traceEvents);
+
+  // set data to DOM
+  setData.dataset['displayTimeUnit'] = data.displayTimeUnit;
+}
+
 function processFile(file) {
   const reader = new FileReader();
   reader.onload = () => {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,17 @@
         "priority": "default"
       },
       {
+        "viewType": "one.view.chromeTrace",
+        "displayName": "chromeTrace",
+        "selector": [
+          {
+            "filenamePattern": "*.trace.json"
+          }
+        ],
+        "priority": "default"
+
+      },
+      {
         "viewType": "onevscode.part-editor",
         "displayName": "ONE Partition Editor",
         "selector": [
@@ -321,10 +332,6 @@
         },
         {
           "command": "one.toolchain.runCfg",
-          "when": "false"
-        },
-        {
-          "command": "one.viewer.jsonTracer",
           "when": "false"
         }
       ]

--- a/src/JsonTracerViewer.ts
+++ b/src/JsonTracerViewer.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+
+import {getNonce} from './Utils/external/Nonce';
+
+
+/**
+ * - Setting up the initial webview for a custom editor.
+ * - Loading scripts and styles in a custom editor.
+ * - Synchronizing changes between a text document and a custom editor.
+ */
+export class ChromeTraceViewerProvider implements vscode.CustomTextEditorProvider {
+  public static register(context: vscode.ExtensionContext): vscode.Disposable {
+    const provider = new ChromeTraceViewerProvider(context);
+    const providerRegistration =
+        vscode.window.registerCustomEditorProvider(ChromeTraceViewerProvider.viewType, provider);
+    return providerRegistration;
+  }
+
+  private static readonly viewType = 'one.view.chromeTrace';
+
+  constructor(private readonly context: vscode.ExtensionContext) {}
+
+  /**
+   * Called when our custom editor is opened.
+   *
+   *
+   */
+  public async resolveCustomTextEditor(
+      document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel,
+      _token: vscode.CancellationToken): Promise<void> {
+    // Setup initial content for the webview
+    webviewPanel.webview.options = {
+      enableScripts: true,
+    };
+
+    console.log('HI');
+    webviewPanel.webview.html = this.getHtmlForWebview(webviewPanel.webview);
+
+    function updateWebview() {
+    	webviewPanel.webview.postMessage({
+    		type: 'update',
+    		text: document.getText(),
+    	});
+    }
+
+    // Hook up event handlers so that we can synchronize the webview with the text document.
+    //
+    // The text document acts as our model, so we have to sync change in the document to our
+    // editor and sync changes in the editor back to the document.
+    //
+    // Remember that a single text document can also be shared between multiple custom
+    // editors (this happens for example when you split a custom editor)
+
+    // const changeDocumentSubscription = vscode.workspace.onDidChangeTextDocument(e => {
+    // 	if (e.document.uri.toString() === document.uri.toString()) {
+    // 		updateWebview();
+    // 	}
+    // });
+
+    // Make sure we get rid of the listener when our editor is closed.
+    // webviewPanel.onDidDispose(() => {
+    // 	changeDocumentSubscription.dispose();
+    // });
+
+    // Receive message from the webview.
+    // 		webviewPanel.webview.onDidReceiveMessage(e => {
+    // 			switch (e.type) {
+    // 				case 'add':
+    // //					this.addNewScratch(document);
+    // 					return;
+
+    // 				case 'delete':
+    // //					this.deleteScratch(document, e.id);
+    // 					return;
+    // 			}
+    // 		});
+
+    //updateWebview();
+  }
+
+    private _getMediaPath(file: string) {
+      return vscode.Uri.joinPath(this.context.extensionUri, 'media/Jsontracer', file);
+    }
+
+  	/**
+  	 * Get the static html used for the editor webviews.
+  	 */
+  	private getHtmlForWebview(webview: vscode.Webview): string {
+      // Use a nonce to whitelist which scripts can be run
+      const nonce = getNonce();
+      console.log("RUN: getHtmlForWebview");
+      // import js
+      const scriptPathOnDisk = this._getMediaPath('index.js');
+      const scriptUri = scriptPathOnDisk.with({scheme: 'vscode-resource'});
+
+      // import css
+      const stylePathOnDisk = this._getMediaPath('style.css');
+      const styleUri = stylePathOnDisk.with({scheme: 'vscode-resource'});
+
+      // import html
+      const htmlPath = this._getMediaPath('index.html');
+      let html = fs.readFileSync(htmlPath.fsPath, {encoding: 'utf-8'});
+
+      // Apply js and cs to html
+      html = html.replace(/\${styleUri}/g, `${styleUri}`);
+      html = html.replace(/\${scriptUri}/g, `${scriptUri}`);
+      html = html.replace(/\${nonce}/g, `${nonce}`);
+      html = html.replace(/\${webview.cspSource}/g, `${webview.cspSource}`);
+
+      return html;
+  	}
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import {CircleViewerProvider} from './CircleGraph/CircleViewer';
 import {DeviceViewProvider} from './Execute/DeviceViewProvider';
 import {runInferenceQuickInput} from './Execute/executeQuickInput';
 import {Jsontracer} from './Jsontracer';
+import {ChromeTraceViewerProvider} from './JsonTracerViewer';
 import {MondrianEditorProvider} from './Mondrian/MondrianEditor';
 import {initOneExplorer} from './OneExplorer/OneExplorer';
 import {PartEditorProvider} from './PartEditor/PartEditor';
@@ -69,11 +70,11 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(CfgEditorPanel.register(context));
 
-  let disposableOneJsontracer = vscode.commands.registerCommand('one.viewer.jsonTracer', () => {
-    Logger.info(tag, 'one json tracer...');
-    Jsontracer.createOrShow(context.extensionUri);
-  });
-  context.subscriptions.push(disposableOneJsontracer);
+  // let disposableOneJsontracer = vscode.commands.registerCommand('one.viewer.jsonTracer', () => {
+  //   Logger.info(tag, 'one json tracer...');
+  //   Jsontracer.createOrShow(context.extensionUri);
+  // });
+  // context.subscriptions.push(disposableOneJsontracer);
 
   context.subscriptions.push(MondrianEditorProvider.register(context));
 
@@ -81,6 +82,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(PartGraphSelPanel.register(context));
 
   context.subscriptions.push(CircleViewerProvider.register(context));
+  context.subscriptions.push(ChromeTraceViewerProvider.register(context));
 
   // returning backend registration function that will be called by backend extensions
   return backendRegistrationApi();


### PR DESCRIPTION
This commit rewrites JsonTracer webview command into CustomTextEditor.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>

---

DRAFT for #1135