### PR TITLE
[Toolchain] Add ToolchainEnv test cases

### DIFF
--- a/src/Job/ToolRunner.ts
+++ b/src/Job/ToolRunner.ts
@@ -25,6 +25,7 @@ const which = require('which');
 
 const K_DATA: string = 'data';
 const K_EXIT: string = 'exit';
+const K_ERROR: string = 'error';
 
 /**
  * Return type when a process exits without error
@@ -69,6 +70,19 @@ export class ToolRunner {
     // stderr
     this.child!.stderr.on(K_DATA, (data: any) => {
       Logger.append(data.toString());
+    });
+
+    // NOTE
+    // The 'error' event is emitted whenever:
+    //   1. The process could not be spawned, or
+    //   2. The process could not be killed, or
+    //   3. Sending a message to the child process failed.
+    // The 'exit' event may or may not fire after an error has occurred.
+    // When listening to both the 'exit' and 'error' events, guard against
+    // accidentally invoking handler functions multiple times.
+    // from https://nodejs.org/api/child_process.html#event-error
+    this.child!.on(K_ERROR, (err) => {
+      Logger.append(err.message);
     });
 
     this.child!.on(K_EXIT, (code: number|null, signal: NodeJS.Signals|null) => {

--- a/src/Tests/MockCompiler.ts
+++ b/src/Tests/MockCompiler.ts
@@ -15,12 +15,15 @@
  */
 
 import {assert} from 'chai';
+import {Command} from '../Backend/Command';
 
 import {CompilerBase} from '../Backend/Compiler';
 import {ToolchainInfo, Toolchains} from '../Backend/Toolchain';
 import {DebianToolchain} from '../Backend/ToolchainImpl/DebianToolchain';
+import {Version} from '../Backend/Version';
 
-const mocCompilerType: string = 'test';
+const mockCompilerType1: string = 'test';
+const mockCompilerType2: string = 'test2';
 
 class MockCompiler extends CompilerBase {
   // TODO: What toolchain is necessary as tests?
@@ -29,28 +32,45 @@ class MockCompiler extends CompilerBase {
 
   constructor() {
     super();
-    this.installedToolchain =
-        new DebianToolchain(new ToolchainInfo('npm', 'package manager for Node.js'));
+    this.installedToolchain = new DebianToolchain(
+        new ToolchainInfo('npm', 'package manager for Node.js', new Version(1, 0, 0)));
     this.availableToolchain = new DebianToolchain(
         new ToolchainInfo('nodejs', 'Node.js event-based server-side javascript engine'));
   }
   getToolchainTypes(): string[] {
-    return [mocCompilerType];
+    return [mockCompilerType1, mockCompilerType2];
   }
   getToolchains(toolchainType: string, start: number, count: number): Toolchains {
-    // TODO(jyoung): Support start and count parameters
-    if (toolchainType === mocCompilerType) {
-      assert(count === 1, 'Count must be 1');
+    if (toolchainType !== mockCompilerType1 && toolchainType !== mockCompilerType2) {
+      throw Error(`Unknown toolchain type: ${toolchainType}`);
+    }
+    if (start < 0) {
+      throw Error(`wrong start number: ${start}`);
+    }
+    if (count < 0) {
+      throw Error(`wrong count number: ${count}`);
+    }
+    if (count === 0) {
+      return [];
+    }
+    assert(count === 1, 'Count must be 1');
+    if (toolchainType === mockCompilerType1) {
       return [this.availableToolchain];
     }
     return [];
   }
   getInstalledToolchains(toolchainType: string): Toolchains {
-    if (toolchainType === mocCompilerType) {
+    if (toolchainType !== mockCompilerType1 && toolchainType !== mockCompilerType2) {
+      throw Error(`Unknown toolchain type: ${toolchainType}`);
+    }
+    if (toolchainType === mockCompilerType1) {
       return [this.installedToolchain];
     }
     return [];
   }
-};
+  prerequisitesForGetToolchains(): Command {
+    return new Command('/bin/bash', ['echo', 'prerequisites']);
+  }
+}
 
 export {MockCompiler};

--- a/src/Tests/MockJob.ts
+++ b/src/Tests/MockJob.ts
@@ -17,7 +17,7 @@
 import {Job} from '../Job/Job';
 import {ToolArgs} from '../Job/ToolArgs';
 
-export class MockJob implements Job {
+class MockJob implements Job {
   jobType: Job.Type = Job.Type.tUndefined;
   name: string;
   root: boolean = false;
@@ -42,3 +42,31 @@ export class MockJob implements Job {
     return args;
   }
 }
+
+class MockFailedJob implements Job {
+  jobType: Job.Type = Job.Type.tUndefined;
+  name: string;
+  root: boolean = false;
+  workDir: string = require('os').homedir();
+  isCancelable: boolean = false;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  public get valid(): boolean {
+    return true;
+  }
+
+  public get tool(): string {
+    return 'lss';
+  }
+
+  public get toolArgs(): ToolArgs {
+    let args = new ToolArgs();
+    args.push('-h');
+    return args;
+  }
+}
+
+export {MockJob, MockFailedJob};

--- a/src/Toolchain/ToolchainEnv.ts
+++ b/src/Toolchain/ToolchainEnv.ts
@@ -69,6 +69,7 @@ class Env implements BuilderJob {
     const rootJobs = this.workFlow.jobs.filter(j => j.root === true);
     if (rootJobs.length > 0) {
       Logger.info(this.logTag, 'Showing password prompt');
+      /* istanbul ignore next */
       showPasswordQuickInput().then(password => {
         if (password === undefined) {
           Logger.info(this.logTag, 'Password dialog canceled');
@@ -94,15 +95,15 @@ class ToolchainEnv extends Env {
     this.init();
   }
 
-  getToolchainTypes(): string[] {
+  public getToolchainTypes(): string[] {
     return this.compiler.getToolchainTypes();
   }
 
-  listAvailable(type: string, start: number, count: number): Toolchain[] {
+  public listAvailable(type: string, start: number, count: number): Toolchain[] {
     return this.compiler.getToolchains(type, start, count);
   }
 
-  listInstalled(): Toolchain[] {
+  public listInstalled(): Toolchain[] {
     return this.compiler.getToolchainTypes()
         .map((type) => this.compiler.getInstalledToolchains(type))
         .reduce((r, a) => {
@@ -110,7 +111,7 @@ class ToolchainEnv extends Env {
         });
   }
 
-  executeEnv(jobs: Array<Job>) {
+  private executeEnv(jobs: Array<Job>) {
     this.clearJobs();
     jobs.forEach((job) => {
       this.addJob(job);
@@ -119,7 +120,7 @@ class ToolchainEnv extends Env {
     this.build();
   }
 
-  request(jobs: Array<Job>): Promise<boolean> {
+  public request(jobs: Array<Job>): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
       jobs.forEach((job) => {
         job.failureCallback = () => reject();
@@ -129,7 +130,7 @@ class ToolchainEnv extends Env {
     });
   }
 
-  prerequisites(): Promise<boolean> {
+  public prerequisites(): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
       const jobs: Array<Job> = [];
       const job = new JobPrerequisites(this.compiler.prerequisitesForGetToolchains());
@@ -145,7 +146,7 @@ class ToolchainEnv extends Env {
     });
   }
 
-  install(toolchain: Toolchain): Promise<boolean> {
+  public install(toolchain: Toolchain): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
       const jobs: Array<Job> = [];
       const job = new JobInstall(toolchain.install());
@@ -156,7 +157,7 @@ class ToolchainEnv extends Env {
     });
   }
 
-  uninstall(toolchain: Toolchain): Promise<boolean> {
+  public uninstall(toolchain: Toolchain): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
       const jobs: Array<Job> = [];
       const job = new JobUninstall(toolchain.uninstall());
@@ -167,7 +168,7 @@ class ToolchainEnv extends Env {
     });
   }
 
-  run(cfg: string, toolchain: Toolchain): Promise<boolean> {
+  public run(cfg: string, toolchain: Toolchain): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
       const jobs: Array<Job> = [];
       const job = new JobConfig(toolchain.run(cfg));
@@ -178,7 +179,7 @@ class ToolchainEnv extends Env {
       this.executeEnv(jobs);
     });
   }
-};
+}
 
 /**
  * Interface of backend map


### PR DESCRIPTION
This commit adds ToolchainEnv test cases.

- Add Error handler on ToolRunner
- Support multiple toolchain types in MockCompiler
- Add MockJob and MockFailedJob

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft PR: #1148 