### PR TITLE
[OneExplorer/Test] Clarify tests

### DIFF
--- a/src/Tests/OneExplorer/ConfigObject.test.ts
+++ b/src/Tests/OneExplorer/ConfigObject.test.ts
@@ -99,6 +99,7 @@ input_path=${modelName}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 1);
           assert.strictEqual(configObj?.getProducts.length, 0);
 
@@ -130,6 +131,7 @@ output_path=${productName}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 0);
           assert.strictEqual(configObj?.getProducts.length, 0);
         }
@@ -158,6 +160,7 @@ input_path=${modelName}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 1);
           assert.strictEqual(configObj?.getProducts.length, 0);
 
@@ -191,6 +194,7 @@ output_path=${productName2}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 0);
           assert.strictEqual(configObj?.getProducts.length, 0);
         }
@@ -226,6 +230,7 @@ output_path=${productName2}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 1);
           assert.notStrictEqual(configObj?.getProducts.length, 0);
 
@@ -260,6 +265,7 @@ output_path=${productName2}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 0);
           assert.strictEqual(configObj?.getProducts.length, 0);
         }
@@ -297,6 +303,7 @@ output_path=${productName2}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 1);
           assert.notStrictEqual(configObj?.getProducts.length, 0);
 
@@ -342,6 +349,7 @@ output_path=dummy/dummy/../..//${productName2}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 1);
           assert.notStrictEqual(configObj?.getProducts.length, 0);
 
@@ -384,6 +392,7 @@ output_path=/dummy/dummy/../..//${productName2}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 1);
           assert.notStrictEqual(configObj?.getProducts.length, 0);
 
@@ -424,6 +433,7 @@ output_path=/${productPath2}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 1);
           assert.notStrictEqual(configObj?.getProducts.length, 0);
 
@@ -468,6 +478,7 @@ output_path=/${productPath2}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 1);
           assert.notStrictEqual(configObj?.getProducts.length, 0);
 
@@ -509,6 +520,7 @@ output_path=/${productPath2}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 1);
           assert.strictEqual(configObj?.getBaseModelsExists.length, 0);
 
@@ -542,6 +554,7 @@ output_path=${productName2}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 0);
           assert.notStrictEqual(configObj?.getProducts.length, 0);
 
@@ -574,6 +587,7 @@ output_path=${productName2}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 0);
           assert.strictEqual(configObj?.getProducts.length, 0);
         }
@@ -602,6 +616,7 @@ command=${productName}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 0);
           assert.notStrictEqual(configObj?.getProducts.length, 0);
 
@@ -631,6 +646,7 @@ command=${productName}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 0);
           assert.strictEqual(configObj?.getProducts.length, 0);
         }
@@ -666,6 +682,7 @@ command=--save-temps --save-allocations ${productName}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 0);
           assert.notStrictEqual(configObj?.getProducts.length, 0);
 
@@ -704,6 +721,7 @@ command=--save-chrome-trace ${traceName}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 0);
           assert.notStrictEqual(configObj?.getProducts.length, 0);
 
@@ -730,6 +748,7 @@ command=--save-chrome-trace ${traceName}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 0);
           assert.strictEqual(configObj?.getProducts.length, 0);
         }
@@ -758,6 +777,7 @@ commands=--save-chrome-trace ${traceName}
 
         // Validation
         {
+          assert.isDefined(configObj);
           assert.strictEqual(configObj?.getBaseModels.length, 0);
           assert.strictEqual(configObj?.getProducts.length, 0);
         }

--- a/src/Tests/OneExplorer/ConfigObject.test.ts
+++ b/src/Tests/OneExplorer/ConfigObject.test.ts
@@ -65,7 +65,7 @@ suite('OneExplorer', function() {
           assert.isObject(configObj!.rawObj);
           assert.isObject(configObj!.obj);
           assert.isArray(configObj!.obj.baseModels);
-          assert.isArray(configObj?.getProducts);
+          assert.isArray(configObj!.getProducts);
           assert.isArray(configObj!.getBaseModels);
           assert.isArray(configObj!.getProducts);
           assert.isArray(configObj!.getBaseModelsExists);
@@ -100,14 +100,14 @@ input_path=${modelName}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 1);
-          assert.strictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 1);
+          assert.strictEqual(configObj!.getProducts.length, 0);
 
-          assert.isTrue(configObj?.isChildOf(modelPath));
+          assert.isTrue(configObj!.isChildOf(modelPath));
           assert.isTrue(
-            configObj?.getBaseModels.map(baseModel => baseModel.path).includes(modelPath));
+              configObj!.getBaseModels.map(baseModel => baseModel.path).includes(modelPath));
           assert.isTrue(
-            configObj?.getBaseModelsExists.map(baseModel => baseModel.path).includes(modelPath));
+              configObj!.getBaseModelsExists.map(baseModel => baseModel.path).includes(modelPath));
         }
       });
 
@@ -132,8 +132,8 @@ output_path=${productName}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 0);
-          assert.strictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 0);
+          assert.strictEqual(configObj!.getProducts.length, 0);
         }
       });
     });
@@ -161,14 +161,14 @@ input_path=${modelName}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 1);
-          assert.strictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 1);
+          assert.strictEqual(configObj!.getProducts.length, 0);
 
-          assert.isTrue(configObj?.isChildOf(modelPath));
+          assert.isTrue(configObj!.isChildOf(modelPath));
           assert.isTrue(
-            configObj?.getBaseModels.map(baseModel => baseModel.path).includes(modelPath));
+              configObj!.getBaseModels.map(baseModel => baseModel.path).includes(modelPath));
           assert.isTrue(
-            configObj?.getBaseModelsExists.map(baseModel => baseModel.path).includes(modelPath));
+              configObj!.getBaseModelsExists.map(baseModel => baseModel.path).includes(modelPath));
         }
       });
 
@@ -195,8 +195,8 @@ output_path=${productName2}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 0);
-          assert.strictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 0);
+          assert.strictEqual(configObj!.getProducts.length, 0);
         }
       });
     });
@@ -231,15 +231,13 @@ output_path=${productName2}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 1);
-          assert.notStrictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 1);
+          assert.notStrictEqual(configObj!.getProducts.length, 0);
 
           assert.isTrue(
-            configObj?.getBaseModels.map(baseModel => baseModel.path).includes(baseModelPath));
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(productPath1));
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(productPath2));
+              configObj!.getBaseModels.map(baseModel => baseModel.path).includes(baseModelPath));
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(productPath1));
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(productPath2));
         }
       });
 
@@ -266,8 +264,8 @@ output_path=${productName2}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 0);
-          assert.strictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 0);
+          assert.strictEqual(configObj!.getProducts.length, 0);
         }
       });
 
@@ -304,19 +302,15 @@ output_path=${productName2}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 1);
-          assert.notStrictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 1);
+          assert.notStrictEqual(configObj!.getProducts.length, 0);
 
           assert.isTrue(
-              configObj?.getBaseModels.map(baseModel => baseModel.path).includes(baseModelPath));
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(productPath1));
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(productPath2));
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(productPath3));
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(productPath4));
+              configObj!.getBaseModels.map(baseModel => baseModel.path).includes(baseModelPath));
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(productPath1));
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(productPath2));
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(productPath3));
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(productPath4));
         }
       });
 
@@ -350,15 +344,13 @@ output_path=dummy/dummy/../..//${productName2}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 1);
-          assert.notStrictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 1);
+          assert.notStrictEqual(configObj!.getProducts.length, 0);
 
           assert.isTrue(
-              configObj?.getBaseModels.map(baseModel => baseModel.path).includes(baseModelPath));
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(productPath1));
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(productPath2));
+              configObj!.getBaseModels.map(baseModel => baseModel.path).includes(baseModelPath));
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(productPath1));
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(productPath2));
         }
       });
 
@@ -393,14 +385,14 @@ output_path=/dummy/dummy/../..//${productName2}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 1);
-          assert.notStrictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 1);
+          assert.notStrictEqual(configObj!.getProducts.length, 0);
 
-          assert.notStrictEqual(configObj?.getBaseModels[0].path, baseModelPath);
+          assert.notStrictEqual(configObj!.getBaseModels[0].path, baseModelPath);
           assert.isFalse(
-              configObj?.getProducts.map(product => product.path).includes(productPath1));
+              configObj!.getProducts.map(product => product.path).includes(productPath1));
           assert.isFalse(
-              configObj?.getProducts.map(product => product.path).includes(productPath2));
+              configObj!.getProducts.map(product => product.path).includes(productPath2));
         }
       });
 
@@ -434,15 +426,12 @@ output_path=/${productPath2}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 1);
-          assert.notStrictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 1);
+          assert.notStrictEqual(configObj!.getProducts.length, 0);
 
-          assert.strictEqual(
-              configObj?.getBaseModels[0].path, baseModelPath);
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(productPath1));
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(productPath2));
+          assert.strictEqual(configObj!.getBaseModels[0].path, baseModelPath);
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(productPath1));
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(productPath2));
         }
       });
 
@@ -479,15 +468,15 @@ output_path=/${productPath2}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 1);
-          assert.notStrictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 1);
+          assert.notStrictEqual(configObj!.getProducts.length, 0);
 
           assert.isTrue(
-              configObj?.getBaseModels.map(baseModel => baseModel.path).includes(baseModelPath));
+              configObj!.getBaseModels.map(baseModel => baseModel.path).includes(baseModelPath));
           assert.isTrue(
-              configObj?.getProductsExists.map(product => product.path).includes(productPath1));
+              configObj!.getProductsExists.map(product => product.path).includes(productPath1));
           assert.isTrue(
-              configObj?.getProductsExists.map(product => product.path).includes(productPath2));
+              configObj!.getProductsExists.map(product => product.path).includes(productPath2));
         }
       });
 
@@ -521,11 +510,11 @@ output_path=/${productPath2}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 1);
-          assert.strictEqual(configObj?.getBaseModelsExists.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 1);
+          assert.strictEqual(configObj!.getBaseModelsExists.length, 0);
 
-          assert.notStrictEqual(configObj?.getProducts.length, 0);
-          assert.strictEqual(configObj?.getBaseModelsExists.length, 0);
+          assert.notStrictEqual(configObj!.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModelsExists.length, 0);
         }
       });
     });
@@ -555,13 +544,12 @@ output_path=${productName2}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 0);
-          assert.notStrictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 0);
+          assert.notStrictEqual(configObj!.getProducts.length, 0);
 
           assert.isTrue(
-              configObj?.getProducts.map(baseModel => baseModel.path).includes(productPath1));
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(productPath2));
+              configObj!.getProducts.map(baseModel => baseModel.path).includes(productPath1));
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(productPath2));
         }
       });
 
@@ -588,8 +576,8 @@ output_path=${productName2}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 0);
-          assert.strictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 0);
+          assert.strictEqual(configObj!.getProducts.length, 0);
         }
       });
     });
@@ -617,11 +605,10 @@ command=${productName}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 0);
-          assert.notStrictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 0);
+          assert.notStrictEqual(configObj!.getProducts.length, 0);
 
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(productPath));
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(productPath));
         }
       });
 
@@ -647,8 +634,8 @@ command=${productName}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 0);
-          assert.strictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 0);
+          assert.strictEqual(configObj!.getProducts.length, 0);
         }
       });
 
@@ -683,19 +670,14 @@ command=--save-temps --save-allocations ${productName}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 0);
-          assert.notStrictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 0);
+          assert.notStrictEqual(configObj!.getProducts.length, 0);
 
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(productPath));
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(extra1Path));
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(extra2Path));
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(extra3Path));
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(extra4Path));
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(productPath));
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(extra1Path));
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(extra2Path));
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(extra3Path));
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(extra4Path));
         }
       });
     });
@@ -722,11 +704,10 @@ command=--save-chrome-trace ${traceName}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 0);
-          assert.notStrictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 0);
+          assert.notStrictEqual(configObj!.getProducts.length, 0);
 
-          assert.isTrue(
-              configObj?.getProducts.map(product => product.path).includes(tracePath));
+          assert.isTrue(configObj!.getProducts.map(product => product.path).includes(tracePath));
         }
       });
 
@@ -749,8 +730,8 @@ command=--save-chrome-trace ${traceName}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 0);
-          assert.strictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 0);
+          assert.strictEqual(configObj!.getProducts.length, 0);
         }
       });
 
@@ -778,8 +759,8 @@ commands=--save-chrome-trace ${traceName}
         // Validation
         {
           assert.isDefined(configObj);
-          assert.strictEqual(configObj?.getBaseModels.length, 0);
-          assert.strictEqual(configObj?.getProducts.length, 0);
+          assert.strictEqual(configObj!.getBaseModels.length, 0);
+          assert.strictEqual(configObj!.getProducts.length, 0);
         }
       });
     });

--- a/src/Tests/OneExplorer/OneExplorer.test.ts
+++ b/src/Tests/OneExplorer/OneExplorer.test.ts
@@ -66,8 +66,8 @@ suite('OneExplorer', function() {
         // Validation
         {
           const dirNode = NodeFactory.create(NodeType.directory, dirPath, undefined);
-          assert.strictEqual(dirNode!.getChildren().length, 1);
-          assert.strictEqual(dirNode!.getChildren()[0].path, baseModelPath);
+          assert.strictEqual(dirNode.getChildren().length, 1);
+          assert.strictEqual(dirNode.getChildren()[0].path, baseModelPath);
         }
       });
 
@@ -98,13 +98,13 @@ input_path=${baseModelPath}
         {
           const baseModelNode = NodeFactory.create(NodeType.baseModel, baseModelPath, undefined);
 
-          assert.strictEqual(baseModelNode!.openViewType, BaseModelNode.defaultOpenViewType);
-          assert.strictEqual(baseModelNode!.icon, BaseModelNode.defaultIcon);
-          assert.strictEqual(baseModelNode!.canHide, BaseModelNode.defaultCanHide);
+          assert.strictEqual(baseModelNode.openViewType, BaseModelNode.defaultOpenViewType);
+          assert.strictEqual(baseModelNode.icon, BaseModelNode.defaultIcon);
+          assert.strictEqual(baseModelNode.canHide, BaseModelNode.defaultCanHide);
 
-          assert.strictEqual(baseModelNode!.getChildren().length, 1);
-          assert.strictEqual(baseModelNode!.getChildren()[0].type, NodeType.config);
-          assert.strictEqual(baseModelNode!.getChildren()[0].path, configPath);
+          assert.strictEqual(baseModelNode.getChildren().length, 1);
+          assert.strictEqual(baseModelNode.getChildren()[0].type, NodeType.config);
+          assert.strictEqual(baseModelNode.getChildren()[0].path, configPath);
         }
       });
 
@@ -126,10 +126,10 @@ input_path=${baseModelPath}
         // Validation
         {
           const configNode = NodeFactory.create(NodeType.config, configPath, undefined);
-          assert.strictEqual(configNode!.openViewType, ConfigNode.defaultOpenViewType);
-          assert.strictEqual(configNode!.icon, ConfigNode.defaultIcon);
-          assert.strictEqual(configNode!.canHide, ConfigNode.defaultCanHide);
-          assert.strictEqual(configNode!.getChildren().length, 0);
+          assert.strictEqual(configNode.openViewType, ConfigNode.defaultOpenViewType);
+          assert.strictEqual(configNode.icon, ConfigNode.defaultIcon);
+          assert.strictEqual(configNode.canHide, ConfigNode.defaultCanHide);
+          assert.strictEqual(configNode.getChildren().length, 0);
         }
       });
 
@@ -151,10 +151,10 @@ input_path=${baseModelPath}
         // Validation
         {
           const productNode = NodeFactory.create(NodeType.product, productPath, undefined);
-          assert.strictEqual(productNode!.openViewType, ProductNode.defaultOpenViewType);
-          assert.strictEqual(productNode!.icon, ProductNode.defaultIcon);
-          assert.strictEqual(productNode!.canHide, ProductNode.defaultCanHide);
-          assert.strictEqual(productNode!.getChildren().length, 0);
+          assert.strictEqual(productNode.openViewType, ProductNode.defaultOpenViewType);
+          assert.strictEqual(productNode.icon, ProductNode.defaultIcon);
+          assert.strictEqual(productNode.canHide, ProductNode.defaultCanHide);
+          assert.strictEqual(productNode.getChildren().length, 0);
         }
       });
 
@@ -173,7 +173,7 @@ input_path=${baseModelPath}
         const directoryNode = NodeFactory.create(NodeType.directory, directoryPath, undefined);
         const productNode = NodeFactory.create(NodeType.product, productPath, directoryNode);
 
-        assert.strictEqual(productNode?.parent, directoryNode);
+        assert.strictEqual(productNode.parent, directoryNode);
       });
 
       test('NEG: get an empty parent', function() {
@@ -187,7 +187,7 @@ input_path=${baseModelPath}
 
         const productNode = NodeFactory.create(NodeType.product, productPath, undefined);
 
-        assert.strictEqual(productNode?.parent, undefined);
+        assert.strictEqual(productNode.parent, undefined);
       });
     });
 
@@ -195,7 +195,7 @@ input_path=${baseModelPath}
       test('constructor', function() {
         const directoryPath = testBuilder.getPath('');
         const directoryNode = NodeFactory.create(NodeType.directory, directoryPath, undefined);
-        const oneNode = new OneNode(vscode.TreeItemCollapsibleState.Collapsed, directoryNode!);
+        const oneNode = new OneNode(vscode.TreeItemCollapsibleState.Collapsed, directoryNode);
         { assert.strictEqual(oneNode.contextValue, 'directory'); }
       });
     });

--- a/src/Tests/OneExplorer/OneExplorer.test.ts
+++ b/src/Tests/OneExplorer/OneExplorer.test.ts
@@ -77,23 +77,22 @@ suite('OneExplorer', function() {
         });
       });
 
-      test('create a base model node with cfg', function() {
+      test('create a base model node outside workspace', function() {
         const baseModelName = 'test.tflite';
         const configName = `test.cfg`;
 
-        // Write a file inside temp directory
-        // and get file paths inside the temp directory
         testBuilder.writeFileSync(baseModelName, '');
-        const baseModelPath = testBuilder.getPath(baseModelName);
+        const baseModelPath = testBuilder.getPath(baseModelName);         // in /tmp
+        const configPath = testBuilder.getPath(configName, 'workspace');  // in workspace
 
+        // Find a base model outside workspace by locating its absolute path
         testBuilder.writeFileSync(
             configName, `
 [one-import-tflite]
-input_file=${baseModelPath}
+input_path=${baseModelPath}
         `,
             'workspace');
 
-        const configPath = testBuilder.getPath(configName, 'workspace');
 
         // Validation
         {

--- a/src/Tests/OneExplorer/OneStorage.test.ts
+++ b/src/Tests/OneExplorer/OneStorage.test.ts
@@ -51,13 +51,13 @@ input_path=${modelName}
           const configPath = testBuilder.getPath(configName, 'workspace');
           const modelPath = testBuilder.getPath(modelName, 'workspace');
 
-        // Validation
-        {
-          assert.isDefined(OneStorage.getCfgs(modelPath));
-          assert.strictEqual(OneStorage.getCfgs(modelPath)?.length, 1);
-          assert.strictEqual(OneStorage.getCfgs(modelPath)![0], configPath);
-        }
-      });
+          // Validation
+          {
+            assert.isDefined(OneStorage.getCfgs(modelPath));
+            assert.strictEqual(OneStorage.getCfgs(modelPath)!.length, 1);
+            assert.strictEqual(OneStorage.getCfgs(modelPath)![0], configPath);
+          }
+        });
 
         test('NEG: Returns undefined for not existing path', function() {
           { assert.isUndefined(OneStorage.getCfgs('invalid/path')); }
@@ -102,7 +102,8 @@ input_path=${modelName}
           // Validation
           {
             assert.isDefined(OneStorage.getCfgObj(configPath));
-            assert.strictEqual(OneStorage.getCfgObj(configPath)?.getBaseModelsExists[0].path, modelPath);
+            assert.strictEqual(
+                OneStorage.getCfgObj(configPath)!.getBaseModelsExists[0].path, modelPath);
           }
         });
 

--- a/src/Tests/OneExplorer/OneStorage.test.ts
+++ b/src/Tests/OneExplorer/OneStorage.test.ts
@@ -51,12 +51,13 @@ input_path=${modelName}
           const configPath = testBuilder.getPath(configName, 'workspace');
           const modelPath = testBuilder.getPath(modelName, 'workspace');
 
-          // Validation
-          {
-            assert.strictEqual(OneStorage.getCfgs(modelPath)?.length, 1);
-            assert.strictEqual(OneStorage.getCfgs(modelPath)![0], configPath);
-          }
-        });
+        // Validation
+        {
+          assert.isDefined(OneStorage.getCfgs(modelPath));
+          assert.strictEqual(OneStorage.getCfgs(modelPath)?.length, 1);
+          assert.strictEqual(OneStorage.getCfgs(modelPath)![0], configPath);
+        }
+      });
 
         test('NEG: Returns undefined for not existing path', function() {
           { assert.isUndefined(OneStorage.getCfgs('invalid/path')); }


### PR DESCRIPTION
This commit clarifies the OneExplorer unit tests by

(1) elaborate `create a base model` test.
(2) Add isDefined checker to easily notice undefined objects
(3) Replace `?` with `!` to assert unexpected undefined objects