### PR TITLE
[ToolchainProvider] Ask user to save documents before run

### DIFF
--- a/src/Tests/Toolchain/ToolchainProvider.test.ts
+++ b/src/Tests/Toolchain/ToolchainProvider.test.ts
@@ -255,14 +255,14 @@ suite('Toolchain', function() {
         const toolchains = toolchainEnv.listInstalled();
         assert.isAbove(toolchains.length, 0);
         DefaultToolchain.getInstance().set(toolchainEnv, toolchains[0]);
-        provider.run(modelCfg);
+        provider._run(modelCfg);
         assert.isTrue(true);
       });
       test('NEG: requests run with uninitialized default toolchain', function() {
         const provider = new ToolchainProvider();
         const modelCfg = 'model.cfg';
         DefaultToolchain.getInstance().unset();
-        const ret = provider.run(modelCfg);
+        const ret = provider._run(modelCfg);
         assert.isFalse(ret);
       });
     });

--- a/src/Toolchain/ToolchainProvider.ts
+++ b/src/Toolchain/ToolchainProvider.ts
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
 import * as vscode from 'vscode';
 
 import {Toolchain} from '../Backend/Toolchain';
 import {Job} from '../Job/Job';
-import {askToSaveFile} from '../Utils/Helpers';
+import {saveDirtyDocuments} from '../Utils/Helpers';
 import {Logger} from '../Utils/Logger';
 import {showInstallQuickInput} from '../View/InstallQuickInput';
 
@@ -283,13 +282,11 @@ export class ToolchainProvider implements vscode.TreeDataProvider<BaseNode> {
   }
 
   public async run(cfg: string): Promise<boolean|undefined> {
-    return await askToSaveFile(cfg)
-        .then(() => {
-          return this._run(cfg);
-        })
-        .catch(() => {
-          return false;
-        });
+    const proceed: boolean = await saveDirtyDocuments(cfg);
+
+    if (proceed) {
+      return this._run(cfg);
+    }
   }
 
   public setDefaultToolchain(tnode: ToolchainNode): boolean|undefined {

--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -21,8 +21,6 @@ import * as vscode from 'vscode';
 import {Balloon} from './Balloon';
 import {Logger} from './Logger';
 
-var ini = require('ini');
-
 const logTag = 'Helpers';
 
 /**
@@ -100,30 +98,40 @@ export interface FileSelector {
 }
 
 /**
- * Show an information message to ask users whether to save the unsaved file
- * @param filepath a full path to the file
- * @return rejected promises if users don't save the file.
+ * Show an information message to ask users whether to save the unsaved file.
+ *
+ * @param filepath a full path to the file.
+ * @return a Promise returning true, if documents are saved.
+ *         a Promise returning false, if error occurs or user choose not
+ *          to save documents.
  */
-export async function askToSaveFile(filepath: string): Promise<void> {
+export async function saveDirtyDocuments(filepath: string): Promise<boolean> {
   const unsavedDocuments = vscode.workspace.textDocuments.filter(td => {
     if ((td.fileName === filepath) && td.isDirty) {
       return td;
     }
   });
 
-  await Promise.all(unsavedDocuments.map(td => {
-    const title = `Do you want to save the changes you made to ${path.parse(td.fileName).name}?`;
-    const detail = undefined;
-    const ansSave = 'Save';
-    return new Promise((resolve, reject) => {
-      vscode.window.showInformationMessage(title, {detail: detail, modal: true}, ansSave)
-          .then(ans => {
-            if (ans === ansSave) {
-              return resolve(td.save());
-            } else {
-              return reject();
-            }
-          });
+  if (unsavedDocuments.length === 0) {
+    return true;
+  }
+
+  const title = `Do you want to save the changes you made to ${path.parse(filepath).name}?`;
+  const detail = undefined;
+  const ansSave = 'Save';
+  const ans =
+      await vscode.window.showInformationMessage(title, {detail: detail, modal: true}, ansSave);
+
+  if (ans === ansSave) {
+    return Promise.all(unsavedDocuments.map(doc => doc.save())).then(res => {
+      if (res.includes(false)) {
+        Logger.error('Failed to save document');
+        return false;
+      } else {
+        return true;
+      }
     });
-  }));
+  } else {
+    return false;
+  }
 }


### PR DESCRIPTION
This commit is to ask user to save dirty target document
before running the document as onecc config.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>

---

For #1236