### PR TITLE
[lint] Remove no-useless-escape

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
       "no-throw-literal": "warn",
       "semi": "off",
       "no-extra-semi": "warn",
-      "no-case-declarations": "warn"
+      "no-case-declarations": "warn",
+      "no-useless-escape" : "warn"
   }
 }

--- a/src/CircleGraph/CircleGraphCtrl.ts
+++ b/src/CircleGraph/CircleGraphCtrl.ts
@@ -363,7 +363,7 @@ export class CircleGraphCtrl {
     let html = fs.readFileSync(htmlPath.fsPath, {encoding: 'utf-8'});
 
     const nonce = getNonce();
-    html = html.replace(/\%nonce%/gi, nonce);
+    html = html.replace(/%nonce%/gi, nonce);
     html = html.replace('%webview.cspSource%', webview.cspSource);
     // necessary files from netron to work
     html = this.updateUri(html, webview, '%view-grapher.css%', 'view-grapher.css');

--- a/src/PartEditor/PartEditor.ts
+++ b/src/PartEditor/PartEditor.ts
@@ -411,7 +411,7 @@ export class PartEditorProvider implements vscode.CustomTextEditorProvider, Part
     let html = fs.readFileSync(htmlPath.fsPath, {encoding: 'utf-8'});
 
     const nonce = getNonce();
-    html = html.replace(/\%nonce%/gi, nonce);
+    html = html.replace(/%nonce%/gi, nonce);
     html = html.replace('%webview.cspSource%', webview.cspSource);
 
     html = this.updateUri(html, webview, '%index.css%', 'index.css');


### PR DESCRIPTION
This commit adds "no-useless-escape" rule and
fixes errors accordingly.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>

---
From #1253

> 
> ### Remove no-useless-escape
> 
> https://eslint.org/docs/latest/rules/no-useless-escape
> 
> > Escaping non-special characters in strings, template literals, and regular expressions doesn’t have any effect
> 
> ```
> /home/dayo/git/ONE-vscode/src/CircleGraph/CircleGraphCtrl.ts
>   366:26  warning  Unnecessary escape character: \%  no-useless-escape
> 
> /home/dayo/git/ONE-vscode/src/PartEditor/PartEditor.ts
>   414:26  warning  Unnecessary escape character: \%  no-useless-escape
> 
> ✖ 2 problems (0 errors, 2 warnings)
> ```
> 