### PR TITLE
[OneExplorer] Use chai instead of assert

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert';
+import {assert} from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
 import {TextEncoder} from 'util';


### PR DESCRIPTION
This commit is to use chai instead of assert.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>