### PR TITLE
[CircleEditor] Add external directory to excluding list

### DIFF
--- a/.ahub/sam/exclude.txt
+++ b/.ahub/sam/exclude.txt
@@ -1,2 +1,3 @@
 # External code
 /ONE-vscode/media/CircleGraph/external
+/ONE-vscode/media/CircleEditor/external


### PR DESCRIPTION
This commit adds `media/CircleEditor/external` directory to excluding list.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>