### PR TITLE
[OneExplorer] Show full path in description

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -389,12 +389,13 @@ class ProductNode extends Node {
 
 export class OneNode extends vscode.TreeItem {
   constructor(
-      public readonly label: string,
       public readonly collapsibleState: vscode.TreeItemCollapsibleState,
       public readonly node: Node,
   ) {
-    super(label, collapsibleState);
+    super(node.name, collapsibleState);
 
+    this.resourceUri = node.uri;
+    this.description = true;
     this.tooltip = `${this.node.path}`;
 
     if (node.openViewType) {
@@ -872,12 +873,11 @@ input_path=${modelName}.${extName}
     this._nodeMap.set(node.path, node);
 
     if (node.type === NodeType.directory) {
-      return new OneNode(node.name, vscode.TreeItemCollapsibleState.Expanded, node);
+      return new OneNode(vscode.TreeItemCollapsibleState.Expanded, node);
     } else if (node.type === NodeType.product) {
-      return new OneNode(node.name, vscode.TreeItemCollapsibleState.None, node);
+      return new OneNode(vscode.TreeItemCollapsibleState.None, node);
     } else if (node.type === NodeType.baseModel || node.type === NodeType.config) {
       return new OneNode(
-          node.name,
           (node.getChildren().length > 0) ? vscode.TreeItemCollapsibleState.Collapsed :
                                             vscode.TreeItemCollapsibleState.None,
           node);

--- a/src/Tests/OneExplorer/OneExplorer.test.ts
+++ b/src/Tests/OneExplorer/OneExplorer.test.ts
@@ -196,8 +196,7 @@ input_file=${baseModelPath}
       test('constructor', function() {
         const directoryPath = testBuilder.getPath('');
         const directoryNode = NodeFactory.create(NodeType.directory, directoryPath, undefined);
-        const oneNode =
-            new OneNode('label', vscode.TreeItemCollapsibleState.Collapsed, directoryNode!);
+        const oneNode = new OneNode(vscode.TreeItemCollapsibleState.Collapsed, directoryNode!);
         { assert.strictEqual(oneNode.contextValue, 'directory'); }
       });
     });


### PR DESCRIPTION
This commit shows parent directory path as description,
to let user notice the file's real path at once.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>


---


### Pictures
#### Before
![1026-label-before](https://user-images.githubusercontent.com/17171963/197920334-e6808b61-352a-4b4d-b42c-b1c17ac0ba42.PNG)


#### After
![1026-label](https://user-images.githubusercontent.com/17171963/197920198-41ad8bdd-224c-4105-9e91-984ccfa71e62.PNG)


--- 

Waiting for #1419 to be merged
