### PR TITLE
[lint] Remove unused variables from CircleGraph and PartEditor

### DIFF
--- a/src/CircleGraph/CircleGraph.ts
+++ b/src/CircleGraph/CircleGraph.ts
@@ -84,7 +84,7 @@ export class CircleGraphPanel extends CircleGraphCtrl {
     this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
 
     // Update the content based on view changes
-    this._panel.onDidChangeViewState(e => {
+    this._panel.onDidChangeViewState(() => {
       if (this._panel.visible) {
         // NOTE if we call this.update(), it'll reload the model which may take time.
         // TODO call conditional this.update() when necessary.

--- a/src/CircleGraph/CircleGraphCtrl.ts
+++ b/src/CircleGraph/CircleGraphCtrl.ts
@@ -342,7 +342,7 @@ export class CircleGraphCtrl {
         total: this._modelLength,
         responseArray: modelData
       });
-      fs.close(fd, (err) => {});
+      fs.close(fd, () => {});
     });
   }
 

--- a/src/CircleGraph/CircleViewer.ts
+++ b/src/CircleGraph/CircleViewer.ts
@@ -124,7 +124,7 @@ export class CircleViewerProvider implements
 
   // CustomReadonlyEditorProvider implements
   async openCustomDocument(
-      uri: vscode.Uri, openContext: {backupId?: string},
+      uri: vscode.Uri, _openContext: {backupId?: string},
       _token: vscode.CancellationToken): Promise<CircleViewerDocument> {
     const document: CircleViewerDocument = await CircleViewerDocument.create(uri);
     // NOTE as a readonly viewer, there is not much to do

--- a/src/PartEditor/PartEditor.ts
+++ b/src/PartEditor/PartEditor.ts
@@ -98,7 +98,7 @@ class PartEditor implements PartGraphEvent {
     });
 
     this._panel.onDidChangeViewState(
-        e => {
+        () => {
             // TODO implement
         },
         null, this._disposables);
@@ -286,7 +286,7 @@ class PartEditor implements PartGraphEvent {
         }
       });
 
-      cmd.on(K_ERROR, (err) => {
+      cmd.on(K_ERROR, () => {
         let msg = 'Failed to run circle-operator: ' + this._modelFileName;
         Balloon.error(msg);
         reject(msg);
@@ -352,7 +352,7 @@ class PartEditor implements PartGraphEvent {
   }
 
   // PartGraphEvent implements
-  public onSelection(names: string[], tensors: string[]) {
+  public onSelection(names: string[], _tensors: string[]) {
     this._webview.postMessage({command: 'selectWithNames', selection: names});
   }
 }
@@ -388,7 +388,7 @@ export class PartEditorProvider implements vscode.CustomTextEditorProvider, Part
 
   public async resolveCustomTextEditor(
       document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel,
-      token: vscode.CancellationToken): Promise<void> {
+      _token: vscode.CancellationToken): Promise<void> {
     let partEditor = new PartEditor(document, webviewPanel, PartEditorProvider.nextId++);
     this._partEditors.push(partEditor);
 

--- a/src/PartEditor/PartGraphSelector.ts
+++ b/src/PartEditor/PartGraphSelector.ts
@@ -205,7 +205,7 @@ export class PartGraphSelPanel extends CircleGraphCtrl implements CircleGraphEve
     this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
 
     // Update the content based on view changes
-    this._panel.onDidChangeViewState(e => {
+    this._panel.onDidChangeViewState(() => {
       if (this._panel.visible) {
         // NOTE if we call this.update(), it'll reload the model which may take time.
         // TODO call conditional this.update() when necessary.


### PR DESCRIPTION
This commit removes unused variables and parameters from CircleGraph and PartEditor.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

----

From #1261 
For #1253 