### PR TITLE
Hide one.toolchain.{install,refresh} from cmd palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -307,7 +307,15 @@
           "when": "false"
         },
         {
+          "command": "one.toolchain.install",
+          "when": "false"
+        },
+        {
           "command": "one.toolchain.uninstall",
+          "when": "false"
+        },
+        {
+          "command": "one.toolchain.refresh",
           "when": "false"
         },
         {

--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
         },
         {
           "command": "one.toolchain.install",
-          "when": "false"
+          "when": "true"
         },
         {
           "command": "one.toolchain.uninstall",


### PR DESCRIPTION
This hides the following from command palette (`ctrl-shift-p`) just like vwe already did for `one.toolchain.uninstall`.

- `one.toolchain.install`
- `one.toolchain.refresh`

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>