### PR TITLE
[OneExplorer] Disable openContainingDirectory based on extensionKind

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,8 @@
       {
         "command": "one.explorer.openContainingFolder",
         "title": "Open Containing Folder",
-        "category": "ONE"
+        "category": "ONE",
+        "when": "one:extensionKind == UI"
       },
       {
         "command": "one.explorer.openAsText",
@@ -248,7 +249,8 @@
         {
           "command": "one.explorer.openContainingFolder",
           "when": "view == OneExplorerView",
-          "group": "3_open@2"
+          "group": "3_open@2",
+          "when": "one:extensionKind == UI"
         },
         {
           "command": "one.explorer.openAsText",

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -448,7 +448,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
 
     const provider = new OneTreeDataProvider(workspaceRoot, context.extension.extensionKind);
 
-    const registrations = [
+    let registrations = [
       vscode.window.createTreeView(
           'OneExplorerView',
           {treeDataProvider: provider, showCollapseAll: true, canSelectMany: true}),
@@ -475,11 +475,19 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
       vscode.commands.registerCommand(
           'one.explorer.rename', (oneNode: OneNode) => provider.rename(oneNode)),
       vscode.commands.registerCommand(
-          'one.explorer.openContainingFolder',
-          (oneNode: OneNode) => provider.openContainingFolder(oneNode)),
-      vscode.commands.registerCommand(
           'one.explorer.delete', (oneNode: OneNode) => provider.delete(oneNode)),
     ];
+
+    if (provider.isLocal) {
+      registrations = [
+        ...[vscode.commands.registerCommand(
+                'one.explorer.openContainingFolder',
+                (oneNode: OneNode) => provider.openContainingFolder(oneNode)),
+      ]
+      ];
+    } else {
+      vscode.commands.executeCommand('setContext', 'one:extensionKind', 'Workspace');
+    }
 
     registrations.forEach(disposable => context.subscriptions.push(disposable));
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,19 @@ export function activate(context: vscode.ExtensionContext) {
 
   Logger.info(tag, 'one-vscode activate OK');
 
+  /**
+   * Set runtime extensionKind in setContext to use in package.json 'when' clause.
+   * NOTE that 'extensionKind' in package.json and 'one:extensionKind' can be different.
+   *      'extensionKind' is a preferred setting
+   *      'context.extension.extensionKind' is an actual runtime extenionKind.
+   *      'one:extensionKind' is a context value equivalent to context.extension.extensionKind.
+   */
+  if (context.extension.extensionKind === vscode.ExtensionKind.UI) {
+    vscode.commands.executeCommand('setContext', 'one:extensionKind', 'UI');
+  } else {
+    vscode.commands.executeCommand('setContext', 'one:extensionKind', 'Workspace');
+  }
+
   OneTreeDataProvider.register(context);
 
   ToolchainProvider.register(context);


### PR DESCRIPTION
This commit disables and hides openContainingDirectory command based on extensionKind.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>

---

Waiting for #1220 

The feature is required because openContainingDirectory doesn't work in remote env.