### PR TITLE
[OneExplorer] Build a node map on demand

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -471,7 +471,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
 
   // NOTE
   // _nodeMap only contains the nodes which have ever been shown in ONE Explorer view by revealing
-  // the parent nodes. To get the unseen node from _nodeMap, _nodeMap needs to be pre-builted. Mind
+  // the parent nodes. To get the unseen node from _nodeMap, _nodeMap needs to be pre-built. Mind
   // that it will slow down the extension to gather data about unseen nodes.
   // Currently, only the two depths from those shown nodes are built.
   private _nodeMap: Map<string, Node> = new Map<string, Node>();


### PR DESCRIPTION
This commit removes the stage of pre-building a node map on the beginning. _nodeMap will collect the path-to-node relation when getTreeItem() is called, which is a function called when the node is shown on the view.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

From #1402