### PR TITLE
[OneExplorer] Add 'Reveal in explorer view' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,11 @@
         "category": "ONE"
       },
       {
+        "command": "one.explorer.reveal",
+        "title": "Reveal in Explorer View",
+        "category": "ONE"
+      },
+      {
         "command": "one.toolchain.refresh",
         "title": "Toolchain Refresh",
         "category": "ONE",
@@ -257,6 +262,11 @@
           "group": "3_open@1"
         },
         {
+          "command": "one.explorer.reveal",
+          "when": "view == OneExplorerView && viewItem != directory",
+          "group": "3_open@3"
+        },
+        {
           "command": "one.explorer.createCfg",
           "when": "view == OneExplorerView && viewItem == baseModel",
           "group": "inline"
@@ -307,6 +317,10 @@
         },
         {
           "command": "one.explorer.openAsText",
+          "when": "false"
+        },
+        {
+          "command": "one.explorer.reveal",
           "when": "false"
         },
         {

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -462,6 +462,11 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<OneNode> {
           (oneNode: OneNode) => {
             vscode.commands.executeCommand('vscode.openWith', oneNode.node.uri, 'default');
           }),
+      vscode.commands.registerCommand(
+          'one.explorer.reveal',
+          (oneNode: OneNode) => {
+            vscode.commands.executeCommand('revealInExplorer', oneNode.node.uri);
+          }),
       vscode.commands.registerCommand('one.explorer.refresh', () => provider.refresh()),
       vscode.commands.registerCommand('one.explorer.hideExtra', () => provider.hideExtra()),
       vscode.commands.registerCommand('one.explorer.showExtra', () => provider.showExtra()),


### PR DESCRIPTION
This commit add 'Reveal in Explorer View' command in menu.
Note that directory cannot be a target.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>

----


For #1234