### PR TITLE
[lint] Use eslint:recommended

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,9 @@
     "Thenable": true,
     "NodeJS": true
   },
+  "extends": [
+    "eslint:recommended"
+  ],
   "rules": {
       "@typescript-eslint/naming-convention": "warn",
       "@typescript-eslint/semi": "warn",
@@ -29,6 +32,7 @@
       "no-case-declarations": "warn",
       "no-useless-escape" : "warn",
       "no-prototype-builtins": "warn",
-      "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]
+      "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
+      "no-undef": "off"
   }
 }


### PR DESCRIPTION
Let's finally use eslint:recommended
NOTE 'no-undef' rule is off because the most vscode-webview's client-side codes 'document' and 'window'

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

For #1253