### PR TITLE
Format custom editor view types

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     },
     "customEditors": [
       {
-        "viewType": "cfg.editor",
+        "viewType": "one.editor.cfg",
         "displayName": "Cfg Editor",
         "selector": [
           {
@@ -59,7 +59,7 @@
         "priority": "option"
       },
       {
-        "viewType": "onevscode.mondrianViewer",
+        "viewType": "one.viewer.mondrian",
         "displayName": "Mondrian",
         "selector": [
           {
@@ -69,7 +69,7 @@
         "priority": "default"
       },
       {
-        "viewType": "onevscode.part-editor",
+        "viewType": "one.editor.part",
         "displayName": "ONE Partition Editor",
         "selector": [
           {
@@ -79,7 +79,7 @@
         "priority": "default"
       },
       {
-        "viewType": "onevscode.circleViewer",
+        "viewType": "one.viewer.circle",
         "displayName": "Circle Viewer",
         "selector": [
           {

--- a/src/CfgEditor/CfgEditorPanel.ts
+++ b/src/CfgEditor/CfgEditorPanel.ts
@@ -52,7 +52,7 @@ export class CfgEditorPanel implements vscode.CustomTextEditorProvider {
   private _disposables: vscode.Disposable[] = [];
   private _oneConfig: CfgData = new CfgData();
 
-  public static readonly viewType = 'cfg.editor';
+  public static readonly viewType = 'one.editor.cfg';
 
   public static register(context: vscode.ExtensionContext): vscode.Disposable {
     const provider = new CfgEditorPanel(context);

--- a/src/CircleGraph/CircleViewer.ts
+++ b/src/CircleGraph/CircleViewer.ts
@@ -99,7 +99,7 @@ export class CircleViewerDocument implements vscode.CustomDocument {
 /* istanbul ignore next */
 export class CircleViewerProvider implements
     vscode.CustomReadonlyEditorProvider<CircleViewerDocument> {
-  public static readonly viewType = 'onevscode.circleViewer';
+  public static readonly viewType = 'one.viewer.circle';
 
   private _context: vscode.ExtensionContext;
 

--- a/src/Jsontracer.ts
+++ b/src/Jsontracer.ts
@@ -27,7 +27,7 @@ export class Jsontracer {
    */
   public static currentPanel: Jsontracer|undefined;
 
-  public static readonly viewType = 'Jsontracer';
+  public static readonly viewType = 'one.viewer.jsontrace';
 
   private readonly _panel: vscode.WebviewPanel;
   private readonly _extensionUri: vscode.Uri;

--- a/src/Mondrian/MondrianEditor.ts
+++ b/src/Mondrian/MondrianEditor.ts
@@ -27,7 +27,7 @@ export class MondrianEditorProvider implements vscode.CustomTextEditorProvider {
     return providerRegistration;
   }
 
-  private static readonly viewType = 'onevscode.mondrianViewer';
+  private static readonly viewType = 'one.viewer.mondrian';
 
   constructor(private readonly context: vscode.ExtensionContext) {}
 

--- a/src/OneExplorer/ConfigObject.ts
+++ b/src/OneExplorer/ConfigObject.ts
@@ -202,7 +202,7 @@ export class ConfigObj {
       artifactAttr: {
         ext: '.circle',
         icon: new vscode.ThemeIcon('symbol-variable'),
-        openViewType: 'onevscode.circleViewer'
+        openViewType: 'one.viewer.circle'
       },
       locator: new Locator((value: string) => LocatorRunner.searchWithExt('.circle', value))
     });
@@ -216,7 +216,7 @@ export class ConfigObj {
       artifactAttr: {
         ext: '.tracealloc.json',
         icon: new vscode.ThemeIcon('graph'),
-        openViewType: 'onevscode.mondrianViewer',
+        openViewType: 'one.viewer.mondrian',
         canHide: true
       },
       locator: new Locator((value: string) => {

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -272,8 +272,8 @@ class BaseModelNode extends Node {
 class ConfigNode extends Node {
   readonly type = NodeType.config;
 
-  // Open file with cfg.editor as default
-  static defaultOpenViewType = 'cfg.editor';
+  // Open file with one.editor.cfg as default
+  static defaultOpenViewType = 'one.editor.cfg';
   // Display gear icon as default
   static defaultIcon = new vscode.ThemeIcon('gear');
   // Show file always as default

--- a/src/PartEditor/PartEditor.ts
+++ b/src/PartEditor/PartEditor.ts
@@ -358,7 +358,7 @@ class PartEditor implements PartGraphEvent {
 
 /* istanbul ignore next */
 export class PartEditorProvider implements vscode.CustomTextEditorProvider, PartEditorEvent {
-  public static readonly viewType = 'onevscode.part-editor';
+  public static readonly viewType = 'one.editor.part';
   public static readonly folderMediaPartEditor = 'media/PartEditor';
 
   private static nextId: number = 1;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(CfgEditorPanel.register(context));
 
-  let disposableOneJsontracer = vscode.commands.registerCommand('one.viewer.jsonTracer', () => {
+  let disposableOneJsontracer = vscode.commands.registerCommand('one.viewer.jsontrace.open', () => {
     Logger.info(tag, 'one json tracer...');
     Jsontracer.createOrShow(context.extensionUri);
   });


### PR DESCRIPTION
This commit formats custom editor view types with prefixes:
one.editor.* (for editors)
one.viewer.* (for viewers, without editing functionality)

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>

---

For #1165


> 
> ## Targets
> 
> current name | suggestion | type
> ---|---|---
> onevscode.mondrianViewer | one.viewer.mondrian | viewType
> onevscode.part-editor | one.editor.part | viewType
> onevscode.circleViewer | one.viewer.circle | viewType
> cfg.editor | one.editor.cfg | viewType
> JsonTracer | one.viewer.jsontrace | viewType
> one.viewer.jsonTracer | one.viewer.jsontrace.open | comnmand (not a viewtype, open command for the panel)