### PR TITLE
[Toolchain] Use Toolchain suite name

### DIFF
--- a/src/Tests/Toolchain/JobConfig.test.ts
+++ b/src/Tests/Toolchain/JobConfig.test.ts
@@ -20,7 +20,7 @@ import {Command} from '../../Backend/Command';
 import {Job} from '../../Job/Job';
 import {JobConfig} from '../../Toolchain/JobConfig';
 
-suite('Project', function() {
+suite('Toolchain', function() {
   suite('JobConfig', function() {
     suite('#contructor()', function() {
       test('is contructed with command', function() {
@@ -35,6 +35,7 @@ suite('Project', function() {
         assert.deepStrictEqual(job.name, 'config');
         assert.equal(job.jobType, Job.Type.tConfig);
         assert.isTrue(job.valid);
+        assert.isTrue(job.isCancelable);
       });
     });
   });

--- a/src/Tests/Toolchain/JobInstall.test.ts
+++ b/src/Tests/Toolchain/JobInstall.test.ts
@@ -20,7 +20,7 @@ import {Command} from '../../Backend/Command';
 import {Job} from '../../Job/Job';
 import {JobInstall} from '../../Toolchain/JobInstall';
 
-suite('Project', function() {
+suite('Toolchain', function() {
   suite('JobInstall', function() {
     suite('#contructor()', function() {
       test('is contructed with command', function() {

--- a/src/Tests/Toolchain/JobUninstall.test.ts
+++ b/src/Tests/Toolchain/JobUninstall.test.ts
@@ -20,7 +20,7 @@ import {Command} from '../../Backend/Command';
 import {Job} from '../../Job/Job';
 import {JobUninstall} from '../../Toolchain/JobUninstall';
 
-suite('Project', function() {
+suite('Toolchain', function() {
   suite('JobUninstall', function() {
     suite('#contructor()', function() {
       test('is contructed with command', function() {


### PR DESCRIPTION
This commit uses Toolchain test suite name in JobConfig, JobInstall, and
JobUninstall tests.

- Add isCancelable related assertion in JobConfig tests

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft PR: #1148 