### PR TITLE
[OneToolchain] Returns the output value as it is

### DIFF
--- a/script/prerequisitesForGetToolchains.sh
+++ b/script/prerequisitesForGetToolchains.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 # This shell script add PPA to get onecc-docker package for ONEToolchain.
 
 PPA_NAME="ppa:one-compiler/onecc-docker"
 
-add-apt-repository -y ${PPA_NAME} > /dev/null 2>&1 &&
-        apt-get update > /dev/null 2>&1
+add-apt-repository -y ${PPA_NAME}
+apt-get update -yqq


### PR DESCRIPTION
This commit returns the output value as it is.
This allows the log to be displayed and the output to be handled.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

~~fix this bug: https://github.com/Samsung/ONE-vscode/pull/1333#issuecomment-1268162214, #1335~~