### PR TITLE
[lint] Add no-unused-vars rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,7 @@
       "no-extra-semi": "warn",
       "no-case-declarations": "warn",
       "no-useless-escape" : "warn",
-      "no-prototype-builtins": "warn"
+      "no-prototype-builtins": "warn",
+      "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]
   }
 }


### PR DESCRIPTION
This commit adds no-unused-vars rule to linter.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

Waiting for #1274
Waiting for #1300