### PR TITLE
DRAFT: [OneExplorer] Build children on demand

### DIFF
--- a/src/Tests/OneExplorer/OneExplorer.test.ts
+++ b/src/Tests/OneExplorer/OneExplorer.test.ts
@@ -238,8 +238,8 @@ suite('OneExplorer', function() {
         // Validation
         {
           const dirNode = NodeFactory.create(NodeType.directory, dirPath);
-          assert.strictEqual(dirNode!.childNodes.length, 1);
-          assert.strictEqual(dirNode!.childNodes[0].path, baseModelPath);
+          assert.strictEqual(dirNode!.getChildren().length, 1);
+          assert.strictEqual(dirNode!.getChildren()[0].path, baseModelPath);
         }
       });
 
@@ -275,9 +275,9 @@ input_file=${baseModelPath}
           assert.strictEqual(baseModelNode!.icon, BaseModelNode.defaultIcon);
           assert.strictEqual(baseModelNode!.canHide, BaseModelNode.defaultCanHide);
 
-          assert.strictEqual(baseModelNode!.childNodes.length, 1);
-          assert.strictEqual(baseModelNode!.childNodes[0].type, NodeType.config);
-          assert.strictEqual(baseModelNode!.childNodes[0].path, configPath);
+          assert.strictEqual(baseModelNode!.getChildren().length, 1);
+          assert.strictEqual(baseModelNode!.getChildren()[0].type, NodeType.config);
+          assert.strictEqual(baseModelNode!.getChildren()[0].path, configPath);
         }
       });
 
@@ -302,7 +302,7 @@ input_file=${baseModelPath}
           assert.strictEqual(configNode!.openViewType, ConfigNode.defaultOpenViewType);
           assert.strictEqual(configNode!.icon, ConfigNode.defaultIcon);
           assert.strictEqual(configNode!.canHide, ConfigNode.defaultCanHide);
-          assert.strictEqual(configNode!.childNodes.length, 0);
+          assert.strictEqual(configNode!.getChildren().length, 0);
         }
       });
 
@@ -327,7 +327,7 @@ input_file=${baseModelPath}
           assert.strictEqual(productNode!.openViewType, ProductNode.defaultOpenViewType);
           assert.strictEqual(productNode!.icon, ProductNode.defaultIcon);
           assert.strictEqual(productNode!.canHide, ProductNode.defaultCanHide);
-          assert.strictEqual(productNode!.childNodes.length, 0);
+          assert.strictEqual(productNode!.getChildren().length, 0);
         }
       });
     });


### PR DESCRIPTION
This commit builds child nodes on demand.
It includes
- Change OneTreeDataProvider into type of TreeDataProvider<Node> instead of <OneNode>
  - OneNode is a TreeItem, which is a representation node
  - Node is an 'element', which is a core data structure
  - TreeDataProvider is designed to have 'element' to be 'unseen materials' and 'TreeItem' to be 'shown nodes, which is collapsible'.
    To make our OneExplorer to build children only when expanding the 'TreeItem', we need to make it as a proper TreeDataProvider<Node>.
- Introduce getChildren() function which builds children on demand.
- Do not create 'hidden' extra nodes
  - Change didHideExtra as static, accordingly
- Change getTree() not to build the whole tree but to obtain the root
  - Move workspaceRoot-checking code inside this
- Change getChildren() and getTreeItem()
  - Implant toOneNode() code into getTreeItem()
  - Simplify getChildren() which only returns its child.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>

-----

To resolve the problem of #1246