### PR TITLE
[Tests] Fix trivial mistakes

### DIFF
--- a/src/Tests/Backend/Command.test.ts
+++ b/src/Tests/Backend/Command.test.ts
@@ -19,7 +19,7 @@ import {Command} from '../../Backend/Command';
 
 suite('Backend', function() {
   suite('Command', function() {
-    suite('#contructor()', function() {
+    suite('#constructor()', function() {
       test('is contructed with values', function() {
         const cmdStr: string = 'ls';
         const optionStrs: string[] = ['-lh', '~'];

--- a/src/Tests/Backend/Compiler.test.ts
+++ b/src/Tests/Backend/Compiler.test.ts
@@ -19,7 +19,7 @@ import {CompilerBase} from '../../Backend/Compiler';
 
 suite('Backend', function() {
   suite('CompilerBase', function() {
-    suite('#contructor()', function() {
+    suite('#constructor()', function() {
       test('Create dummy compiler', function(pass) {
         const compiler = new CompilerBase();
 

--- a/src/Tests/Backend/Executor.test.ts
+++ b/src/Tests/Backend/Executor.test.ts
@@ -19,7 +19,7 @@ import {ExecutorBase} from '../../Backend/Executor';
 
 suite('Backend', function() {
   suite('ExecutorBase', function() {
-    suite('#contructor()', function() {
+    suite('#constructor()', function() {
       test('Create dummy executor', function(pass) {
         const executor = new ExecutorBase();
 

--- a/src/Tests/Backend/Spec.test.ts
+++ b/src/Tests/Backend/Spec.test.ts
@@ -21,63 +21,78 @@ import {BridgeSpec, DeviceSpec, HostPCSpec, sdbSpec, TizenDeviceSpec} from '../.
 
 suite('Spec', function() {
   suite('DeviceSpec', function() {
-    suite('#contructor()', function() {
-      const hw: string = 'TestHW';
-      const sw: string = 'TestOS';
-      const testSpec = new DeviceSpec(hw, sw, undefined);
-      assert.isObject<DeviceSpec>(testSpec);
-      assert.strictEqual(testSpec.hw, hw);
-      assert.strictEqual(testSpec.sw, sw);
-      assert.strictEqual(testSpec.bridge, undefined);
+    suite('#constructor()', function() {
+      test('construct DeviseSpec', function() {
+        const hw: string = 'TestHW';
+        const sw: string = 'TestOS';
+        const testSpec = new DeviceSpec(hw, sw, undefined);
+        assert.isObject<DeviceSpec>(testSpec);
+        assert.strictEqual(testSpec.hw, hw);
+        assert.strictEqual(testSpec.sw, sw);
+        assert.strictEqual(testSpec.bridge, undefined);
+      });
     });
     suite('#satisfied()', function() {
-      const executorSpec = new DeviceSpec('arm', 'Tizen', undefined);
-      const dummySpec1 = new TizenDeviceSpec('armv7l', 'Tizen 7.0.0 (Tizen7/TV)');
-      const dummySpec2 = new HostPCSpec('x86_64', 'Ubuntu 20.04.4 LTS');
-      assert.isTrue(executorSpec.satisfied(dummySpec1));
-      assert.isFalse(executorSpec.satisfied(dummySpec2));
+      test('check DeviseSpec satisfied', function() {
+        const executorSpec = new DeviceSpec('arm', 'Tizen', undefined);
+        const dummySpec1 = new TizenDeviceSpec('armv7l', 'Tizen 7.0.0 (Tizen7/TV)');
+        const dummySpec2 = new HostPCSpec('x86_64', 'Ubuntu 20.04.4 LTS');
+        assert.isTrue(executorSpec.satisfied(dummySpec1));
+        assert.isFalse(executorSpec.satisfied(dummySpec2));
+      });
     });
   });
   suite('TizenDeviceSpec', function() {
-    suite('#contructor()', function() {
-      const hw: string = 'armv7l';
-      const sw: string = 'Tizen 7.0.0';
-      const testSpec = new TizenDeviceSpec(hw, sw);
-      assert.isObject<TizenDeviceSpec>(testSpec);
-      assert.strictEqual(testSpec.hw, hw);
-      assert.strictEqual(testSpec.sw, sw);
-      assert.strictEqual(testSpec.bridge, sdbSpec);
+    suite('#constructor()', function() {
+      test('construct TizenDeviceSpec', function() {
+        const hw: string = 'armv7l';
+        const sw: string = 'Tizen 7.0.0';
+        const testSpec = new TizenDeviceSpec(hw, sw);
+        assert.isObject<TizenDeviceSpec>(testSpec);
+        assert.strictEqual(testSpec.hw, hw);
+        assert.strictEqual(testSpec.sw, sw);
+        assert.strictEqual(testSpec.bridge, sdbSpec);
+      });
     });
   });
   suite('HostPCSpec', function() {
-    suite('#contructor()', function() {
-      const hw: string = 'x86_64';
-      const sw: string = 'Ubuntu 18';
-      const testSpec = new HostPCSpec(hw, sw);
-      assert.isObject<HostPCSpec>(testSpec);
-      assert.strictEqual(testSpec.hw, hw);
-      assert.strictEqual(testSpec.sw, sw);
-      assert.strictEqual(testSpec.bridge, undefined);
+    suite('#constructor()', function() {
+      test('construct HostPCSpec', function() {
+        const hw: string = 'x86_64';
+        const sw: string = 'Ubuntu 18';
+        const testSpec = new HostPCSpec(hw, sw);
+        assert.isObject<HostPCSpec>(testSpec);
+        assert.strictEqual(testSpec.hw, hw);
+        assert.strictEqual(testSpec.sw, sw);
+        assert.strictEqual(testSpec.bridge, undefined);
+      });
     });
   });
   suite('BridgeSpec', function() {
     suite('#constructor()', function() {
-      const dummyDeviceList = 'testDeiveList';
-      const dummyShell = 'testBridgeShell';
-      const testBridgeSpec = new BridgeSpec('test', dummyDeviceList, dummyShell);
-      assert.isObject<BridgeSpec>(testBridgeSpec);
-      assert.strictEqual(testBridgeSpec.name, 'test');
-      assert.strictEqual(testBridgeSpec.deviceListCmd.str(), dummyDeviceList);
-      assert.strictEqual(testBridgeSpec.shellCmd.str(), dummyShell);
+      test('construct BridgeSpec', function() {
+        const dummyDeviceList = 'testDeiveList';
+        const dummyShell = 'testBridgeShell';
+        const testBridgeSpec = new BridgeSpec('test', dummyDeviceList, dummyShell);
+        assert.isObject<BridgeSpec>(testBridgeSpec);
+        assert.strictEqual(testBridgeSpec.name, 'test');
+        assert.strictEqual(testBridgeSpec.deviceListCmd.str(), dummyDeviceList);
+        assert.strictEqual(testBridgeSpec.shellCmd.str(), dummyShell);
+      });
     });
-  });
-  suite('sdbSpec', function() {
-    const extensionId = 'Samsung.one-vscode';
-    const ext = vscode.extensions.getExtension(extensionId) as vscode.Extension<any>;
-    const deviceListCom = vscode.Uri.joinPath(ext!.extensionUri, 'script', 'sdbSpecList.sh').fsPath;
-    assert.isObject<BridgeSpec>(sdbSpec);
-    assert.strictEqual(sdbSpec.name, 'sdb');
-    assert.strictEqual(sdbSpec.deviceListCmd.str(), deviceListCom);
-    assert.strictEqual(sdbSpec.shellCmd.str(), 'sdb shell');
+    suite('sdbSpec', function() {
+      suite('#constructor()', function() {
+        test('construct sdbSpec', function() {
+          const extensionId = 'Samsung.one-vscode';
+          const ext = vscode.extensions.getExtension(extensionId) as vscode.Extension<any>;
+          const deviceListCom =
+              vscode.Uri.joinPath(ext!.extensionUri, 'script', 'sdbSpecList.sh').fsPath;
+          assert.isObject<BridgeSpec>(sdbSpec);
+          assert.strictEqual(sdbSpec.name, 'sdb');
+          assert.strictEqual(sdbSpec.deviceListCmd.str(), deviceListCom);
+          assert.strictEqual(sdbSpec.shellCmd.str(), 'sdb shell');
+        });
+      });
+    });
   });
 });

--- a/src/Tests/Backend/Toolchain.test.ts
+++ b/src/Tests/Backend/Toolchain.test.ts
@@ -21,7 +21,7 @@ suite('Backend', function() {
   suite('Toolchain', function() {
     const toolchainInfo = new ToolchainInfo('dummy', 'dummy toolchain');
 
-    suite('#contructor()', function() {
+    suite('#constructor()', function() {
       test('Create dummy toolchain', function(pass) {
         const toolchain = new Toolchain(toolchainInfo);
 

--- a/src/Tests/Backend/ToolchainImpl/DebianToolchain.test.ts
+++ b/src/Tests/Backend/ToolchainImpl/DebianToolchain.test.ts
@@ -32,7 +32,7 @@ suite('Backend', function() {
       const version = new Version(6, 14, 4, '+ds-1ubuntu2');
       const info = new ToolchainInfo(name, desc, version);
 
-      suite('#contructor()', function() {
+      suite('#constructor()', function() {
         test('is contructed with values', function() {
           const uri = 'http://archive.ubuntu.com/ubuntu';
           const dist = 'foscal';

--- a/src/Tests/Backend/Version.test.ts
+++ b/src/Tests/Backend/Version.test.ts
@@ -19,7 +19,7 @@ import {Version} from '../../Backend/Version';
 
 suite('Backend', function() {
   suite('Version', function() {
-    suite('#contructor()', function() {
+    suite('#constructor()', function() {
       test('is contructed with values', function() {
         const major: number = 1;
         const minor: number = 0;

--- a/src/Tests/Execute/Device.test.ts
+++ b/src/Tests/Execute/Device.test.ts
@@ -21,7 +21,7 @@ import {Device} from '../../Execute/Device';
 
 suite('Device', function() {
   suite('#Device', function() {
-    test('Basic contructor', function() {
+    test('Basic constructor', function() {
       const deviceName: string = 'testDevice';
       const hw: string = 'TestHW';
       const sw: string = 'TestOS';
@@ -45,7 +45,7 @@ suite('Device', function() {
   });
 
   suite('#TizenTVDevice', function() {
-    test('Tizen contructor', function() {
+    test('Tizen constructor', function() {
       const deviceName: string = '127.0.0.1:26101';
       const hw: string = 'armv7l';
       const sw: string = 'Tizen 7.0.0';

--- a/src/Tests/Job/Workflow.test.ts
+++ b/src/Tests/Job/Workflow.test.ts
@@ -25,7 +25,7 @@ suite('Job', function() {
     const name1 = 'job1';
     const job0 = new MockJob(name0);
     const job1 = new MockJob(name1);
-    suite('#contructor()', function() {
+    suite('#constructor()', function() {
       test('is constructed as WorkFlow', function() {
         let workFlow = new WorkFlow();
         assert.isNotNull(workFlow);

--- a/src/Tests/Toolchain/JobConfig.test.ts
+++ b/src/Tests/Toolchain/JobConfig.test.ts
@@ -22,7 +22,7 @@ import {JobConfig} from '../../Toolchain/JobConfig';
 
 suite('Toolchain', function() {
   suite('JobConfig', function() {
-    suite('#contructor()', function() {
+    suite('#constructor()', function() {
       test('is contructed with command', function() {
         let cmd = new Command('onecc');
         cmd.push('--config');

--- a/src/Tests/Toolchain/JobInstall.test.ts
+++ b/src/Tests/Toolchain/JobInstall.test.ts
@@ -22,7 +22,7 @@ import {JobInstall} from '../../Toolchain/JobInstall';
 
 suite('Toolchain', function() {
   suite('JobInstall', function() {
-    suite('#contructor()', function() {
+    suite('#constructor()', function() {
       test('is contructed with command', function() {
         let cmd = new Command('apt-get');
         cmd.push('install');

--- a/src/Tests/Toolchain/JobPrerequisites.test.ts
+++ b/src/Tests/Toolchain/JobPrerequisites.test.ts
@@ -22,7 +22,7 @@ import {JobPrerequisites} from '../../Toolchain/JobPrerequisites';
 
 suite('Toolchain', function() {
   suite('JobPrerequisites', function() {
-    suite('#contructor()', function() {
+    suite('#constructor()', function() {
       test('is contructed with command', function() {
         let cmd = new Command('/bin/bash');
         cmd.push('scriptpath');

--- a/src/Tests/Toolchain/JobUninstall.test.ts
+++ b/src/Tests/Toolchain/JobUninstall.test.ts
@@ -22,7 +22,7 @@ import {JobUninstall} from '../../Toolchain/JobUninstall';
 
 suite('Toolchain', function() {
   suite('JobUninstall', function() {
-    suite('#contructor()', function() {
+    suite('#constructor()', function() {
       test('is contructed with command', function() {
         let cmd = new Command('apt-get');
         cmd.push('purge');


### PR DESCRIPTION
This commit fixes following trivial mistakes.
- Fix `contructor` to `constructor`
- Add `test` to `suite` only test cases

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>