### PR TITLE
[OneToolchain] Change ONEToolchain and ONECompiler name

### DIFF
--- a/src/Backend/API.ts
+++ b/src/Backend/API.ts
@@ -20,7 +20,7 @@ import {Backend} from './Backend';
 import {gToolchainEnvMap, ToolchainEnv} from '../Toolchain/ToolchainEnv';
 import {Logger} from '../Utils/Logger';
 import {Executor} from './Executor';
-import {ONEToolchain} from './ONE/ONEToolchain';
+import {OneToolchain} from './One/OneToolchain';
 
 /**
  * Interface of backend map
@@ -63,7 +63,7 @@ function backendRegistrationApi() {
     }
   };
 
-  registrationAPI.registerBackend(new ONEToolchain());
+  registrationAPI.registerBackend(new OneToolchain());
 
   return registrationAPI;
 }

--- a/src/Backend/One/OneToolchain.ts
+++ b/src/Backend/One/OneToolchain.ts
@@ -20,7 +20,7 @@ import {Compiler} from '../Compiler';
 import {Executor} from '../Executor';
 import {Toolchains} from '../Toolchain';
 
-class ToolchainCompiler implements Compiler {
+class OneCompiler implements Compiler {
   private readonly toolchainTypes: string[];
 
   constructor() {
@@ -44,13 +44,13 @@ class ToolchainCompiler implements Compiler {
   }
 }
 
-class ONEToolchain implements Backend {
+class OneToolchain implements Backend {
   private readonly backendName: string;
   private readonly toolchainCompiler: Compiler|undefined;
 
   constructor() {
     this.backendName = 'ONE';
-    this.toolchainCompiler = new ToolchainCompiler();
+    this.toolchainCompiler = new OneCompiler();
   }
 
   name(): string {
@@ -70,4 +70,4 @@ class ONEToolchain implements Backend {
   }
 }
 
-export {ToolchainCompiler, ONEToolchain};
+export {OneCompiler, OneToolchain};

--- a/src/Tests/Backend/Backend.test.ts
+++ b/src/Tests/Backend/Backend.test.ts
@@ -20,7 +20,7 @@ import {backendRegistrationApi, globalBackendMap, globalExecutorArray} from '../
 import {Backend} from '../../Backend/Backend';
 import {Compiler, CompilerBase} from '../../Backend/Compiler';
 import {Executor, ExecutorBase} from '../../Backend/Executor';
-import {ONEToolchain} from '../../Backend/ONE/ONEToolchain';
+import {OneToolchain} from '../../Backend/One/OneToolchain';
 import {gToolchainEnvMap} from '../../Toolchain/ToolchainEnv';
 
 const oneBackendName = 'ONE';
@@ -56,9 +56,9 @@ class ExecutorMockup extends ExecutorBase {
 
 suite('Backend', function() {
   suite('backendRegistrationApi', function() {
-    test('registers a ONEToolchain', function() {
+    test('registers a OneToolchain', function() {
       backendRegistrationApi();
-      let oneBackend = new ONEToolchain();
+      let oneBackend = new OneToolchain();
       assert.strictEqual(Object.entries(globalBackendMap).length, 1);
       assert.strictEqual(globalExecutorArray.length, 0);
 

--- a/src/Tests/Backend/One/OneToolchain.test.ts
+++ b/src/Tests/Backend/One/OneToolchain.test.ts
@@ -16,15 +16,15 @@
 
 import {assert} from 'chai';
 
-import {ONEToolchain, ToolchainCompiler} from '../../../Backend/ONE/ONEToolchain';
+import {OneCompiler, OneToolchain} from '../../../Backend/One/OneToolchain';
 
 const oneBackendName = 'ONE';
 
 suite('Backend', function() {
-  suite('ToolchainCompiler', function() {
+  suite('OneCompiler', function() {
     suite('#constructor()', function() {
-      test('Create dummy ONEToolchain compiler', function(pass) {
-        assert.doesNotThrow(() => new ToolchainCompiler());
+      test('Create OneToolchain compiler', function(pass) {
+        assert.doesNotThrow(() => new OneCompiler());
 
         pass();
         assert.ok(true);
@@ -48,10 +48,10 @@ suite('Backend', function() {
     // });
   });
 
-  suite('ONEToolchain', function() {
+  suite('OneToolchain', function() {
     suite('#constructor()', function() {
-      test('Create dummy ONEToolchain backend', function(pass) {
-        assert.doesNotThrow(() => new ONEToolchain());
+      test('Create dummy OneToolchain backend', function(pass) {
+        assert.doesNotThrow(() => new OneToolchain());
 
         pass();
         assert.ok(true);
@@ -60,7 +60,7 @@ suite('Backend', function() {
 
     suite('#name()', function() {
       test('returns backend name', function() {
-        const oneBackend = new ONEToolchain();
+        const oneBackend = new OneToolchain();
         assert.strictEqual(oneBackend.name(), oneBackendName);
       });
     });


### PR DESCRIPTION
Because OneExplorer used `One` prefix, modify the file and directory name in the same format.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>