### PR TITLE
[OneExplorer] Fix to use then phrase

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -594,9 +594,9 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
           if (newname) {
             const dirpath = path.dirname(oneNode.node.uri.fsPath);
             const newpath = `${dirpath}/${newname}`;
-            vscode.workspace.fs.rename(oneNode.node.uri, vscode.Uri.file(newpath));
-
-            this.refresh();
+            vscode.workspace.fs.rename(oneNode.node.uri, vscode.Uri.file(newpath)).then(() => {
+              this.refresh();
+            });
           }
         });
   }


### PR DESCRIPTION
`refresh()` was sometimes called after `rename(...)` is not yet finished.
This commit fixes it by using then phrase.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>