### PR TITLE
[Toolchain] Remove unset userpassword in child process's exit function

### DIFF
--- a/src/Job/ToolRunner.ts
+++ b/src/Job/ToolRunner.ts
@@ -94,7 +94,6 @@ export class ToolRunner {
           `echo wrong_pw | sudo -S ...` fail.
         */
         cp.spawnSync('sudo', ['-k']);
-        process.env.userp = '';
       }
 
       // From https://nodejs.org/api/child_process.html#event-exit


### PR DESCRIPTION
This commit removes unset userpassword code in child process's exit
function. This password can be used again even after one job is
finished. For example, uninstall and install are executed in one
workflow. So it should not delete the user password just because
one job is finished.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>