### PR TITLE
Fix args of aptitude

### DIFF
--- a/src/Backend/ToolchainImpl/DebianToolchain.ts
+++ b/src/Backend/ToolchainImpl/DebianToolchain.ts
@@ -77,7 +77,8 @@ class DebianToolchain implements Toolchain {
     this.prepare();
     let cmd = new Command('aptitude');
     cmd.push('install');
-    cmd.push(`-o Aptitude::ProblemResolver::SolutionCost='100*canceled-actions,200*removals'`);
+    cmd.push('-o');
+    cmd.push('Aptitude::ProblemResolver::SolutionCost=100*canceled-actions,200*removals');
     let pkg: string = this.info.name;
     if (this.info.version !== undefined) {
       pkg = `${pkg}=${this.info.version.str()}`;

--- a/src/Tests/Backend/ToolchainImpl/DebianToolchain.test.ts
+++ b/src/Tests/Backend/ToolchainImpl/DebianToolchain.test.ts
@@ -59,7 +59,7 @@ suite('Backend', function() {
           let dt = new DebianToolchain(info);
           let cmd = dt.install();
           const expectedStr =
-              `sudo aptitude install -o Aptitude::ProblemResolver::SolutionCost='100*canceled-actions,200*removals' ${
+              `sudo aptitude install -o Aptitude::ProblemResolver::SolutionCost=100*canceled-actions,200*removals ${
                   name}=${version.str()} -q -y`;
           assert.strictEqual(cmd.str(), expectedStr);
         });


### PR DESCRIPTION
This fixes the args of aptitude.
(This fixes an erroneous situation where some toolchain cannot be installed.)

1. Split `"-o Aptitude::..."` into `"-o"`, `"Aptutude::..."`
2. Since we don't use `shell:true`, remove shell metachars
   `SolutionCost='100*cancel-..removals'` to
   `SolutionCost=100*cancel-..removals` (without `'`)

ONE-vscode-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>