### PR TITLE
[OneExplorer] Refresh on directory deletion/move

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -421,8 +421,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
       this._onDidChangeTreeData.event;
 
   // TODO(dayo) Get the ext list(cfg,tflite..) from ArtifactLocator
-  private fileWatcher = vscode.workspace.createFileSystemWatcher(
-      `**/*.{cfg,pb,tflite,onnx,circle,tvn,tv2w,tv2o,tv2m,log,json}`);
+  private fileWatcher = vscode.workspace.createFileSystemWatcher(`**/*`);
 
   private tree: DirectoryNode|undefined;
   public didHideExtra: boolean = false;


### PR DESCRIPTION
This commit changes ONE Explorer's file watcher to watch all files
to watch directories too.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>


-----

For #1217 

/cc @hyunsik-yoon @llFreetimell 