### PR TITLE
[lint] Remove no-unused-vars warnings from Tests

### DIFF
--- a/src/Tests/Backend/Compiler.test.ts
+++ b/src/Tests/Backend/Compiler.test.ts
@@ -21,7 +21,7 @@ suite('Backend', function() {
   suite('CompilerBase', function() {
     suite('#constructor()', function() {
       test('Create dummy compiler', function(pass) {
-        const compiler = new CompilerBase();
+        assert.doesNotThrow(() => new CompilerBase());
 
         pass();
         assert.ok(true);

--- a/src/Tests/Backend/Executor.test.ts
+++ b/src/Tests/Backend/Executor.test.ts
@@ -21,7 +21,7 @@ suite('Backend', function() {
   suite('ExecutorBase', function() {
     suite('#constructor()', function() {
       test('Create dummy executor', function(pass) {
-        const executor = new ExecutorBase();
+        assert.doesNotThrow(() => new ExecutorBase());
 
         pass();
         assert.ok(true);

--- a/src/Tests/Backend/Toolchain.test.ts
+++ b/src/Tests/Backend/Toolchain.test.ts
@@ -23,7 +23,7 @@ suite('Backend', function() {
 
     suite('#constructor()', function() {
       test('Create dummy toolchain', function(pass) {
-        const toolchain = new Toolchain(toolchainInfo);
+        assert.doesNotThrow(() => new Toolchain(toolchainInfo));
 
         pass();
         assert.ok(true);

--- a/src/Tests/Backend/ToolchainImpl/DebianToolchain.test.ts
+++ b/src/Tests/Backend/ToolchainImpl/DebianToolchain.test.ts
@@ -15,7 +15,7 @@
  */
 
 import {assert} from 'chai';
-import {PackageInfo, ToolchainInfo} from '../../../Backend/Toolchain';
+import {ToolchainInfo} from '../../../Backend/Toolchain';
 import {DebianArch, DebianRepo, DebianToolchain} from '../../../Backend/ToolchainImpl/DebianToolchain';
 import {Version} from '../../../Backend/Version';
 

--- a/src/Tests/Execute/Device.test.ts
+++ b/src/Tests/Execute/Device.test.ts
@@ -37,7 +37,7 @@ suite('Device', function() {
       const sw: string = 'TestOS';
       const testSpec = new DeviceSpec(hw, sw, undefined);
       try {
-        const testDevice = new Device(deviceName, testSpec);
+        new Device(deviceName, testSpec);
       } catch (err: any) {
         assert.strictEqual(err.message, 'empty name device cannot be created.');
       }
@@ -61,7 +61,7 @@ suite('Device', function() {
       const sw: string = 'Tizen 7.0.0';
       const testSpec = new TizenDeviceSpec(hw, sw);
       try {
-        const tizenTV = new Device(deviceName, testSpec);
+        new Device(deviceName, testSpec);
       } catch (err: any) {
         assert.strictEqual(err.message, 'empty name device cannot be created.');
       }
@@ -85,7 +85,7 @@ suite('Device', function() {
       const sw: string = 'TestOS';
       const testSpec = new HostPCSpec(hw, sw);
       try {
-        const hostPC = new Device(deviceName, testSpec);
+        new Device(deviceName, testSpec);
       } catch (err: any) {
         assert.strictEqual(err.message, 'empty name device cannot be created.');
       }

--- a/src/Tests/Execute/DeviceViewProvider.test.ts
+++ b/src/Tests/Execute/DeviceViewProvider.test.ts
@@ -16,8 +16,6 @@
 
 import {assert} from 'chai';
 import * as vscode from 'vscode';
-import {globalExecutorArray} from '../../Backend/API';
-import {ExecutorBase} from '../../Backend/Executor';
 import {deviceManagerList, DeviceViewNode, DeviceViewProvider, NodeType} from '../../Execute/DeviceViewProvider';
 
 
@@ -101,7 +99,7 @@ suite('DeviceViewProvider', function() {
   suite('#getChildren', function() {
     test('get Children under undfined', function(done) {
       let provider = new DeviceViewProvider();
-      provider.loadDeviceManager('local', function(_provider: DeviceViewProvider) {
+      provider.loadDeviceManager('local', function() {
         let deviceManagers = provider.getChildren();
         assert.strictEqual(deviceManagers.length, deviceManagerList.length);
         for (let index = 0; index < deviceManagers.length; index++) {
@@ -112,7 +110,7 @@ suite('DeviceViewProvider', function() {
     });
     test('get Children under deviceManager Node', function(done) {
       let provider = new DeviceViewProvider();
-      provider.loadDeviceManager('local', function(_provider: DeviceViewProvider) {
+      provider.loadDeviceManager('local', function() {
         for (const key in provider.deviceManagerMap) {
           if (Object.prototype.hasOwnProperty.call(provider.deviceManagerMap, key)) {
             const element = provider.deviceManagerMap[key];
@@ -130,7 +128,7 @@ suite('DeviceViewProvider', function() {
     });
     test('get Children under Device Node', function(done) {
       let provider = new DeviceViewProvider();
-      provider.loadDeviceManager('local', function(_provider: DeviceViewProvider) {
+      provider.loadDeviceManager('local', function() {
         for (const key in provider.deviceManagerMap) {
           if (Object.prototype.hasOwnProperty.call(provider.deviceManagerMap, key)) {
             const element = provider.deviceManagerMap[key];

--- a/src/Tests/Job/ToolRunner.test.ts
+++ b/src/Tests/Job/ToolRunner.test.ts
@@ -15,7 +15,6 @@
  */
 
 import {assert} from 'chai';
-import {join} from 'path';
 
 import {ToolArgs} from '../../Job/ToolArgs';
 import {SuccessResult, ToolRunner} from '../../Job/ToolRunner';
@@ -116,8 +115,6 @@ suite('Job', function() {
 
     suite(`#kill()`, function() {
       test('basic case', async function() {
-        let finished = false;
-
         let toolRunner = new ToolRunner();
 
         let args = new ToolArgs();
@@ -128,7 +125,7 @@ suite('Job', function() {
             .then((val: SuccessResult) => {
               assert.equal(val.intentionallyKilled, true);
             })
-            .catch(exitcode => {
+            .catch(() => {
               assert.fail();
             });
 
@@ -155,7 +152,7 @@ suite('Job', function() {
               assert.equal(val.exitCode, 0);
               finished = true;
             })
-            .catch(exitcode => {
+            .catch(() => {
               assert.fail();
             });
 

--- a/src/Tests/OneExplorer/ArtifactLocator.test.ts
+++ b/src/Tests/OneExplorer/ArtifactLocator.test.ts
@@ -176,7 +176,7 @@ suite('OneExplorer', function() {
         // Register a locator which always throws
         locatorRunner.register({
           artifactAttr: {ext: '.test'},
-          locator: new Locator(value => {
+          locator: new Locator(() => {
             throw Error('Test');
           })
         });

--- a/src/Tests/OneExplorer/ConfigObject.test.ts
+++ b/src/Tests/OneExplorer/ConfigObject.test.ts
@@ -780,8 +780,6 @@ command=--save-chrome-trace ${traceName}
 
         // Get file paths inside the temp directory
         const configPath = testBuilder.getPath(configName);
-        const tracePath = testBuilder.getPath(traceName);
-
         const configObj = ConfigObj.createConfigObj(vscode.Uri.file(configPath));
 
         // Validation
@@ -810,8 +808,6 @@ commands=--save-chrome-trace ${traceName}
 
         // Get file paths inside the temp directory
         const configPath = testBuilder.getPath(configName);
-        const tracePath = testBuilder.getPath(traceName);
-
         const configObj = ConfigObj.createConfigObj(vscode.Uri.file(configPath));
 
         // Validation

--- a/src/Tests/OneExplorer/OneExplorer.test.ts
+++ b/src/Tests/OneExplorer/OneExplorer.test.ts
@@ -19,7 +19,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import {_unit_test_BaseModelNode as BaseModelNode, _unit_test_ConfigNode as ConfigNode, _unit_test_DirectoryNode as DirectoryNode, _unit_test_getCfgList as getCfgList, _unit_test_NodeFactory as NodeFactory, _unit_test_NodeType as NodeType, _unit_test_OneNode as OneNode, _unit_test_ProductNode as ProductNode} from '../../OneExplorer/OneExplorer';
+import {_unit_test_BaseModelNode as BaseModelNode, _unit_test_ConfigNode as ConfigNode, _unit_test_getCfgList as getCfgList, _unit_test_NodeFactory as NodeFactory, _unit_test_NodeType as NodeType, _unit_test_OneNode as OneNode, _unit_test_ProductNode as ProductNode} from '../../OneExplorer/OneExplorer';
 import {obtainWorkspaceRoot} from '../../Utils/Helpers';
 
 

--- a/src/Tests/OneExplorer/OneStorage.test.ts
+++ b/src/Tests/OneExplorer/OneStorage.test.ts
@@ -180,7 +180,6 @@ input_path=${modelName}
 
         testBuilder.writeFileSync(modelName, '', 'workspace');
 
-        const modelPath = testBuilder.getPath(modelName, 'workspace');
         { assert.isUndefined(OneStorage.getCfgs('invalid/path')); }
       });
 

--- a/src/Tests/Toolchain/ToolchainEnv.test.ts
+++ b/src/Tests/Toolchain/ToolchainEnv.test.ts
@@ -127,7 +127,7 @@ suite('Toolchain', function() {
             (value) => {
               assert.equal(value, true);
             },
-            (_reason) => {
+            () => {
               assert.fail();
             });
       });
@@ -136,7 +136,7 @@ suite('Toolchain', function() {
         let env = new ToolchainEnv(compiler);
         const job0 = new MockFailedJob('job0');
         const jobs: Array<Job> = [job0];
-        env.request(jobs).then((_value) => {
+        env.request(jobs).then(() => {
           assert.fail();
         });
       });
@@ -148,10 +148,10 @@ suite('Toolchain', function() {
       const job1 = new MockFailedJob('job1');
       const jobs: Array<Job> = [job0, job1];
       env.request(jobs).then(
-          (_value) => {
+          () => {
             assert.fail();
           },
-          (_reason) => {
+          () => {
             assert.isTrue(true);
           });
     });
@@ -160,10 +160,10 @@ suite('Toolchain', function() {
       test('requests prerequisites', function() {
         let env = new ToolchainEnv(compiler);
         env.prerequisites().then(
-            (_value) => {
+            () => {
               assert.isTrue(true);
             },
-            (_reason) => {
+            () => {
               assert.fail();
             });
       });

--- a/src/Tests/Utils/PipedSpawn.test.ts
+++ b/src/Tests/Utils/PipedSpawn.test.ts
@@ -39,7 +39,7 @@ suite('Utils', function() {
 
     test('NEG: first cmd fails', function() {
       try {
-        let cat = pipedSpawn('cat', ['invalid_file'], {}, 'wc', ['-l'], {});
+        pipedSpawn('cat', ['invalid_file'], {}, 'wc', ['-l'], {});
       } catch (err) {
         assert.ok(true, 'Should be thrown');
       }
@@ -64,7 +64,7 @@ suite('Utils', function() {
       sudo.stdout!.on('data', (data) => {
         assert.fail(`should not fail. ${data}`);
       });
-      sudo.on('exit', (exitcode: number|null, signal: NodeJS.Signals|null) => {
+      sudo.on('exit', (exitcode: number|null) => {
         if (exitcode === 0) {
           assert.fail(`exitcode === 0`);
         } else {


### PR DESCRIPTION
This commit removes 'no-unused-vars' warnings from Tests.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>