### PR TITLE
[MetadataViewer] Hide from the menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,16 +109,6 @@
         "priority": "option"
       },
       {
-        "viewType": "one.viewer.metadata",
-        "displayName": "Metadata Viewer",
-        "selector": [
-          {
-            "filenamePattern": "*"
-          }
-        ],
-        "priority": "option"
-      },
-      {
         "viewType": "one.viewer.visq",
         "displayName": "Visq Viewer",
         "selector": [
@@ -325,18 +315,6 @@
           "command": "one.toolchain.uninstall",
           "when": "view == ToolchainView && viewItem =~ /toolchain/ && !one.job:running",
           "group": "inline"
-        },
-        {
-          "command": "one.viewer.metadata.showFromOneExplorer",
-          "when": "view == OneExplorerView && viewItem =~ /baseModel|product/",
-          "group": "7_metadata@1"
-        }
-      ],
-      "explorer/context": [
-        {
-          "command": "one.viewer.metadata.showFromDefaultExplorer",
-          "when": "resourceExtname in one.metadata.supportedFiles && !explorerResourceIsFolder",
-          "group": "7_metadata@1"
         }
       ],
       "commandPalette": [


### PR DESCRIPTION
This commit hides MetadataViewer command as it now only shows the sample viewer. Let's enable this when the backend comes in.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>