### PR TITLE
[OneExplorer] Subscribe omitted disposables

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -530,10 +530,10 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
 
     if (provider.isLocal) {
       registrations = [
-        ...[vscode.commands.registerCommand(
-                'one.explorer.openContainingFolder',
-                (node: Node) => provider.openContainingFolder(node)),
-      ]
+        ...registrations,
+        vscode.commands.registerCommand(
+            'one.explorer.openContainingFolder',
+            (node: Node) => provider.openContainingFolder(node)),
       ];
     } else {
       vscode.commands.executeCommand('setContext', 'one:extensionKind', 'Workspace');


### PR DESCRIPTION
This commit fixes the disposable registrations in OneTreeDataProvider.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung.lee <dayoung.lee@samsung.com>