### PR TITLE
Modify README.md and HowToUse.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ In addition, we are trying to have a well-designed structure ourselves so that v
 
 Through these activities, ONE-vscode can provide a differentiation that cannot be experienced only with the existing CLI by linking the toolchain with the execution environment, ONE Runtime, or a target simulator corresponding to the backend compiler. This will eventually lead to fun and high productivity for developers.
 
+## Quick Links
+
+1. [Install ONE-vscode extension.](./docs/HowToInstall.md)
+1. [Tutorial](./docs/Tutorial.md)

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -1,4 +1,4 @@
-# How to use?
+# Tutorial
 
 Let's compile an example by using ONE-vscode.
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"viewsWelcome": [
       {
         "view": "OneExplorerView",
-        "contents": "Open folder which includes models and configuration files.\n[Open Folder](Command:workbench.action.files.openFolder)\nFollowing types of models will be displayed.\n- *.tflite, *pb and *.onnx\n- Intermediate and compiled models of backend(s).\n\nTo learn more about ONE-vscode extension usage [read our docs](https://github.com/Samsung/ONE-vscode/blob/main/docs/HowToUse.md)."
+        "contents": "Open folder which includes models and configuration files.\n[Open Folder](Command:workbench.action.files.openFolder)\nFollowing types of models will be displayed.\n- *.tflite, *pb and *.onnx\n- Intermediate and compiled models of backend(s).\n\nTo learn more about ONE-vscode extension usage [read our docs](https://github.com/Samsung/ONE-vscode/blob/main/docs/Tutorial.md)."
       }
     ],
     "viewsContainers": {

--- a/src/Toolchain/DefaultToolchain.ts
+++ b/src/Toolchain/DefaultToolchain.ts
@@ -72,7 +72,7 @@ class DefaultToolchain {
 
   openDocument() {
     const doc =
-        'https://github.com/Samsung/ONE-vscode/blob/main/docs/HowToUse.md#set-default-toolchain';
+        'https://github.com/Samsung/ONE-vscode/blob/main/docs/Tutorial.md#set-default-toolchain';
     vscode.env.openExternal(vscode.Uri.parse(doc));
   }
 


### PR DESCRIPTION
This adds link to installation and tutorial document into README.md.

I renamed HowToUse.md to Tutorial.md.

Note: Installation and tutorial document will be revised later.

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>