### PR TITLE
[Mondrian] Tidy registration

### DIFF
--- a/src/Mondrian/MondrianEditor.ts
+++ b/src/Mondrian/MondrianEditor.ts
@@ -20,11 +20,15 @@ import {getUri} from '../Utils/external/Uri';
 
 /* istanbul ignore next */
 export class MondrianEditorProvider implements vscode.CustomTextEditorProvider {
-  public static register(context: vscode.ExtensionContext): vscode.Disposable {
+  public static register(context: vscode.ExtensionContext): void {
     const provider = new MondrianEditorProvider(context);
-    const providerRegistration =
-        vscode.window.registerCustomEditorProvider(MondrianEditorProvider.viewType, provider);
-    return providerRegistration;
+
+    const registrations = [
+      vscode.window.registerCustomEditorProvider(MondrianEditorProvider.viewType, provider)
+      // Add command registration here
+    ];
+
+    registrations.forEach(disposable => context.subscriptions.push(disposable));
   }
 
   private static readonly viewType = 'onevscode.mondrianViewer';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
   context.subscriptions.push(disposableOneJsontracer);
 
-  context.subscriptions.push(MondrianEditorProvider.register(context));
+  MondrianEditorProvider.register(context);
 
   context.subscriptions.push(PartEditorProvider.register(context));
   context.subscriptions.push(PartGraphSelPanel.register(context));


### PR DESCRIPTION
This commit tidies registration of MondrianEditorProvider.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>

----

- For #1167