### PR TITLE
[OneExplorer] Revisit NodeFactory.create

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -161,14 +161,6 @@ abstract class Node {
 class NodeFactory {
   static create(type: NodeType, fpath: string, parent: Node|undefined, attr?: ArtifactAttr): Node
       |undefined {
-    // WHY HIDDEN NODES ARE NOT TO BE CREATED?
-    //
-    // A 'TreeDataProvider<element>' expects every elements (Node) to be correspond to visible
-    // TreeItem, so let's not build hidden nodes.
-    if (attr && attr?.canHide && OneTreeDataProvider.didHideExtra) {
-      return undefined;
-    }
-
     const uri = vscode.Uri.file(fpath);
 
     let node: Node;

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -159,23 +159,32 @@ abstract class Node {
 }
 
 class NodeFactory {
-  static create(type: NodeType, fpath: string, parent: Node|undefined, attr?: ArtifactAttr): Node
-      |undefined {
+  static create(type: NodeType, fpath: string, parent: Node|undefined, attr?: ArtifactAttr): Node {
     const uri = vscode.Uri.file(fpath);
 
     let node: Node;
-    if (type === NodeType.directory) {
-      assert.strictEqual(attr, undefined, 'Directory nodes cannot have attributes');
-      node = new DirectoryNode(uri, parent);
-    } else if (type === NodeType.baseModel) {
-      node = new BaseModelNode(uri, parent, attr?.openViewType, attr?.icon, attr?.canHide);
-    } else if (type === NodeType.config) {
-      assert.strictEqual(attr, undefined, 'Config nodes cannot have attributes');
-      node = new ConfigNode(uri, parent);
-    } else if (type === NodeType.product) {
-      node = new ProductNode(uri, parent, attr?.openViewType, attr?.icon, attr?.canHide);
-    } else {
-      throw Error('Undefined NodeType');
+    switch (type) {
+      case NodeType.directory: {
+        assert.strictEqual(attr, undefined, 'Directory nodes cannot have attributes');
+        node = new DirectoryNode(uri, parent);
+        break;
+      }
+      case NodeType.baseModel: {
+        node = new BaseModelNode(uri, parent, attr?.openViewType, attr?.icon, attr?.canHide);
+        break;
+      }
+      case NodeType.config: {
+        assert.strictEqual(attr, undefined, 'Config nodes cannot have attributes');
+        node = new ConfigNode(uri, parent);
+        break;
+      }
+      case NodeType.product: {
+        node = new ProductNode(uri, parent, attr?.openViewType, attr?.icon, attr?.canHide);
+        break;
+      }
+      default: {
+        throw Error('Undefined NodeType');
+      }
     }
 
     return node;


### PR DESCRIPTION
This commit revisits NodeFactory.create

- BUG FIX: It fixes a possible bug of hide & show.
If onecc was run in hide mode, the extra files would have never shown.
Let's fix it by removing this redundant legacy codes.

- CLEANING: It uses switch-case instead of if statement

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

Related to #1435 (This should have been applied with the PR)