### PR TITLE
[OneExplorer] Do not build hidden nodes

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -177,6 +177,10 @@ abstract class Node {
 
 class NodeFactory {
   static create(type: NodeType, fpath: string, attr?: ArtifactAttr): Node|undefined {
+    // WHY HIDDEN NODES ARE NOT TO BE CREATED?
+    //
+    // A 'TreeDataProvider<element>' expects every elements (Node) to be correspond to visible
+    // TreeItem, so let's not build hidden nodes.
     if(attr?.canHide === true && OneTreeDataProvider.didHideExtra === true)
     {
       return undefined;
@@ -185,7 +189,6 @@ class NodeFactory {
     const uri = vscode.Uri.file(fpath);
 
     let node: Node;
-
     if (type === NodeType.directory) {
       assert.strictEqual(attr, undefined, 'Directory nodes cannot have attributes');
       node = new DirectoryNode(uri);

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -181,7 +181,7 @@ class NodeFactory {
     //
     // A 'TreeDataProvider<element>' expects every elements (Node) to be correspond to visible
     // TreeItem, so let's not build hidden nodes.
-    if(attr?.canHide === true && OneTreeDataProvider.didHideExtra === true)
+    if(attr && attr?.canHide === true && OneTreeDataProvider.didHideExtra === true)
     {
       return undefined;
     }

--- a/src/Tests/OneExplorer/OneExplorer.test.ts
+++ b/src/Tests/OneExplorer/OneExplorer.test.ts
@@ -238,8 +238,8 @@ suite('OneExplorer', function() {
         // Validation
         {
           const dirNode = NodeFactory.create(NodeType.directory, dirPath);
-          assert.strictEqual(dirNode.childNodes.length, 1);
-          assert.strictEqual(dirNode.childNodes[0].path, baseModelPath);
+          assert.strictEqual(dirNode!.childNodes.length, 1);
+          assert.strictEqual(dirNode!.childNodes[0].path, baseModelPath);
         }
       });
 
@@ -271,13 +271,13 @@ input_file=${baseModelPath}
         {
           const baseModelNode = NodeFactory.create(NodeType.baseModel, baseModelPath);
 
-          assert.strictEqual(baseModelNode.openViewType, BaseModelNode.defaultOpenViewType);
-          assert.strictEqual(baseModelNode.icon, BaseModelNode.defaultIcon);
-          assert.strictEqual(baseModelNode.canHide, BaseModelNode.defaultCanHide);
+          assert.strictEqual(baseModelNode!.openViewType, BaseModelNode.defaultOpenViewType);
+          assert.strictEqual(baseModelNode!.icon, BaseModelNode.defaultIcon);
+          assert.strictEqual(baseModelNode!.canHide, BaseModelNode.defaultCanHide);
 
-          assert.strictEqual(baseModelNode.childNodes.length, 1);
-          assert.strictEqual(baseModelNode.childNodes[0].type, NodeType.config);
-          assert.strictEqual(baseModelNode.childNodes[0].path, configPath);
+          assert.strictEqual(baseModelNode!.childNodes.length, 1);
+          assert.strictEqual(baseModelNode!.childNodes[0].type, NodeType.config);
+          assert.strictEqual(baseModelNode!.childNodes[0].path, configPath);
         }
       });
 
@@ -299,10 +299,10 @@ input_file=${baseModelPath}
         // Validation
         {
           const configNode = NodeFactory.create(NodeType.config, configPath);
-          assert.strictEqual(configNode.openViewType, ConfigNode.defaultOpenViewType);
-          assert.strictEqual(configNode.icon, ConfigNode.defaultIcon);
-          assert.strictEqual(configNode.canHide, ConfigNode.defaultCanHide);
-          assert.strictEqual(configNode.childNodes.length, 0);
+          assert.strictEqual(configNode!.openViewType, ConfigNode.defaultOpenViewType);
+          assert.strictEqual(configNode!.icon, ConfigNode.defaultIcon);
+          assert.strictEqual(configNode!.canHide, ConfigNode.defaultCanHide);
+          assert.strictEqual(configNode!.childNodes.length, 0);
         }
       });
 
@@ -324,10 +324,10 @@ input_file=${baseModelPath}
         // Validation
         {
           const productNode = NodeFactory.create(NodeType.product, productPath);
-          assert.strictEqual(productNode.openViewType, ProductNode.defaultOpenViewType);
-          assert.strictEqual(productNode.icon, ProductNode.defaultIcon);
-          assert.strictEqual(productNode.canHide, ProductNode.defaultCanHide);
-          assert.strictEqual(productNode.childNodes.length, 0);
+          assert.strictEqual(productNode!.openViewType, ProductNode.defaultOpenViewType);
+          assert.strictEqual(productNode!.icon, ProductNode.defaultIcon);
+          assert.strictEqual(productNode!.canHide, ProductNode.defaultCanHide);
+          assert.strictEqual(productNode!.childNodes.length, 0);
         }
       });
     });
@@ -337,7 +337,7 @@ input_file=${baseModelPath}
         const directoryPath = testBuilder.getPath('');
         const directoryNode = NodeFactory.create(NodeType.directory, directoryPath);
         const oneNode =
-            new OneNode('label', vscode.TreeItemCollapsibleState.Collapsed, directoryNode);
+            new OneNode('label', vscode.TreeItemCollapsibleState.Collapsed, directoryNode!);
         { assert.strictEqual(oneNode.contextValue, 'directory'); }
       });
     });


### PR DESCRIPTION
This commit is not to build hidden nodes.
This is required to change the OneTreeDataProvider's element type from OneNode to Node.
The provider will expect every nodes to be correspond to OneNodes, which is a visible tree item.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>


----

From #1247 