### PR TITLE
[vscode] Add a recommended extension for a workspace

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-		"dbaeumer.vscode-eslint"
+		"dbaeumer.vscode-eslint",
+		"xaver.clang-format"
 	]
 }


### PR DESCRIPTION
This commit adds xaver.clang-format as a recommended extension for a workspace.

ONE-vscode-DCO-1.0-Signed-off-by: Changho Shin <chshin59@gmail.com>