### PR TITLE
[MetadataManager] Return consistent type

### DIFF
--- a/src/MetadataManager/Metadata.ts
+++ b/src/MetadataManager/Metadata.ts
@@ -97,7 +97,8 @@ export class Metadata {
 
   public static async getObj(hash: string) {
     if (!vscode.workspace.workspaceFolders) {
-      return;
+      // TODO: Error Handling
+      return undefined;
     }
 
     const jsonUri = vscode.Uri.joinPath(


### PR DESCRIPTION
`getObj` function in `Metadata` was not returning consistent type. This commit will fix it.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>