### PR TITLE
[OneExplorer] Revive rename command

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,11 @@
         "icon": "$(play)"
       },
       {
+        "command": "one.explorer.rename",
+        "title": "Rename",
+        "category": "ONE"
+      },
+      {
         "command": "one.explorer.delete",
         "title": "Delete",
         "category": "ONE"
@@ -272,6 +277,11 @@
           "group": "inline"
         },
         {
+          "command": "one.explorer.rename",
+          "when": "view == OneExplorerView && viewItem != directory",
+          "group": "7_modification"
+        },
+        {
           "command": "one.explorer.delete",
           "when": "view == OneExplorerView",
           "group": "7_modification@9"
@@ -338,6 +348,10 @@
         },
         {
           "command": "one.toolchain.setDefaultToolchain",
+          "when": "false"
+        },
+        {
+          "command": "one.explorer.rename",
           "when": "false"
         },
         {

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -641,20 +641,29 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
     // TODO: prohibit special characters for security ('..', '*', etc)
     let warningMessage;
 
-    if (node.type === NodeType.baseModel) {
-      // TODO automatically change the corresponding files
-      warningMessage = `WARNING! ${
-          node.getChildren()
-              .map(node => `'${node.name}'`)
-              .toString()} will disappear from the view.`;
-    } else if (node.type === NodeType.product) {
-      // TODO automatically change the corresponding files
-      warningMessage = `WARNING! '${node.name}' may disappear from the view.`;
-    } else if (node.type === NodeType.config) {
-      // DO NOTHING
-      // Renaming config doesn't affect ONE Explorer view
-    } else if (node.type === NodeType.directory) {
-      assert.fail('Renaming is not allowed for directories.');
+    switch (node.type) {
+      case NodeType.baseModel:
+        // TODO automatically change the corresponding files
+        warningMessage = `WARNING! ${
+            node.getChildren()
+                .map(node => `'${node.name}'`)
+                .toString()} will disappear from the view.`;
+        break;
+      case NodeType.product:
+        // TODO automatically change the corresponding files
+        warningMessage = `WARNING! '${node.name}' may disappear from the view.`;
+        break;
+      case NodeType.config:
+        // DO NOTHING
+        // Renaming config doesn't affect ONE Explorer view
+        break;
+      case NodeType.directory:
+        assert.fail('Renaming is not allowed for directories.');
+        break;
+      default: {
+        // ..
+        break;
+      }
     }
 
     const validateInputPath = (newname: string): string|undefined => {

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -533,6 +533,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
             vscode.commands.executeCommand('one.toolchain.runCfg', node.uri.fsPath);
           }),
       vscode.commands.registerCommand('one.explorer.delete', (node: Node) => provider.delete(node)),
+      vscode.commands.registerCommand('one.explorer.rename', (node: Node) => provider.rename(node)),
     ];
 
     if (provider.isLocal) {
@@ -629,6 +630,69 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
    */
   openContainingFolder(node: Node): void {
     vscode.commands.executeCommand('revealFileInOS', node.uri);
+  }
+
+  /**
+   * Rename a file of all types of nodes (baseModel, product, config) excepts for directory.
+   * It only alters the file name, not the path.
+   * @command one.explorer.rename
+   */
+  rename(node: Node): void {
+    // TODO: prohibit special characters for security ('..', '*', etc)
+    let warningMessage;
+
+    if (node.type === NodeType.baseModel) {
+      // TODO automatically change the corresponding files
+      warningMessage = `WARNING! ${
+          node.getChildren()
+              .map(node => `'${node.name}'`)
+              .toString()} will disappear from the view.`;
+    } else if (node.type === NodeType.product) {
+      // TODO automatically change the corresponding files
+      warningMessage = `WARNING! '${node.name}' may disappear from the view.`;
+    } else if (node.type === NodeType.config) {
+      // DO NOTHING
+      // Renaming config doesn't affect ONE Explorer view
+    } else if (node.type === NodeType.directory) {
+      assert.fail('Renaming is not allowed for directories.');
+    }
+
+    const validateInputPath = (newname: string): string|undefined => {
+      const oldpath = node.path;
+      const dirpath = path.dirname(node.uri.fsPath);
+      const newpath: string = path.join(dirpath, newname);
+      if (!newname.endsWith(path.extname(oldpath))) {
+        // NOTE
+        // `if (path.extname(newpath) !== path.extname(oldpath))`
+        // Do not use above code here.
+        // It will evaluate '.tflite' as false, because it's extname is ''.
+        return `A file extension must be (${path.extname(oldpath)})`;
+      }
+      if (newpath !== oldpath && fs.existsSync(newpath)) {
+        return `A file or folder ${
+            newname} already exists at this location. Please choose a different name.`;
+      }
+    };
+
+    vscode.window
+        .showInputBox({
+          title: 'Enter a file name:',
+          value: `${path.basename(node.uri.fsPath)}`,
+          valueSelection:
+              [0, path.basename(node.uri.fsPath).length - path.parse(node.uri.fsPath).ext.length],
+          placeHolder: `Enter a new name for ${path.basename(node.uri.fsPath)}`,
+          prompt: warningMessage,
+          validateInput: validateInputPath
+        })
+        .then(newname => {
+          if (newname) {
+            const dirpath = path.dirname(node.uri.fsPath);
+            const newpath = `${dirpath}/${newname}`;
+            vscode.workspace.fs.rename(node.uri, vscode.Uri.file(newpath)).then(() => {
+              this.refresh();
+            });
+          }
+        });
   }
 
   /**

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -661,7 +661,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
         assert.fail('Renaming is not allowed for directories.');
         break;
       default: {
-        // ..
+        assert.fail('Cannot reach here');
         break;
       }
     }


### PR DESCRIPTION
This commit revives rename command which is deprecated by #1243.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

FOR REVIEWERS,

This is a baseline for 'Cfg Refactoring' feature, which replaces input_file names with the new one when the mode file name is changed.

For #1359


## GIF

NOTE That the behavior is the same as before, it's just a revival of the same old 'rename' command.

![1017-revive](https://user-images.githubusercontent.com/17171963/196081183-b70a8b8a-8326-425d-99e3-8e97fb5f3105.gif)
