### PR TITLE
[OneExplorer] Simplify getting workspaceRoot 

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -21,8 +21,7 @@ import {TextEncoder} from 'util';
 import * as vscode from 'vscode';
 
 import {CfgEditorPanel} from '../CfgEditor/CfgEditorPanel';
-import {Balloon} from '../Utils/Balloon';
-import {obtainWorkspaceRoot} from '../Utils/Helpers';
+import {getErrorMessage, obtainWorkspaceRoot} from '../Utils/Helpers';
 import {Logger} from '../Utils/Logger';
 
 import {ArtifactAttr} from './ArtifactLocator';
@@ -441,21 +440,12 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
   public static register(context: vscode.ExtensionContext) {
     let workspaceRoot: vscode.Uri|undefined = undefined;
 
-    // TODO: do error handling in one function (helper function or here)
     try {
       workspaceRoot = vscode.Uri.file(obtainWorkspaceRoot());
       Logger.info('OneExplorer', `workspace: ${workspaceRoot.fsPath}`);
     } catch (e: unknown) {
-      if (e instanceof Error) {
-        if (e.message === 'Need workspace') {
-          Logger.info('OneExplorer', e.message);
-        } else {
-          Logger.error('OneExplorer', e.message);
-          Balloon.error('Something goes wrong while setting workspace.', true);
-        }
-      } else {
-        Logger.error('OneExplorer', 'Unknown error has been thrown.');
-      }
+      Logger.info('OneExplorer', getErrorMessage(e));
+      return;
     }
 
     const provider = new OneTreeDataProvider(workspaceRoot, context.extension.extensionKind);

--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -69,7 +69,7 @@ export function getErrorMessage(error: unknown) {
   if (error instanceof Error) {
     return error.message;
   }
-  return String(error);
+  return JSON.stringify(error);
 }
 
 /**

--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -65,6 +65,13 @@ export class RealPath {
   }
 }
 
+export function getErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
 /**
  * @brief Get Workspace root folder as string
  * @return Return only the first workspaceFolder if multiple root exists, with showing a notfication


### PR DESCRIPTION
This commit simplifies the error handling logic
when ONE Explorer sets workspace root.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

For #1419