### PR TITLE
[Toolchain] Return consistent type

### DIFF
--- a/src/Toolchain/ToolchainProvider.ts
+++ b/src/Toolchain/ToolchainProvider.ts
@@ -287,6 +287,8 @@ export class ToolchainProvider implements vscode.TreeDataProvider<BaseNode> {
     if (proceed) {
       return this._run(cfg);
     }
+
+    return false;
   }
 
   public setDefaultToolchain(tnode: ToolchainNode): boolean|undefined {


### PR DESCRIPTION
`run` function in `ToolchainProvider` was not returning consistent type. This commit will fix it.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>