### PR TITLE
[MetadataManager] Fix incorrect return type for callback function

### DIFF
--- a/src/MetadataManager/PathToHash.ts
+++ b/src/MetadataManager/PathToHash.ts
@@ -181,10 +181,9 @@ export class PathToHash {
     let map = this._map;
 
     splitPath.forEach((path) => {
-      if (map === undefined) {
-        return undefined;
+      if (map !== undefined) {
+        map = map[path];
       }
-      map = map[path];
     });
 
     return map;


### PR DESCRIPTION
`forEach` function requires a function who returns `void`. This commit will fix it.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>