### PR TITLE
[CI] Use pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/check-commit.yml
+++ b/.github/workflows/check-commit.yml
@@ -1,7 +1,7 @@
 name: Check Commit
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ main ]
 
 jobs:

--- a/.github/workflows/check-copyright.yml
+++ b/.github/workflows/check-copyright.yml
@@ -1,7 +1,7 @@
 name: Check Copyright
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ main ]
 
 jobs:
@@ -22,17 +22,7 @@ jobs:
       - run: npm install
       - run: npx ts-node infra/copyright/copyright-checker.ts
 
-      - uses: actions/github-script@v6
-        if: ${{ hashFiles('copyright-checker.fail') }}
-        with:
-          script: |
-            var fs = require('fs');
-            var body_content = fs.readFileSync('copyright-checker.fail', 'utf-8');
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body_content
-            })
-      - run: exit 1
-        if: ${{ hashFiles('copyright-checker.fail') }}
+      - if: ${{ hashFiles('copyright-checker.fail') }}
+        run: |
+          cat copyright-checker.fail
+          exit 1

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -1,7 +1,7 @@
 name: License Verification
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ main ]
     paths: [ 'package.json' ]
 
@@ -62,16 +62,4 @@ jobs:
 
       - run: npm install
       - run: npx ts-node infra/license/check-result-formatter.ts ubuntu-latest.json windows-latest.json macos-latest.json
-
-      - uses: actions/github-script@v6
-        with:
-          script: |
-            var fs = require('fs');
-            var body_content = fs.readFileSync('license_check_result.md', 'utf-8');
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body_content
-            });
+      - run: cat license_check_result.md


### PR DESCRIPTION
This commit substitute `pull_request_target` with `pull_request`.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>