### PR TITLE
[CI] Make CI fail when license verification is failed

### DIFF
--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -62,4 +62,8 @@ jobs:
 
       - run: npm install
       - run: npx ts-node infra/license/check-result-formatter.ts ubuntu-latest.json windows-latest.json macos-latest.json
-      - run: cat license_check_result.md
+
+      - if: ${{ hashFiles('license_check_result.fail') }}
+        run: |
+          cat license_check_result.md
+          exit 1


### PR DESCRIPTION
Until now, CI did not fail even when license verification is failed. It was because maintainers can judge the result by comment. However, as result of license verification is not created anymore, it is better for CI to fail when the verification is failed.

ONE-vscode-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>