### PR TITLE
[Tests/Utils] Add missing assert

### DIFF
--- a/src/Tests/Utils/Hash.test.ts
+++ b/src/Tests/Utils/Hash.test.ts
@@ -48,6 +48,7 @@ suite('Utils', function() {
         const notExistingPath = testBuilder.getPath('non-existing');
         generateHash(vscode.Uri.file(notExistingPath)).catch(() => {
           pass();
+          assert.ok(true);
         });
       });
     });


### PR DESCRIPTION
This commit adds missing assert in test case for `Utils/Hash`.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>