### PR TITLE
[OneExplorer] Add id to Node

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -94,6 +94,7 @@ enum NodeType {
 
 abstract class Node {
   abstract readonly type: NodeType;
+  public readonly id: string;
   /**
    * @protected _childNodes
    * `undefined` when it's not build yet.
@@ -113,6 +114,7 @@ abstract class Node {
   abstract canHide: boolean;
 
   constructor(uri: vscode.Uri, parent: Node|undefined) {
+    this.id = Math.random().toString();
     this._childNodes = undefined;
     this.uri = uri;
     this._parent = parent;
@@ -394,6 +396,7 @@ export class OneNode extends vscode.TreeItem {
   ) {
     super(node.name, collapsibleState);
 
+    this.id = node.id;
     this.resourceUri = node.uri;
     this.description = true;
     this.tooltip = `${this.node.path}`;


### PR DESCRIPTION
This commit adds id to Node class.
`id` is a member variable kept by TreeItem,
which makes it possible to keep existing node when its name is changed.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

For #1422