### PR TITLE
[Metadata Provider] Add a Util Function that isOneExploereTargetFile

### DIFF
--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -135,3 +135,10 @@ export async function saveDirtyDocuments(filepath: string): Promise<boolean> {
     return false;
   }
 }
+
+// TODO Manager target file ext in ONE Explorer
+export function isOneExplorerTargetFile(uri: vscode.Uri): boolean {
+  const path = uri.path;
+  const ends = ['.pb', '.onnx', '.tflite', '.circle', '.cfg', '.log'];
+  return ends.some((x) => path.endsWith(x));
+}


### PR DESCRIPTION
This PR introduces a function that checks if a file is a model or product file. This function verfies thath the input Uri ends with the specific extension we want.

ONE-vscode-DCO-1.0-Signed-off-by: HyeonMyeong Jung <gandi0330@naver.com>