### PR TITLE
[lint] Remove no-prototype-builtins

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,7 @@
       "semi": "off",
       "no-extra-semi": "warn",
       "no-case-declarations": "warn",
-      "no-useless-escape" : "warn"
+      "no-useless-escape" : "warn",
+      "no-prototype-builtins": "warn"
   }
 }

--- a/media/CircleGraph/view.js
+++ b/media/CircleGraph/view.js
@@ -581,7 +581,7 @@ view.View = class {
         this._clearSelection();
 
         // set new selection
-        if (selection.hasOwnProperty('names')) {
+        if (Object.prototype.hasOwnProperty.call(selection, 'names')) {
             // selection is by names
             const names = selection.names;
             let scrollToSelects = [];  // elements to make visible by scroll to
@@ -643,7 +643,7 @@ view.View = class {
         //      (3) interate all graph nodes and set if exist in opname, clear if not.
         //      here, (3) is implemented
 
-        if (!message.hasOwnProperty('partition')) {
+        if (!Object.prototype.hasOwnProperty.call(message, 'partition')) {
             return;
         }
         const partition = message.partition;

--- a/media/PartEditor/index.js
+++ b/media/PartEditor/index.js
@@ -359,7 +359,7 @@ editor.Editor = class {
     this.clearOperatorsCode();
 
     for (let name in this.partition.OPNAME) {
-      if (this.partition.OPNAME.hasOwnProperty(name)) {
+      if (Object.prototype.hasOwnProperty.call(this.partition.OPNAME, name)) {
         let backend = this.partition.OPNAME[name];
         let beCode = this.backendCode(backend);
         if (beCode !== -1) {
@@ -430,7 +430,7 @@ editor.Editor = class {
   backendCode(value) {
     if (typeof value === 'string') {
       value = value.toUpperCase();
-      if (this.beToCode.hasOwnProperty(value)) {
+      if (Object.prototype.hasOwnProperty.call(this.beToCode, value)) {
         return this.beToCode[value];
       }
     }

--- a/src/PartEditor/PartEditor.ts
+++ b/src/PartEditor/PartEditor.ts
@@ -328,10 +328,11 @@ class PartEditor implements PartGraphEvent {
       partContent['partition'] = this.makeDefaultPartiton();
     }
 
-    if (message.hasOwnProperty('opname')) {
+    if (Object.prototype.hasOwnProperty.call(message, 'opname')) {
       partContent.OPNAME = message.opname;
     }
-    if (message.hasOwnProperty('partition')) {
+
+    if (Object.prototype.hasOwnProperty.call(message, 'partition')) {
       partContent.partition = message.partition;
     }
 


### PR DESCRIPTION
This commit adds "no-prototype-builtins" rule and
fixes errors accordingly.

ONE-vscode-DCO-1.0-Signed-off-by: dayo09 <dayoung.lee@samsung.com>

---

For #1253 

> 
> ### Remove no-prototype-builtins
> #### Reference
> 
> > https://eslint.org/docs/latest/rules/no-prototype-builtins
> 
> > In ECMAScript 5.1, Object.create was added, which enables the creation of objects with a specified [[Prototype]]. Object.create(null) is a common pattern used to create objects that will be used as a Map. This can lead to errors when it is assumed that objects will have properties from Object.prototype. This rule prevents calling some Object.prototype methods directly from an object.
> > 
> > Additionally, objects can have properties that shadow the builtins on Object.prototype, potentially causing unintended behavior or denial-of-service security vulnerabilities. For example, it would be unsafe for a webserver to parse JSON input from a client and call hasOwnProperty directly on the resulting object, because a malicious client could send a JSON value like {"hasOwnProperty": 1} and cause the server to crash.
> > 
> > To avoid subtle bugs like this, it’s better to always call these methods from Object.prototype. For example, foo.hasOwnProperty("bar") should be replaced with Object.prototype.hasOwnProperty.call(foo, "bar").
> 
> #### Example
> 
> > 
> > Examples of incorrect code for this rule:
> > var hasBarProperty = foo.hasOwnProperty("bar");
> > ....
> > Examples of correct code for this rule:
> > var hasBarProperty = Object.prototype.hasOwnProperty.call(foo, "bar");
