### PR TITLE
[OneExplorer] Change element type to Node from OneNode

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -506,8 +506,8 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
           'one.explorer.createCfg', (node: Node) => provider.createCfg(node)),
       vscode.commands.registerCommand(
           'one.explorer.runCfg',
-          (oneNode: OneNode) => {
-            vscode.commands.executeCommand('one.toolchain.runCfg', oneNode.node.uri.fsPath);
+          (node: Node) => {
+            vscode.commands.executeCommand('one.toolchain.runCfg', node.uri.fsPath);
           }),
       vscode.commands.registerCommand('one.explorer.delete', (node: Node) => provider.delete(node)),
     ];

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -503,7 +503,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
       vscode.commands.registerCommand('one.explorer.hideExtra', () => provider.hideExtra()),
       vscode.commands.registerCommand('one.explorer.showExtra', () => provider.showExtra()),
       vscode.commands.registerCommand(
-          'one.explorer.createCfg', (oneNode: OneNode) => provider.createCfg(oneNode)),
+          'one.explorer.createCfg', (node: Node) => provider.createCfg(node)),
       vscode.commands.registerCommand(
           'one.explorer.runCfg',
           (oneNode: OneNode) => {
@@ -582,20 +582,20 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
   }
 
   /**
-   * Refresh the tree under the given oneNode
+   * Refresh the tree under the given Node
    * @command one.explorer.refresh
-   * @param oneNode A start node to rebuild. The sub-tree under the node will be rebuilt.
+   * @param node A start node to rebuild. The sub-tree under the node will be rebuilt.
    *                If not given, the whole tree will be rebuilt.
    */
-  refresh(oneNode?: OneNode): void {
+  refresh(node?: Node): void {
     OneStorage.reset();
 
-    if (!oneNode) {
+    if (!node) {
       // Reset the root in order to build from scratch (at OneTreeDataProvider.getTree)
       this.tree = undefined;
       this._onDidChangeTreeData.fire(undefined);
     } else {
-      this._onDidChangeTreeData.fire(oneNode.node);
+      this._onDidChangeTreeData.fire(node);
     }
   }
 
@@ -656,12 +656,12 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
    * The operation will be cancelled if the file already exists.
    *
    * @command one.explorer.createCfg
-   * @param oneNode A base model to create configuration
+   * @param node A base model to create configuration
    */
-  async createCfg(oneNode: OneNode): Promise<void> {
-    const dirPath = path.parse(oneNode.node.path).dir;
-    const modelName = path.parse(oneNode.node.path).name;
-    const extName = path.parse(oneNode.node.path).ext.slice(1);
+  async createCfg(node: Node): Promise<void> {
+    const dirPath = path.parse(node.path).dir;
+    const modelName = path.parse(node.path).name;
+    const extName = path.parse(node.path).ext.slice(1);
 
     const encoder = new TextEncoder;
     // TODO(dayo) Auto-configure more fields
@@ -705,7 +705,7 @@ input_path=${modelName}.${extName}
           vscode.workspace.fs.writeFile(uri, content)
               .then(() => {
                 return new Promise<vscode.Uri>(resolve => {
-                  this.refresh(oneNode);
+                  this.refresh(node);
 
                   // Wait until the refresh event listeners are handled
                   // TODO: Add an event after revising refresh commmand

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -485,11 +485,6 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
           'OneExplorerView',
           {treeDataProvider: provider, showCollapseAll: true, canSelectMany: true}),
       vscode.commands.registerCommand(
-          'one.explorer.open',
-          (file) => {
-            vscode.commands.executeCommand('vscode.openWith', file.uri, CfgEditorPanel.viewType);
-          }),
-      vscode.commands.registerCommand(
           'one.explorer.openAsText',
           (node: Node) => {
             vscode.commands.executeCommand('vscode.openWith', node.uri, 'default');

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -496,8 +496,8 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
           }),
       vscode.commands.registerCommand(
           'one.explorer.reveal',
-          (oneNode: OneNode) => {
-            vscode.commands.executeCommand('revealInExplorer', oneNode.node.uri);
+          (node: Node) => {
+            vscode.commands.executeCommand('revealInExplorer', node.uri);
           }),
       vscode.commands.registerCommand('one.explorer.refresh', () => provider.refresh()),
       vscode.commands.registerCommand('one.explorer.hideExtra', () => provider.hideExtra()),

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -516,7 +516,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
       registrations = [
         ...[vscode.commands.registerCommand(
                 'one.explorer.openContainingFolder',
-                (oneNode: OneNode) => provider.openContainingFolder(oneNode)),
+                (node: Node) => provider.openContainingFolder(node)),
       ]
       ];
     } else {
@@ -603,8 +603,8 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
   /**
    * @command one.explorer.openContainingFolder
    */
-  openContainingFolder(oneNode: OneNode): void {
-    vscode.commands.executeCommand('revealFileInOS', oneNode.node.uri);
+  openContainingFolder(node: Node): void {
+    vscode.commands.executeCommand('revealFileInOS', node.uri);
   }
 
   /**

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -491,8 +491,8 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
           }),
       vscode.commands.registerCommand(
           'one.explorer.openAsText',
-          (oneNode: OneNode) => {
-            vscode.commands.executeCommand('vscode.openWith', oneNode.node.uri, 'default');
+          (node: Node) => {
+            vscode.commands.executeCommand('vscode.openWith', node.uri, 'default');
           }),
       vscode.commands.registerCommand(
           'one.explorer.reveal',
@@ -509,8 +509,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
           (oneNode: OneNode) => {
             vscode.commands.executeCommand('one.toolchain.runCfg', oneNode.node.uri.fsPath);
           }),
-      vscode.commands.registerCommand(
-          'one.explorer.delete', (oneNode: OneNode) => provider.delete(oneNode)),
+      vscode.commands.registerCommand('one.explorer.delete', (node: Node) => provider.delete(node)),
     ];
 
     if (provider.isLocal) {
@@ -611,11 +610,11 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
   /**
    * @command one.explorer.delete
    */
-  delete(oneNode: OneNode): void {
-    const isDirectory = (oneNode.node.type === NodeType.directory);
+  delete(node: Node): void {
+    const isDirectory = (node.type === NodeType.directory);
 
     let recursive: boolean;
-    let title = `Are you sure you want to delete '${oneNode.node.name}'`;
+    let title = `Are you sure you want to delete '${node.name}'`;
     if (isDirectory) {
       title += ` and its contents?`;
       recursive = true;
@@ -643,8 +642,8 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
     vscode.window.showInformationMessage(title, {detail: detail, modal: true}, approval)
         .then(ans => {
           if (ans === approval) {
-            Logger.info('OneExplorer', `Delete '${oneNode.node.name}'.`);
-            vscode.workspace.fs.delete(oneNode.node.uri, {recursive: recursive, useTrash: useTrash})
+            Logger.info('OneExplorer', `Delete '${node.name}'.`);
+            vscode.workspace.fs.delete(node.uri, {recursive: recursive, useTrash: useTrash})
                 .then(() => this.refresh());
           }
         });


### PR DESCRIPTION
This commit builds child nodes on demand.
It includes
- Change OneTreeDataProvider into type of TreeDataProvider<Node> instead of <OneNode>
  - OneNode is a TreeItem, which is a representation node
  - Node is an 'element', which is a core data structure
  - TreeDataProvider is designed to have 'element' to be 'unseen materials' and 'TreeItem' to be 'shown nodes, which is collapsible'.
    To make our OneExplorer to build children only when expanding the 'TreeItem', we need to make it as a proper TreeDataProvider<Node>.
- Introduce getChildren() function which builds children on demand.
- Do not create 'hidden' extra nodes
  - Change didHideExtra as static, accordingly
- Change getTree() not to build the whole tree but to obtain the root
  - Move workspaceRoot-checking code inside this
- Change getChildren() and getTreeItem()
  - Implant toOneNode() code into getTreeItem()
  - Simplify getChildren() which only returns its child.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>

---

From #1247 
Waiting for #1249