### PR TITLE
[Utils] Fix wrong return type for filter function

### DIFF
--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -108,8 +108,9 @@ export interface FileSelector {
 export async function saveDirtyDocuments(filepath: string): Promise<boolean> {
   const unsavedDocuments = vscode.workspace.textDocuments.filter(td => {
     if ((td.fileName === filepath) && td.isDirty) {
-      return td;
+      return true;
     }
+    return false;
   });
 
   if (unsavedDocuments.length === 0) {


### PR DESCRIPTION
`filter` function for array type should return boolean values. This commit will fix it.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>