### PR TITLE
[OneExplorer] Fix the bug of not showing trace result immediately

### DIFF
--- a/src/OneExplorer/ConfigObject.ts
+++ b/src/OneExplorer/ConfigObject.ts
@@ -279,6 +279,13 @@ export class ConfigObj {
       })
     });
 
+    /**
+     * When you add a new product type, please append the ext type to
+     * OneTreeDataProvider.fileWatcher too, to prevent a bug.
+     *
+     * TODO Provide better structure to remove this extra work
+     */
+
     let artifacts: Artifact[] = locatorRunner.run(iniObj, dir);
 
     return artifacts;

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -420,9 +420,9 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
   readonly onDidChangeTreeData: vscode.Event<OneNode|undefined|void> =
       this._onDidChangeTreeData.event;
 
-  // TODO(dayo) Get the ext list(cfg,tflite..) from backend
-  private fileWatcher =
-      vscode.workspace.createFileSystemWatcher(`**/*.{cfg,tflite,onnx,circle,tvn}`);
+  // TODO(dayo) Get the ext list(cfg,tflite..) from ArtifactLocator
+  private fileWatcher = vscode.workspace.createFileSystemWatcher(
+      `**/*.{cfg,pb,tflite,onnx,circle,tvn,tv2w,tv2o,tv2m,log,json}`);
 
   private tree: DirectoryNode|undefined;
   public didHideExtra: boolean = false;


### PR DESCRIPTION
This commit fixes the bug of not showing the trace result automatically,
but only after refreshing the view, if the profiling took long.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>

---

Thanks for the report @jyoungyun 😄 