### PR TITLE
[OneExplorer] Fix comment

### DIFF
--- a/src/OneExplorer/ArtifactLocator.ts
+++ b/src/OneExplorer/ArtifactLocator.ts
@@ -122,13 +122,13 @@ export class Locator {
    * EXAMPLE - file
    *
    * [one-import-tflite]            <--- section: "one-import-tflite"
-   *   input_file = "model.tflite"  <--- key: input_file
-   *   output_file = "model.circle" <--- key: output_file
+   *   input_path = "model.tflite"  <--- key: input_path
+   *   output_path = "model.circle" <--- key: output_path
    *
    * EXAMPLE - imported object
    *
-   * iniObj[one-import-tflite]['input_file'] === "model.tflite"
-   * iniObj[one-import-tflite]['input_file'] === "model.circle"
+   * iniObj[one-import-tflite]['input_path'] === "model.tflite"
+   * iniObj[one-import-tflite]['input_path'] === "model.circle"
    */
   public locate(iniObj: object, dir: string): string[] {
     assert.strictEqual(


### PR DESCRIPTION
This commit fixes typo in comments.
- input_file->input_path
- output_file->output_path.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>