### PR TITLE
DRAFT: [OneExplorer] Support refactoring by renaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,11 @@
         "icon": "$(play)"
       },
       {
+        "command": "one.explorer.rename",
+        "title": "Rename",
+        "category": "ONE"
+      },
+      {
         "command": "one.explorer.delete",
         "title": "Delete",
         "category": "ONE"
@@ -272,6 +277,11 @@
           "group": "inline"
         },
         {
+          "command": "one.explorer.rename",
+          "when": "view == OneExplorerView && viewItem != directory",
+          "group": "7_modification"
+        },
+        {
           "command": "one.explorer.delete",
           "when": "view == OneExplorerView",
           "group": "7_modification@9"
@@ -338,6 +348,10 @@
         },
         {
           "command": "one.toolchain.setDefaultToolchain",
+          "when": "false"
+        },
+        {
+          "command": "one.explorer.rename",
           "when": "false"
         },
         {

--- a/src/OneExplorer/ConfigObject.ts
+++ b/src/OneExplorer/ConfigObject.ts
@@ -17,12 +17,25 @@
 import * as fs from 'fs';
 import * as ini from 'ini';
 import * as path from 'path';
+import {TextEncoder} from 'util';
 import * as vscode from 'vscode';
 
 import {RealPath} from '../Utils/Helpers';
 import {Logger} from '../Utils/Logger';
 
 import {Artifact, Locator, LocatorRunner} from './ArtifactLocator';
+
+type Cfg = {
+  'one-import-tflite': CfgOneImportTflite,
+  'one-import-onnx': CfgOneImportOnnx,
+  'one-import-tf': CfgOneImportTf,
+};
+type CfgKeys = keyof Cfg;
+
+// TODO Update
+type CfgOneImportTflite = any;
+type CfgOneImportOnnx = any;
+type CfgOneImportTf = any;
 
 /**
  * @brief A helper class to get parsed artifacts (baseModels, products)
@@ -46,7 +59,7 @@ export class ConfigObj {
   /**
    * a raw ini object read from config file
    */
-  rawObj: object;
+  rawObj: Cfg;
 
   /**
    * a parsed config object
@@ -79,6 +92,15 @@ export class ConfigObj {
   }
 
   /**
+   * @breif Get absolute path
+   * @param path Relative path of cfg file
+   */
+  getFullPath(relpath: string) {
+    const abspath = path.resolve(path.dirname(this.uri.fsPath), relpath);
+    return abspath;
+  }
+
+  /**
    * @brief Return true if the `baseModelPath` is included in `baseModels`
    */
   public isChildOf(baseModelPath: string): boolean {
@@ -88,13 +110,39 @@ export class ConfigObj {
     return found ? true : false;
   }
 
-  private constructor(uri: vscode.Uri, rawObj: object) {
+  private constructor(uri: vscode.Uri, rawObj: Cfg) {
     this.uri = uri;
     this.rawObj = rawObj;
     this.obj = {
       baseModels: ConfigObj.parseBaseModels(uri.fsPath, rawObj),
       products: ConfigObj.parseProducts(uri.fsPath, rawObj)
     };
+  }
+
+  public updateBaseModelField(oldname: string, newname: string): Thenable<void> {
+    const getSection = (name: string) => {
+      const ext = path.extname(name);
+      const sections = {
+        '.pb': 'one-import-tf',
+        '.tflite': 'one-import-tflite',
+        '.onnx': 'one-import-onnx'
+      };
+
+      return sections[ext as keyof typeof sections];
+    };
+
+    const section: string = getSection(oldname);
+    const kSection: CfgKeys = section as keyof Cfg;
+
+    if (this.rawObj[kSection].input_path &&
+        this.getFullPath(this.rawObj[kSection].input_path) === oldname) {
+      this.rawObj[kSection].input_path = newname;
+    } else {
+      Logger.warn('ConfigObject', `Cannot update base model field: ${oldname} not found`);
+    }
+
+    return vscode.workspace.fs.writeFile(
+        this.uri, (new TextEncoder).encode(ini.stringify(this.rawObj)));
   }
 
   /**
@@ -112,7 +160,7 @@ export class ConfigObj {
       return null;
     }
 
-    return new ConfigObj(uri, obj);
+    return new ConfigObj(uri, obj as Cfg);
   }
 
   /**


### PR DESCRIPTION
This commit enables refactoring by renaming.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

----

For #768


## GIF
![1017-refactor](https://user-images.githubusercontent.com/17171963/196078229-e93b2eae-cfb2-40ce-9782-409dc8071064.gif)

