### PR TITLE
[lint] Remove no-case-declarations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
       "eqeqeq": "warn",
       "no-throw-literal": "warn",
       "semi": "off",
-      "no-extra-semi": "warn"
+      "no-extra-semi": "warn",
+      "no-case-declarations": "warn"
   }
 }

--- a/src/CfgEditor/CfgEditorPanel.ts
+++ b/src/CfgEditor/CfgEditorPanel.ts
@@ -142,7 +142,7 @@ export class CfgEditorPanel implements vscode.CustomTextEditorProvider {
             vscode.workspace.applyEdit(edit);
           }
           break;
-        case 'getPathByDialog':
+        case 'getPathByDialog': {
           const dialogOptions = {
             canSelectMany: false,
             canSelectFolders: e.isFolder,
@@ -158,6 +158,7 @@ export class CfgEditorPanel implements vscode.CustomTextEditorProvider {
             }
           });
           break;
+        }
         default:
           break;
       }


### PR DESCRIPTION
This commit adds "no-case-declarations" rule to our lint configuration and
fixes the errors.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>

----

For #1253

> 
> ### Remove no-case-declarations
> 
> https://eslint.org/docs/latest/rules/no-case-declarations
> 
> #### Why is this a problem?
> >  The reason is that the lexical declaration is visible in the entire switch block but it only gets initialized when it is assigned, which will only happen if the case where it is defined is reached.
> 
> #### Sol
> > To ensure that the lexical declaration only applies to the current case clause wrap your clauses in blocks.
> 
> 
> ### 2 Errors
> ```
> /home/dayo/git/ONE-vscode/src/CfgEditor/CfgEditorPanel.ts
>   146:11  warning  Unexpected lexical declaration in case block  no-case-declarations
>   152:11  warning  Unexpected lexical declaration in case block  no-case-declarations
> 
> ✖ 2 problems (0 errors, 2 warnings)
> ```
> 
> 