### PR TITLE
[Helpers] Fix obtainWorkspaceRoot

### DIFF
--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -67,27 +67,24 @@ export class RealPath {
 
 /**
  * @brief Get Workspace root folder as string
- * @note  will throw if not working in workspace mode.
+ * @return Return only the first workspaceFolder if multiple root exists, with showing a notfication
+ *     balloon.
+ *         Throws if there is no workspace.
  */
 export function obtainWorkspaceRoot(): string {
   const workspaceFolders = vscode.workspace.workspaceFolders;
-  if (!workspaceFolders) {
-    Logger.error(logTag, 'obtainWorkspaceRoot: NO workspaceFolders');
-    // TODO revise message
+
+  if (!workspaceFolders || workspaceFolders.length === 0) {
+    Logger.info(logTag, 'obtainWorkspaceRoot', 'No WorkspaceFolders');
     throw new Error('Need workspace');
   }
 
-  // TODO support active workspace among the multiple workspaceFolders
   // TODO support multi-root workspace
   if (workspaceFolders.length > 1) {
     Balloon.info('Warning: Only the first workspace directory is currently supported');
   }
+
   const workspaceRoot = workspaceFolders[0].uri.path;
-  if (!workspaceRoot) {
-    Logger.error(logTag, 'obtainWorkspaceRoot: NO workspaceRoot');
-    // TODO revise message
-    throw new Error('Need workspace');
-  }
   Logger.debug(logTag, 'obtainWorkspaceRoot:', workspaceRoot);
 
   return workspaceRoot;

--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -68,8 +68,7 @@ export class RealPath {
 /**
  * @brief Get Workspace root folder as string
  * @return Return only the first workspaceFolder if multiple root exists, with showing a notfication
- *     balloon.
- *         Throws if there is no workspace.
+ *         balloon. Throws if there is no workspace.
  */
 export function obtainWorkspaceRoot(): string {
   const workspaceFolders = vscode.workspace.workspaceFolders;

--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -75,6 +75,7 @@ export function obtainWorkspaceRoot(): string {
 
   if (!workspaceFolders || workspaceFolders.length === 0) {
     Logger.info(logTag, 'obtainWorkspaceRoot', 'No WorkspaceFolders');
+    // TODO revise message
     throw new Error('Need workspace');
   }
 

--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -68,7 +68,7 @@ export class RealPath {
 /**
  * @brief Get Workspace root folder as string
  * @return Return only the first workspaceFolder if multiple root exists, with showing a notfication
- *         balloon. Throws if there is no workspace.
+ *         balloon. Throw if there is no workspace.
  */
 export function obtainWorkspaceRoot(): string {
   const workspaceFolders = vscode.workspace.workspaceFolders;


### PR DESCRIPTION
This commit rewrites obtainWorkspaceRoot.
It fixes the bug of throwing unknown error by accessing workspaceFolders[0].uri.path when worksapceFolder is an empty array but not undefined.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

For #1419