### PR TITLE
[OneExplorer] Support refactoring by renaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
       },
       {
         "command": "one.explorer.refactor",
-        "title": "Refactor",
+        "title": "Rename Model",
         "category": "ONE"
       },
       {

--- a/package.json
+++ b/package.json
@@ -166,6 +166,11 @@
         "category": "ONE"
       },
       {
+        "command": "one.explorer.refactor",
+        "title": "Refactor",
+        "category": "ONE"
+      },
+      {
         "command": "one.explorer.delete",
         "title": "Delete",
         "category": "ONE"
@@ -292,6 +297,11 @@
           "group": "7_modification"
         },
         {
+          "command": "one.explorer.refactor",
+          "when": "view == OneExplorerView && viewItem == baseModel",
+          "group": "7_modification"
+        },
+        {
           "command": "one.explorer.delete",
           "when": "view == OneExplorerView",
           "group": "7_modification@9"
@@ -362,6 +372,10 @@
         },
         {
           "command": "one.explorer.rename",
+          "when": "false"
+        },
+        {
+          "command": "one.explorer.refactor",
           "when": "false"
         },
         {

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -742,7 +742,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
         if (cfgObj) {
           const oldpath = node.path;
           return cfgObj.updateBaseModelField(oldpath, newpath).then(() => {
-            return Logger.info(
+            Logger.info(
                 'OneExplorer', `Replaced ${oldpath} with ${newpath} in ${child.path}`);
           });
         }

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -742,8 +742,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
         if (cfgObj) {
           const oldpath = node.path;
           return cfgObj.updateBaseModelField(oldpath, newpath).then(() => {
-            Logger.info(
-                'OneExplorer', `Replaced ${oldpath} with ${newpath} in ${child.path}`);
+            Logger.info('OneExplorer', `Replaced ${oldpath} with ${newpath} in ${child.path}`);
           });
         }
       }));


### PR DESCRIPTION
This commit enables refactoring by renaming,
so that the model file renaming can be automatically applied to related
config files.
It renames all the changed model file names in children config files.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

----

Waiting for #1388 to be merged
For #768

## GIF (Updated, 2022-10-19)

NOTE: Command name is changed from `Refactor` to `Rename Model` after taking this video. 
![1019-refactor](https://user-images.githubusercontent.com/17171963/196652802-6fbec286-a004-45d8-87ef-c6b3af6879b9.gif)
