### PR TITLE
[JsonTracer] Add `displayTimeUnit` to DOM

### DIFF
--- a/media/Jsontracer/index.js
+++ b/media/Jsontracer/index.js
@@ -56,7 +56,7 @@ window.addEventListener('message', event => {
   switch (message.type) {
     case 'load':
       initData();
-      processData(message.content);
+      processData(message.content, message.displayTimeUnit);
       break;
     default:
       break;

--- a/media/Jsontracer/processData.js
+++ b/media/Jsontracer/processData.js
@@ -50,7 +50,7 @@ import renderDashboard from './dashboard.js';
 
 const setData = document.querySelector('.set-data');
 
-export function processData(data) {
+export function processData(data, displayTimeUnit) {
   const processedData = {};
   const backgroundColor = {};
   const utility = {};
@@ -98,6 +98,7 @@ export function processData(data) {
   // set data to DOM
   setData.dataset['digit'] = digit;
   setData.dataset['timeLimit'] = timeLimit;
+  setData.dataset['displayTimeUnit'] = displayTimeUnit;
 
   // render dashboard
   renderDashboard(utility, timeLimit, digit, processedData);

--- a/src/Jsontracer/JsonTracerViewerPanel.ts
+++ b/src/Jsontracer/JsonTracerViewerPanel.ts
@@ -133,8 +133,9 @@ export class JsonTracerViewerPanel implements vscode.CustomTextEditorProvider {
 
   private updateWebview(document: vscode.TextDocument, webview: vscode.Webview): void {
     const content = JSON.parse(document.getText()).traceEvents;
+    const displayTimeUnit = JSON.parse(document.getText()).displayTimeUnit;
     if (content !== undefined) {
-      webview.postMessage({type: 'load', content: content});
+      webview.postMessage({type: 'load', content: content, displayTimeUnit: displayTimeUnit});
     }
   };
 }


### PR DESCRIPTION
This commit adds `displayTimeUnit` value to DOM to fix bugs.

ONE-vscode-DCO-1.0-Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>

---

Now `ts` and `dur` values are available in `JsonTracer`!

![image](https://user-images.githubusercontent.com/50489513/185841863-89fa96c0-beab-4f10-9b24-c8f4e0a310e1.png)


for: #1218 