### PR TITLE
[Toolchain] Use spawnsync instead of execSync

### DIFF
--- a/src/Backend/One/OneToolchain.ts
+++ b/src/Backend/One/OneToolchain.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import {execSync} from 'child_process';
+import * as cp from 'child_process';
 import * as vscode from 'vscode';
 
+import {pipedSpawnSync} from '../../Utils/PipedSpawnSync';
 import {Backend} from '../Backend';
 import {Command} from '../Command';
 import {Compiler} from '../Compiler';
@@ -111,24 +112,28 @@ class OneCompiler implements Compiler {
     }
 
     try {
-      execSync(`apt-cache show ${this.toolchainName}`);
+      cp.spawnSync(`apt-cache show ${this.toolchainName}`);
     } catch (error) {
       throw Error(`Getting ${this.toolchainName} package list is failed`);
     }
 
-    const availableToolchains = new Toolchains();
-
-    let toolchainVersions: string;
+    let result;
     try {
-      toolchainVersions =
-          execSync(`apt-cache show ${this.toolchainName} | grep Version | awk '{print $2}' | xargs`)
-              .toString();
+      result = pipedSpawnSync(
+          'apt-cache', ['madison', `${this.toolchainName}`], {encoding: 'utf8'}, 'awk',
+          ['{printf $1" "$3}'], {encoding: 'utf8'});
     } catch (error) {
       throw Error(`Getting ${this.toolchainName} package version list is failed`);
     }
 
+    if (result.status !== 0) {
+      return [];
+    }
+
+    const toolchainVersions: string = result.stdout.toString();
     const versionList = toolchainVersions.trim().split(' ');
 
+    const availableToolchains = new Toolchains();
     for (const version of versionList) {
       const toolchainInfo =
           new ToolchainInfo(this.toolchainName, 'Description: test', this.parseVersion(version));
@@ -145,29 +150,24 @@ class OneCompiler implements Compiler {
       throw Error(`Invalid toolchain type : ${_toolchainType}`);
     }
 
-    let isInstalledToolchain: string;
+    let result;
     try {
-      isInstalledToolchain =
-          execSync(`dpkg-query --show ${this.toolchainName} > /dev/null 2>&1; echo $?`).toString();
+      result = cp.spawnSync(
+          'dpkg-query',
+          ['--show', `--showformat='\${Version} \${Description}'`, `${this.toolchainName}`],
+          {encoding: 'utf8'});
     } catch (error) {
       throw new Error(`Getting installed ${this.toolchainName} package list is failed`);
     }
 
-    if (parseInt(isInstalledToolchain) !== 0) {
+    if (result.status !== 0) {
       return [];
     }
 
-    const installedToolchains = new Toolchains();
-
-    let installedToolchain: string;
-    try {
-      installedToolchain = execSync(`dpkg-query --show --showformat='\${Version} \${Description}' ${
-                                        this.toolchainName} | xargs`)
-                               .toString();
-    } catch (error) {
-      throw new Error(`Getting installed ${this.toolchainName} package list is failed`);
-    }
-
+    // NOTE
+    // The output format string of dpkg-query is '${Version} ${Description}'.
+    // To remove the first and last single quote character of output string, it slices from 1 to -1.
+    const installedToolchain: string = result.stdout.toString().slice(1, -1);
     const descriptionIdx = installedToolchain.search(' ');
     const versionStr = installedToolchain.slice(0, descriptionIdx).trim();
     const description = installedToolchain.slice(descriptionIdx).trim();
@@ -178,20 +178,21 @@ class OneCompiler implements Compiler {
 
     // TODO
     // onecc-docker's depends should be modified later so that we can read the one-compiler version.
-
     const depends: Array<PackageInfo> = [new PackageInfo('one-compiler', new Version(1, 21, 0))];
     const toolchainInfo =
         new ToolchainInfo(this.toolchainName, description, this.parseVersion(versionStr), depends);
     const toolchain = new OneDebianToolchain(toolchainInfo, this.debianRepo, this.debianArch);
-    installedToolchains.push(toolchain);
-    return installedToolchains;
+    return [toolchain];
   }
 
   prerequisitesForGetToolchains(): Command {
     const extensionId = 'Samsung.one-vscode';
     const ext = vscode.extensions.getExtension(extensionId) as vscode.Extension<any>;
+    if (ext === undefined) {
+      throw new Error(`Cannot find the ${extensionId} extension.`);
+    }
     const scriptPath =
-        vscode.Uri.joinPath(ext!.extensionUri, 'script', 'prerequisitesForGetToolchains.sh').fsPath;
+        vscode.Uri.joinPath(ext.extensionUri, 'script', 'prerequisitesForGetToolchains.sh').fsPath;
 
     const cmd = new Command('/bin/sh', [`${scriptPath}`]);
     cmd.setRoot();

--- a/src/Tests/Backend/One/OneToolchain.test.ts
+++ b/src/Tests/Backend/One/OneToolchain.test.ts
@@ -15,7 +15,6 @@
  */
 
 import {assert} from 'chai';
-import {execSync} from 'child_process';
 import * as vscode from 'vscode';
 
 import {OneCompiler, OneDebianToolchain, OneToolchain} from '../../../Backend/One/OneToolchain';
@@ -158,19 +157,10 @@ suite('OneCompiler', function() {
       assert.isDefined(oneCompiler.getInstalledToolchains);
     });
 
-    test('NEG: check invalid toolchain', function() {
-      const dummyToolchainName = 'dummyToolchain';
-      const isInstalledToolchain =
-          execSync(`dpkg-query --show ${dummyToolchainName} > /dev/null 2>&1; echo $?`).toString();
-      assert.strictEqual(parseInt(isInstalledToolchain), 1);
-    });
-
     test('NEG: request wrong toolchain type', function() {
       const oneCompiler = new OneCompiler();
       const dummyToolchainType = 'dummy';
-      const start = 0;
-      const count = 1;
-      assert.throws(() => oneCompiler.getToolchains(dummyToolchainType, start, count));
+      assert.throws(() => oneCompiler.getInstalledToolchains(dummyToolchainType));
     });
   });
 

--- a/src/Tests/Utils/PipedSpawnSync.test.ts
+++ b/src/Tests/Utils/PipedSpawnSync.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {assert} from 'chai';
+import {spawnSync} from 'child_process';
+
+import {pipedSpawnSync, pipedSpawnSyncStdout} from '../../Utils/PipedSpawnSync';
+
+suite('Utils', function() {
+  suite('#pipedSpawnSync', function() {
+    test('basic pipedSpawnSync', function() {
+      try {
+        let wc = pipedSpawnSync('echo', ['123'], {cwd: '.'}, 'grep', ['123'], {cwd: '.'});
+        assert.isTrue(wc.stdout.toString().startsWith('123'));
+      } catch (err) {
+        assert.fail('Should not reach here');
+      }
+    });
+
+    test('NEG: first cmd fails in pipedSpawnSync', function() {
+      try {
+        pipedSpawnSync('invalid_cmd', ['123'], {}, 'grep', ['not_exist'], {});
+        assert.fail('should not reach here');
+      } catch (err) {
+        assert.ok(true, 'Should be thrown');
+      }
+    });
+
+    test('NEG: second cmd fails in pipedSpawnSync', function() {
+      try {
+        let grep = pipedSpawnSync('echo', ['123'], {}, 'grep', ['not_exist'], {});
+        assert.notEqual(grep.status, 0);
+      } catch (err) {
+        assert.fail('Should not reach here');
+      }
+    });
+
+    test('NEG: do not use sudo -S in pipedSpawnSync', function() {
+      // make sure that sudo pw is not cached
+      spawnSync('sudo', ['-k']);
+
+      try {
+        pipedSpawnSync('echo', ['incorrect_pw'], {}, 'sudo', ['-S', 'true'], {});
+        assert.fail('should not reach here');
+      } catch (err) {
+        // success
+        assert.isTrue(true);
+      }
+    });
+  });
+
+  suite('#pipedSpawnSyncStdout', function() {
+    test('basic pipedSpawnSyncStdout', function() {
+      try {
+        let grep = pipedSpawnSyncStdout('echo', ['123'], {cwd: '.'}, 'grep', ['123'], {cwd: '.'});
+        assert.isTrue(grep.startsWith('123'));
+      } catch (err) {
+        assert.fail('Should not reach here');
+      }
+    });
+
+    test('NEG: first cmd fails in pipedSpawnSyncStdout', function() {
+      try {
+        pipedSpawnSyncStdout('invalid_cmd', ['123'], {}, 'grep', ['not_exist'], {});
+        assert.fail('should not reach here');
+      } catch (err) {
+        assert.ok(true, 'Should be thrown');
+      }
+    });
+
+    test('NEG: second cmd fails in pipedSpawnSyncStdout', function() {
+      try {
+        pipedSpawnSyncStdout('echo', ['123'], {}, 'grep', ['not_exist'], {});
+        assert.fail('should not reach here');
+      } catch (err) {
+        assert.ok(true, 'Should be thrown');
+      }
+    });
+
+    test('NEG: do not use sudo -S in pipedSpawnSyncStdout', function() {
+      // make sure that sudo pw is not cached
+      spawnSync('sudo', ['-k']);
+
+      try {
+        pipedSpawnSyncStdout('echo', ['incorrect_pw'], {}, 'sudo', ['-S', 'true'], {});
+        assert.fail('should not reach here');
+      } catch (err) {
+        // success
+        assert.isTrue(true);
+      }
+    });
+  });
+});

--- a/src/Utils/PipedSpawnSync.ts
+++ b/src/Utils/PipedSpawnSync.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {spawnSync, SpawnSyncOptions} from 'child_process';
+
+/**
+ * Function that call cmd1 and then cmd2. stdout of cmd1 is put into stdin of cmd2.
+ *
+ * When error happens during cmd1, Error will be thrown.
+ * Otherwise, result after calling spawnSync(cmd2,...) will be returned.
+ */
+export function pipedSpawnSync(
+    cmd1: string, cmd1Args: string[], cmd1Option: SpawnSyncOptions, cmd2: string,
+    cmd2Args: string[], cmd2Option: SpawnSyncOptions) {
+  if (cmd2 === 'sudo' && cmd2Args.includes('-S')) {
+    // In case of command, e.g., 'echo wrong_pw | sudo -S ls', sometimes it takes long time(> 2 sec)
+    // before `sudo` exits with code === 1. So it would be better to use `pipedSpawn()` instead.
+    const msg = 'Use pipedSpawn() instead';
+    console.log('[error][pipedSpawnSync]', msg);
+    throw Error(msg);
+  }
+
+  // Let's handle `$ cmd1 | cmd2` in sync mode
+  const mergedSpawnOption1: SpawnSyncOptions = {
+    // NOTE: interesting JS syntax. This creates an object by merging two objects with '...' prefix.
+    ...cmd1Option,
+    ...{
+      // In out test, apt-cache sometime returns 13MB text.
+      // Let's make it reasonably big.
+      maxBuffer: 1024 * 1024 * 64
+    }
+  };
+  const first = spawnSync(cmd1, cmd1Args, mergedSpawnOption1);
+
+  if (first.status === 0) {
+    const mergedSpawnOption2: SpawnSyncOptions = {
+      ...cmd2Option,
+      ...{
+        input: first.stdout
+      }
+    };
+    return spawnSync(cmd2, cmd2Args, mergedSpawnOption2);
+  } else {
+    const msg = `Error: running ${cmd1} failed. Exit code: ${first.status}, stdout: ${
+        first.stdout}, stderr: ${first.stderr}`;
+    console.log('[error][pipedSpawnSync]', msg);
+    throw Error(msg);
+  }
+}
+
+/**
+ * Function that call cmd1 and then cmd2. stdout of cmd1 is put into stdin of cmd2.
+ *
+ * When exit code is not 0 after running cmd1 or cmd2, Error will be thrown.
+ * Otherwise, it returns stdout of cmd2.
+ */
+export function pipedSpawnSyncStdout(
+    cmd1: string, cmd1Args: string[], cmd1Option: SpawnSyncOptions, cmd2: string,
+    cmd2Args: string[], cmd2Option: SpawnSyncOptions): string {
+  let stdout: string|null = null;
+
+  try {
+    let cmd1Result = pipedSpawnSync(cmd1, cmd1Args, cmd1Option, cmd2, cmd2Args, cmd2Option);
+    if (cmd1Result.status !== 0) {
+      const msg = `${cmd1} exists with code ${cmd1Result.status}`;
+      console.log(msg);
+      throw Error(msg);
+    } else {
+      stdout = cmd1Result.stdout.toString();
+    }
+  } catch (cmd2Err) {
+    console.log(cmd2Err);
+    throw cmd2Err;
+  }
+
+  return stdout;
+}


### PR DESCRIPTION
The execSync has a security issue.
So this PR modifies `execSync` to `spawnSync`.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

/cc @llFreetimell @Samsung/ootpg_vscode 