### PR TITLE
[OneExplorer] Remove unused getCfgList()

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -32,56 +32,12 @@ import {OneStorage} from './OneStorage';
 export {
   BaseModelNode as _unit_test_BaseModelNode,
   ConfigNode as _unit_test_ConfigNode,
-
   DirectoryNode as _unit_test_DirectoryNode,
-  getCfgList as _unit_test_getCfgList,
-
   NodeFactory as _unit_test_NodeFactory,
   NodeType as _unit_test_NodeType,
   OneNode as _unit_test_OneNode,
   ProductNode as _unit_test_ProductNode,
 };
-
-/**
- * TODO Remove
- *
- * Get the list of .cfg files wiithin the workspace
- * @param root  the file or directory,
- *              which MUST exist in the file system
- */
-function getCfgList(root: string = obtainWorkspaceRoot()): string[] {
-  /**
-   * Returns every file inside directory
-   * @todo Check soft link
-   * @param root
-   * @returns
-   */
-  const readdirSyncRecursive = (root: string): string[] => {
-    if (fs.statSync(root).isFile()) {
-      return [root];
-    }
-
-    let children: string[] = [];
-    if (fs.statSync(root).isDirectory()) {
-      fs.readdirSync(root).forEach(val => {
-        children = children.concat(readdirSyncRecursive(path.join(root, val)));
-      });
-    }
-    return children;
-  };
-
-  try {
-    fs.statSync(root);
-  } catch {
-    Logger.error('OneExplorer', 'getCfgList', 'called on not existing directory or file.');
-    return [];
-  }
-
-  // Get the list of all the cfg files inside workspace root
-  const cfgList = readdirSyncRecursive(root).filter(val => val.endsWith('.cfg'));
-
-  return cfgList;
-}
 
 /**
  * NOTE

--- a/src/OneExplorer/OneStorage.ts
+++ b/src/OneExplorer/OneStorage.ts
@@ -85,7 +85,7 @@ export class OneStorage {
     try {
       return readdirSyncRecursive(root).filter(val => val.endsWith('.cfg'));
     } catch {
-      Logger.error('OneExplorer', 'getCfgList', 'called on not existing directory or file.');
+      Logger.error('OneExplorer', '_initCfgList', 'called on not existing directory or file.');
       return [];
     }
   }

--- a/src/Tests/OneExplorer/OneExplorer.test.ts
+++ b/src/Tests/OneExplorer/OneExplorer.test.ts
@@ -17,7 +17,7 @@
 import {assert} from 'chai';
 import * as vscode from 'vscode';
 
-import {_unit_test_BaseModelNode as BaseModelNode, _unit_test_ConfigNode as ConfigNode, _unit_test_getCfgList as getCfgList, _unit_test_NodeFactory as NodeFactory, _unit_test_NodeType as NodeType, _unit_test_OneNode as OneNode, _unit_test_ProductNode as ProductNode} from '../../OneExplorer/OneExplorer';
+import {_unit_test_BaseModelNode as BaseModelNode, _unit_test_ConfigNode as ConfigNode, _unit_test_NodeFactory as NodeFactory, _unit_test_NodeType as NodeType, _unit_test_OneNode as OneNode, _unit_test_ProductNode as ProductNode} from '../../OneExplorer/OneExplorer';
 import {TestBuilder} from '../TestBuilder';
 
 suite('OneExplorer', function() {
@@ -32,59 +32,6 @@ suite('OneExplorer', function() {
       testBuilder.tearDown();
     });
 
-    suite('#getCfgList()', function() {
-      test('NEG: get empty cfg list', function() {
-        const cfgList = getCfgList(testBuilder.getPath(''));
-        { assert.strictEqual(cfgList.length, 0); }
-      });
-
-      test('NEG: get cfg list on not existing path', function() {
-        const cfgList = getCfgList(testBuilder.getPath(''));
-        { assert.strictEqual(cfgList.length, 0); }
-      });
-
-      test('get cfg list', function() {
-        const configName1 = 'test1.cfg';
-        const configName2 = 'test2.cfg';
-
-        // Write a file inside temp directory
-        testBuilder.writeFileSync(configName1, '');
-        testBuilder.writeFileSync(configName2, '');
-
-        // Get file paths inside the temp directory
-        const configPath1 = testBuilder.getPath(configName1);
-        const configPath2 = testBuilder.getPath(configName2);
-
-        const cfgList = getCfgList(testBuilder.getPath(''));
-        {
-          assert.isTrue(cfgList.includes(configPath1));
-          assert.isTrue(cfgList.includes(configPath2));
-        }
-      });
-
-      test('get cfg list recursively', function() {
-        const configName1 = 'test1/test1.cfg';
-        const configName21 = 'test2/test2.1.cfg';
-        const configName22 = 'test2/test2.2.cfg';
-
-        // Write a file inside temp directory
-        testBuilder.writeFileSync(configName1, '');
-        testBuilder.writeFileSync(configName21, '');
-        testBuilder.writeFileSync(configName22, '');
-
-        // Get file paths inside the temp directory
-        const configPath1 = testBuilder.getPath(configName1);
-        const configPath21 = testBuilder.getPath(configName21);
-        const configPath22 = testBuilder.getPath(configName22);
-
-        const cfgList = getCfgList(testBuilder.getPath(''));
-        {
-          assert.isTrue(cfgList.includes(configPath1));
-          assert.isTrue(cfgList.includes(configPath21));
-          assert.isTrue(cfgList.includes(configPath22));
-        }
-      });
-    });
 
     suite('#NodeFactory', function() {
       test('NEG: create a directory node with attributes', function() {


### PR DESCRIPTION
This commit removes unused function getCfgList().
It's been replaced with OneStorage class's other functions and it's not used anywhere now.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>