### PR TITLE
[lint] Remove no-control-regex

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
       "eqeqeq": "warn",
       "no-throw-literal": "warn",
       "semi": "off",
+      "no-control-regex": "warn",
       "no-extra-semi": "warn",
       "no-case-declarations": "warn"
   }

--- a/src/View/PasswordQuickInput.ts
+++ b/src/View/PasswordQuickInput.ts
@@ -18,6 +18,7 @@ import * as vscode from 'vscode';
 
 // NOTE ASCII characters have codes ranging from u+0000 to u+007f
 function containsNonAscii(str: string): boolean {
+  // eslint-disable-next-line no-control-regex
   return !/^[\u0000-\u007f]*$/.test(str);
 }
 

--- a/src/View/PasswordQuickInput.ts
+++ b/src/View/PasswordQuickInput.ts
@@ -16,7 +16,18 @@
 
 import * as vscode from 'vscode';
 
-// NOTE ASCII characters have codes ranging from u+0000 to u+007f
+// NOTE
+//
+//   u+0000-u+001f: control ascii codes,    ascii (ALLOWED)
+//   u+0020-u+007f: printable ascii codes,  ascii (ALLOWED)
+//   u+0080-u+00ff: extended ascii codes,   extended ascii (NOT ALLOWED)
+//
+// By experience, Linux os takes all extended ascii characters(u+0000-u+00ff) for passwords, even
+// controll asciis. whereas 'eslint' recommends not using regex including control ascii codes.
+// Therefore, we allow users to put control ascii codes.
+//
+// By experience, the passwords including extended ascii characters are not working when loging in
+// to remote vscode. Therefore, here we allow only 'ascii characters'(0x00-0x7f).
 function containsNonAscii(str: string): boolean {
   // eslint-disable-next-line no-control-regex
   return !/^[\u0000-\u007f]*$/.test(str);

--- a/src/View/PasswordQuickInput.ts
+++ b/src/View/PasswordQuickInput.ts
@@ -18,15 +18,15 @@ import * as vscode from 'vscode';
 
 // NOTE
 //
-//   u+0000-u+001f: control ascii codes,    ascii (ALLOWED)
+//   u+0000-u+001f: control ascii codes,    ascii (ALLOWED) *
 //   u+0020-u+007f: printable ascii codes,  ascii (ALLOWED)
-//   u+0080-u+00ff: extended ascii codes,   extended ascii (NOT ALLOWED)
+//   u+0080-u+00ff: extended ascii codes,   extended ascii (NOT ALLOWED) **
 //
-// By experience, Linux os takes all extended ascii characters(u+0000-u+00ff) for passwords, even
-// controll asciis, whereas 'eslint' recommends not to use the regex which includes any control ascii.
-// Therefore, we allow users to put control ascii codes.
+// *By experience, Linux os takes all extended ascii characters(u+0000-u+00ff) for passwords, even
+// controll asciis, whereas 'eslint' recommends not to use the regex which includes any control
+// ascii. Therefore, we allow users to put control ascii codes.
 //
-// By experience, the passwords including extended ascii characters are not working when loging in
+// **By experience, the passwords including extended ascii characters are not working when loging in
 // to remote vscode. Therefore, here we allow only 'ascii characters'(0x00-0x7f).
 function containsNonAscii(str: string): boolean {
   // eslint-disable-next-line no-control-regex

--- a/src/View/PasswordQuickInput.ts
+++ b/src/View/PasswordQuickInput.ts
@@ -23,7 +23,7 @@ import * as vscode from 'vscode';
 //   u+0080-u+00ff: extended ascii codes,   extended ascii (NOT ALLOWED)
 //
 // By experience, Linux os takes all extended ascii characters(u+0000-u+00ff) for passwords, even
-// controll asciis. whereas 'eslint' recommends not using regex including control ascii codes.
+// controll asciis, whereas 'eslint' recommends not to use the regex which includes any control ascii.
 // Therefore, we allow users to put control ascii codes.
 //
 // By experience, the passwords including extended ascii characters are not working when loging in


### PR DESCRIPTION
This commit enables 'no-control-regex' rule
and removes the errors accordingly.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>

---

For #1253

> 
> ### Remove no-control-regex
> 
> #### Reference
> > https://stackoverflow.com/questions/14313183/javascript-regex-how-do-i-check-if-the-string-is-ascii-only
> 
> #### Problematic lines
> 
> ```typescript
> // NOTE ASCII characters have codes ranging from u+0000 to u+007f
> function containsNonAscii(str: string): boolean {
>   return !/^[\u0000-\u007f]*$/.test(str);
> }
> ```
> 
> The line is required to check if it's an ascii, but how about checking 'printable ascii' aside from those problematic non-printables?