### PR TITLE
[Jsontracer] Fix to display json content initially

### DIFF
--- a/media/Jsontracer/index.js
+++ b/media/Jsontracer/index.js
@@ -48,6 +48,8 @@
 import dynamicGraduation from './dynamicGraduation.js';
 import {processData} from './processData.js';
 
+const vscode = acquireVsCodeApi();
+
 // event from vscode extension
 window.addEventListener('message', event => {
   const message = event.data;
@@ -161,3 +163,5 @@ function initData() {
     detail.remove();
   }
 }
+
+vscode.postMessage({type: 'requestDisplayJson'});

--- a/src/Jsontracer/JsonTracerViewerPanel.ts
+++ b/src/Jsontracer/JsonTracerViewerPanel.ts
@@ -92,6 +92,17 @@ export class JsonTracerViewerPanel implements vscode.CustomTextEditorProvider {
     html = html.replace(/\${scriptUri}/g, `${scriptUri}`);
     html = html.replace(/\${styleUri}/g, `${styleUri}`);
     webview.html = html;
+
+    // Receive message from the webview.
+    webview.onDidReceiveMessage(e => {
+      switch (e.type) {
+        case 'requestDisplayJson':
+          this.updateWebview(document, webview);
+          break;
+        default:
+          break;
+      }
+    });
   }
 
   private initWebviewPanel(document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel): void {


### PR DESCRIPTION
Until now, json content is not loaded initially, especially in remote-ssh environment.
It was because displaying json request is done even before all the elements are not ready.
This commit will fix it to request displaying json content after all the elements are ready.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>