### PR TITLE
[OneExplorer] Introduce BaseModelToCfgMap/CfgToCfgObjMap

### DIFF
--- a/src/OneExplorer/OneStorage.ts
+++ b/src/OneExplorer/OneStorage.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {assert} from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -24,12 +25,157 @@ import {Logger} from '../Utils/Logger';
 import {ConfigObj} from './ConfigObject';
 import {Node, NodeType} from './OneExplorer';
 
-interface StringListMap {
-  [key: string]: string[];
+export {
+  BaseModelToCfgMap as _unit_test_BaseModelToCfgMap,
+  CfgToCfgObjMap as _unit_test_CfgToCfgObjMap,
+};
+
+class CfgToCfgObjMap {
+  private _map: Map<string, ConfigObj>;
+
+  constructor() {
+    this._map = new Map<string, ConfigObj>();
+  }
+
+  public init(cfgList: string[]) {
+    cfgList.forEach(cfg => {
+      const cfgObj = ConfigObj.createConfigObj(vscode.Uri.file(cfg));
+      if (cfgObj) {
+        this._map.set(cfg, cfgObj);
+      }
+    });
+  }
+
+  get size() {
+    return this._map.size;
+  }
+
+  public get(path: string) {
+    return this._map.get(path);
+  }
+
+  public reset(type: NodeType, path: string) {
+    switch (type) {
+      case NodeType.config:
+        this._map.delete(path);
+        break;
+      case NodeType.baseModel:
+      case NodeType.product:
+      case NodeType.directory:
+      default:
+        assert.isOk(false, `Cannot reach here`);
+        break;
+    }
+  }
+
+  /**
+   * Update the data when cfg file's path is changed or the content is changed.
+   * @param type NodeType
+   * @param path config path to update
+   * @param newpath (optional) if exists, change the file path
+   */
+  public update(type: NodeType, path: string, newpath?: string) {
+    switch (type) {
+      case NodeType.config: {
+        this._map.delete(path);
+
+        if (newpath) {
+          path = newpath;
+        }
+        const cfgObj = ConfigObj.createConfigObj(vscode.Uri.file(path));
+        if (cfgObj) {
+          this._map.set(path, cfgObj);
+        }
+
+        break;
+      }
+      case NodeType.baseModel:
+      case NodeType.product:
+      case NodeType.directory:
+      default:
+        assert.isOk(false, `Cannot reach here`);
+        break;
+    }
+  }
 }
 
-interface ConfigObjMap {
-  [key: string]: ConfigObj;
+class BaseModelToCfgMap {
+  private _map: Map<string, string[]>;
+
+  constructor() {
+    this._map = new Map<string, string[]>();
+  }
+
+  public init(cfgList: string[], cfgToCfgObjMap: CfgToCfgObjMap) {
+    cfgList.forEach(cfg => {
+      const cfgObj = cfgToCfgObjMap.get(cfg);
+
+      (cfgObj ? cfgObj.getBaseModelsExists : []).forEach(artifact => {
+        this._map.get(artifact.path) ?
+            this._map.set(artifact.path, this._map.get(artifact.path)!.concat([cfg])) :
+            this._map.set(artifact.path, [cfg]);
+      });
+    });
+  }
+
+  get size() {
+    return this._map.size;
+  }
+
+  public get(path: string) {
+    return this._map.get(path);
+  }
+
+  public reset(type: NodeType, path: string) {
+    switch (type) {
+      case NodeType.baseModel:
+        this._map.delete(path);
+        break;
+      case NodeType.config:
+        this._map.forEach((cfgs, key, map) => {
+          if (cfgs.includes(path)) {
+            cfgs = cfgs.filter(cfg => cfg !== path);
+            map.set(key, cfgs);
+          }
+        });
+        break;
+      case NodeType.product:
+      case NodeType.directory:
+      default:
+        assert.isOk(false, `Cannot reach here`);
+        break;
+    }
+  }
+
+  public update(type: NodeType, oldpath: string, newpath: string) {
+    switch (type) {
+      case NodeType.baseModel: {
+        const value = this._map.get(oldpath);
+
+        if (!value) {
+          return;
+        }
+
+        this._map.delete(oldpath);
+        this._map.set(newpath, value);
+
+        break;
+      }
+      case NodeType.config:
+        this._map.forEach((cfgs, key, map) => {
+          if (cfgs.includes(oldpath)) {
+            cfgs = cfgs.map(cfg => (cfg === oldpath) ? newpath : cfg);
+            map.set(key, cfgs);
+          }
+        });
+        break;
+      case NodeType.product:
+      case NodeType.directory:
+      default:
+        assert.isOk(false, `Cannot reach here`);
+        break;
+    }
+  }
 }
 
 /**
@@ -62,11 +208,11 @@ export class OneStorage {
   /**
    * @brief A map of ConfigObj (key: cfg path)
    */
-  private _cfgToCfgObjMap: ConfigObjMap;
+  private _cfgToCfgObjMap: CfgToCfgObjMap;
   /**
    * @brief A map of BaseModel path to Cfg path
    */
-  private _baseModelToCfgsMap: StringListMap;
+  private _baseModelToCfgsMap: BaseModelToCfgMap;
 
   /**
    * Get the list of .cfg files within the workspace
@@ -101,49 +247,17 @@ export class OneStorage {
     }
   }
 
-  private _initCfgToCfgObjMap(cfgList: string[]): ConfigObjMap {
-    let map: ConfigObjMap = {};
-
-    cfgList.forEach(cfg => {
-      const cfgObj = ConfigObj.createConfigObj(vscode.Uri.file(cfg));
-      if (cfgObj) {
-        map[cfg] = cfgObj;
-      }
-    });
-
-    return map;
-  }
-
-  private _initBaseModelToCfgsMap(cfgList: string[], cfgToCfgObjMap: ConfigObjMap): StringListMap {
-    let map: StringListMap = {};
-
-    cfgList.forEach(cfg => {
-      const cfgObj = cfgToCfgObjMap[cfg];
-      if (cfgObj) {
-        cfgObj.getBaseModelsExists.forEach(baseModelArtifact => {
-          if (!map[baseModelArtifact.path]) {
-            map[baseModelArtifact.path] = [];
-          }
-
-          if (!map[baseModelArtifact.path].includes(cfg)) {
-            map[baseModelArtifact.path].push(cfg);
-          }
-        });
-      }
-    });
-
-    return map;
-  }
-
   private static _delete(node: Node) {
-    OneStorage.get()._nodeMap.delete(node.path);
+    const instance = OneStorage.get();
+    instance._nodeMap.delete(node.path);
 
     switch (node.type) {
       case NodeType.baseModel:
-        OneStorage.resetBaseModel(node.path);
+        instance._baseModelToCfgsMap.reset(node.type, node.path);
         break;
       case NodeType.config:
-        OneStorage.resetConfig(node.path);
+        instance._baseModelToCfgsMap.reset(node.type, node.path);
+        instance._cfgToCfgObjMap.reset(node.type, node.path);
         break;
       default:
         break;
@@ -152,8 +266,12 @@ export class OneStorage {
 
   private constructor() {
     const cfgList = this._getCfgList();
-    this._cfgToCfgObjMap = this._initCfgToCfgObjMap(cfgList);
-    this._baseModelToCfgsMap = this._initBaseModelToCfgsMap(cfgList, this._cfgToCfgObjMap);
+
+    this._cfgToCfgObjMap = new CfgToCfgObjMap();
+    this._cfgToCfgObjMap.init(cfgList);
+
+    this._baseModelToCfgsMap = new BaseModelToCfgMap();
+    this._baseModelToCfgsMap.init(cfgList, this._cfgToCfgObjMap);
   }
 
   private static _obj: OneStorage|undefined;
@@ -162,20 +280,20 @@ export class OneStorage {
    * Get cfg lists which refers the base model path
    * @param baseModelPath
    * @return a list of cfg path or undefined
-   *         'undefined' is returned when
+   *         An empty array is returned when
    *          (1) the path not exists
    *          (2) the path is not a base model file
    *          (3) the path is a lonely base model file
    */
   public static getCfgs(baseModelPath: string): string[]|undefined {
-    return OneStorage.get()._baseModelToCfgsMap[baseModelPath];
+    return OneStorage.get()._baseModelToCfgsMap.get(baseModelPath);
   }
 
   /**
    * Get cfgObj from the map
    */
   public static getCfgObj(cfgPath: string): ConfigObj|undefined {
-    return OneStorage.get()._cfgToCfgObjMap[cfgPath];
+    return OneStorage.get()._cfgToCfgObjMap.get(cfgPath);
   }
 
   /**
@@ -188,7 +306,7 @@ export class OneStorage {
   public static insert(node: Node) {
     // NOTE
     // Only _nodeMap is built by calling this function
-    // _baseModelToCfgsMap and _cfgToCfgObjMap are built at once by scanning the file system.
+    // _baseModelToCfgsMap and _cfgToCfgObjMap are built at constuctors
     OneStorage.get()._nodeMap.set(node.path, node);
   }
 
@@ -225,19 +343,5 @@ export class OneStorage {
 
   public static reset(): void {
     OneStorage._obj = undefined;
-  }
-
-  public static resetBaseModel(path: string): void {
-    delete OneStorage.get()._baseModelToCfgsMap[path];
-    Logger.debug('OneStorage', `Base Mode Path(${path}) is removed.`);
-  }
-
-  public static resetConfig(path: string): void {
-    delete OneStorage.get()._cfgToCfgObjMap[path];
-    Object.entries(OneStorage.get()._baseModelToCfgsMap).forEach(([modelpath]) => {
-      OneStorage.get()._baseModelToCfgsMap[modelpath] =
-          OneStorage.get()._baseModelToCfgsMap[modelpath].filter(cfg => cfg !== path);
-    });
-    Logger.debug('OneStorage', `Config Path(${path}) is removed.`);
   }
 }

--- a/src/Tests/OneExplorer/OneStorage.test.ts
+++ b/src/Tests/OneExplorer/OneStorage.test.ts
@@ -15,8 +15,10 @@
  */
 
 import {assert} from 'chai';
-import {OneStorage} from '../../OneExplorer/OneStorage';
 
+import {NodeType} from '../../OneExplorer/OneExplorer';
+import {OneStorage} from '../../OneExplorer/OneStorage';
+import {_unit_test_BaseModelToCfgMap as BaseModelToCfgMap, _unit_test_CfgToCfgObjMap as CfgToCfgObjMap} from '../../OneExplorer/OneStorage';
 import {TestBuilder} from '../TestBuilder';
 
 suite('OneExplorer', function() {
@@ -133,6 +135,356 @@ input_path=${modelName}
           OneStorage.reset();
 
           { assert.isDefined(OneStorage.getCfgObj(configPath)); }
+        });
+      });
+    });
+
+    suite('CfgToCfgObjMap', function() {
+      suite('#constructor()', function() {
+        test('does not throw', function() {
+          assert.doesNotThrow(() => new CfgToCfgObjMap());
+        });
+      });
+
+      suite('#init()', function() {
+        test('NEG: with an empty cfglist', function() {
+          const cfgToCfgObjMap = new CfgToCfgObjMap();
+          assert.doesNotThrow(() => {
+            cfgToCfgObjMap.init([]);
+          });
+          assert.strictEqual(cfgToCfgObjMap.size, 0);
+        });
+        test('NEG: a falsy cfg list (not existing)', function() {
+          const cfgToCfgObjMap = new CfgToCfgObjMap();
+          assert.doesNotThrow(() => {
+            cfgToCfgObjMap.init(['not/existing/path']);
+          });
+          assert.isUndefined(cfgToCfgObjMap.get('not/existing/path'));
+          assert.strictEqual(cfgToCfgObjMap.size, 0);
+        });
+      });
+
+      suite('#get()', function() {
+        test('NEG: empty path', function() {
+          const cfgToCfgObjMap = new CfgToCfgObjMap();
+          cfgToCfgObjMap.init([]);
+          assert.isUndefined(cfgToCfgObjMap.get(''));
+          assert.strictEqual(cfgToCfgObjMap.size, 0);
+        });
+
+        test('NEG: invalid path', function() {
+          const cfgToCfgObjMap = new CfgToCfgObjMap();
+          cfgToCfgObjMap.init([]);
+          assert.isUndefined(cfgToCfgObjMap.get('invalid/path'));
+          assert.strictEqual(cfgToCfgObjMap.size, 0);
+        });
+
+        test('existing path', function() {
+          const configName = 'model.cfg';
+          const configPath = testBuilder.getPath(configName, 'workspace');
+          testBuilder.writeFileSync(configName, '', 'workspace');
+
+          const cfgToCfgObjMap = new CfgToCfgObjMap();
+          cfgToCfgObjMap.init([configPath]);
+
+          assert.strictEqual(cfgToCfgObjMap.size, 1);
+          assert.strictEqual(cfgToCfgObjMap.get(configPath)?.uri.fsPath, configPath);
+        });
+      });
+
+      suite('#reset()', function() {
+        test('existing path', function() {
+          const configName = 'model.cfg';
+          const configPath = testBuilder.getPath(configName, 'workspace');
+          testBuilder.writeFileSync(configName, '', 'workspace');
+          const cfgToCfgObjMap = new CfgToCfgObjMap();
+          cfgToCfgObjMap.init([configPath]);
+
+          assert.strictEqual(cfgToCfgObjMap.size, 1);
+          cfgToCfgObjMap.reset(NodeType.config, configPath);
+          assert.strictEqual(cfgToCfgObjMap.size, 0);
+        });
+        test('NEG: not existing path', function() {
+          const configName = 'model.cfg';
+          const configPath = testBuilder.getPath(configName, 'workspace');
+          // commented out : testBuilder.writeFileSync(configName, '', 'workspace');
+          const cfgToCfgObjMap = new CfgToCfgObjMap();
+          cfgToCfgObjMap.init([configPath]);
+
+          assert.strictEqual(cfgToCfgObjMap.size, 0);
+          assert.doesNotThrow(() => {
+            cfgToCfgObjMap.reset(NodeType.config, configPath);
+          });
+          assert.strictEqual(cfgToCfgObjMap.size, 0);
+        });
+      });
+
+      suite('#update()', function() {
+        test('existing path', function() {
+          const configName = 'model.cfg';
+          const configPath = testBuilder.getPath(configName, 'workspace');
+          testBuilder.writeFileSync(configName, '', 'workspace');
+
+          const cfgToCfgObjMap = new CfgToCfgObjMap();
+          cfgToCfgObjMap.init([configPath]);
+
+          const newConfigName = 'model.new.cfg';
+          const newConfigPath = testBuilder.getPath(newConfigName, 'workspace');
+          testBuilder.writeFileSync(newConfigName, '', 'workspace');
+
+          assert.strictEqual(cfgToCfgObjMap.size, 1);
+          cfgToCfgObjMap.update(NodeType.config, configPath, newConfigPath);
+          assert.strictEqual(cfgToCfgObjMap.size, 1);
+          assert.isUndefined(cfgToCfgObjMap.get(configPath));
+          assert.isDefined(cfgToCfgObjMap.get(newConfigPath));
+          assert.strictEqual(cfgToCfgObjMap.get(newConfigPath)?.uri.fsPath, newConfigPath);
+        });
+
+        test('NEG: not existing new path', function() {
+          const configName = 'model.cfg';
+          const configPath = testBuilder.getPath(configName, 'workspace');
+          testBuilder.writeFileSync(configName, '', 'workspace');
+          const cfgToCfgObjMap = new CfgToCfgObjMap();
+          cfgToCfgObjMap.init([configPath]);
+
+          const newConfigName = 'model.new.cfg';
+          const newConfigPath = testBuilder.getPath(newConfigName, 'workspace');
+          // commented out : testBuilder.writeFileSync(newConfigPath, '', 'workspace');
+
+          assert.strictEqual(cfgToCfgObjMap.size, 1);
+          cfgToCfgObjMap.update(NodeType.config, configPath, newConfigPath);
+          assert.strictEqual(cfgToCfgObjMap.size, 0);
+        });
+
+        test('NEG: not existing path', function() {
+          const configName = 'model.cfg';
+          const configPath = testBuilder.getPath(configName, 'workspace');
+          // commented out : testBuilder.writeFileSync(configName, '', 'workspace');
+          const cfgToCfgObjMap = new CfgToCfgObjMap();
+          cfgToCfgObjMap.init([configPath]);
+
+          const newConfigName = 'model.new.cfg';
+          const newConfigPath = testBuilder.getPath(configName, 'workspace');
+
+          assert.strictEqual(cfgToCfgObjMap.size, 0);
+          assert.doesNotThrow(() => {
+            cfgToCfgObjMap.update(NodeType.config, configPath, newConfigName);
+          });
+          assert.strictEqual(cfgToCfgObjMap.size, 0);
+          assert.isUndefined(cfgToCfgObjMap.get(configPath));
+          assert.isUndefined(cfgToCfgObjMap.get(newConfigPath));
+        });
+      });
+    });
+
+    suite('BaseModelToCfgMap', function() {
+      suite('#constructor()', function() {
+        test('does not throw', function() {
+          assert.doesNotThrow(() => new BaseModelToCfgMap());
+        });
+      });
+
+      suite('#init()', function() {
+        test('NEG: with an empty cfglist and cfgObjMap', function() {
+          const baseModelToCfgMap = new BaseModelToCfgMap();
+          assert.doesNotThrow(() => {
+            baseModelToCfgMap.init([], new CfgToCfgObjMap());
+          });
+          assert.strictEqual(baseModelToCfgMap.size, 0);
+        });
+        test('NEG: falsy cfg list (not existing)', function() {
+          const baseModelToCfgMap = new BaseModelToCfgMap();
+          assert.doesNotThrow(() => {
+            baseModelToCfgMap.init(['not/existing/path'], new CfgToCfgObjMap());
+          });
+          assert.isUndefined(baseModelToCfgMap.get('not/existing/path'));
+          assert.strictEqual(baseModelToCfgMap.size, 0);
+        });
+      });
+
+      suite('#get()', function() {
+        test('NEG: empty path', function() {
+          const baseModelToCfgMap = new BaseModelToCfgMap();
+          baseModelToCfgMap.init([], new CfgToCfgObjMap());
+          assert.isUndefined(baseModelToCfgMap.get(''));
+          assert.strictEqual(baseModelToCfgMap.size, 0);
+        });
+
+        test('NEG: invalid path', function() {
+          const baseModelToCfgMap = new BaseModelToCfgMap();
+          baseModelToCfgMap.init([], new CfgToCfgObjMap());
+          assert.isUndefined(baseModelToCfgMap.get('invalid/path'));
+          assert.strictEqual(baseModelToCfgMap.size, 0);
+        });
+
+        test('existing path', function() {
+          const model = testBuilder.getPath('model.tflite', 'workspace');
+          const config = testBuilder.getPath('model.cfg', 'workspace');
+          const content = `
+  [one-import-onnx]
+  input_path='model.tflite'
+          `;
+
+          testBuilder.writeFileSync('model.cfg', content, 'workspace');
+          testBuilder.writeFileSync('model.tflite', '', 'workspace');
+
+          const cfgList = [config];
+          const cfgToCfgObjMap = new CfgToCfgObjMap();
+          const baseModelToCfgMap = new BaseModelToCfgMap();
+          cfgToCfgObjMap.init(cfgList);
+          baseModelToCfgMap.init(cfgList, cfgToCfgObjMap);
+
+          assert.isDefined(baseModelToCfgMap.get(model));
+          assert.strictEqual(baseModelToCfgMap.get(model)!.length, 1);
+          assert.strictEqual(baseModelToCfgMap.get(model)![0], config);
+          assert.strictEqual(baseModelToCfgMap.size, 1);
+        });
+      });
+
+      suite('#reset()', function() {
+        test('existing path', function() {
+          const model = testBuilder.getPath('model.tflite', 'workspace');
+          const config = testBuilder.getPath('model.cfg', 'workspace');
+          const content = `
+  [one-import-onnx]
+  input_path='model.tflite'
+          `;
+
+          testBuilder.writeFileSync('model.cfg', content, 'workspace');
+          testBuilder.writeFileSync('model.tflite', '', 'workspace');
+
+          const cfgList = [config];
+          const cfgToCfgObjMap = new CfgToCfgObjMap();
+          const baseModelToCfgMap = new BaseModelToCfgMap();
+          cfgToCfgObjMap.init(cfgList);
+          baseModelToCfgMap.init(cfgList, cfgToCfgObjMap);
+
+          assert.isDefined(baseModelToCfgMap.get(model));
+          assert.strictEqual(baseModelToCfgMap.get(model)!.length, 1);
+          assert.strictEqual(baseModelToCfgMap.get(model)![0], config);
+          assert.strictEqual(baseModelToCfgMap.size, 1);
+
+          baseModelToCfgMap.reset(NodeType.config, config);
+
+          assert.isDefined(baseModelToCfgMap.get(model));
+          assert.strictEqual(baseModelToCfgMap.get(model)!.length, 0);
+          assert.strictEqual(baseModelToCfgMap.size, 1);
+        });
+        test('NEG: not existing path', function() {
+          const config = testBuilder.getPath('model.cfg', 'workspace');
+
+          const cfgList = [config];
+          const cfgToCfgObjMap = new CfgToCfgObjMap();
+          const baseModelToCfgMap = new BaseModelToCfgMap();
+          cfgToCfgObjMap.init(cfgList);
+          baseModelToCfgMap.init(cfgList, cfgToCfgObjMap);
+
+          assert.strictEqual(baseModelToCfgMap.size, 0);
+          assert.doesNotThrow(() => baseModelToCfgMap.reset(NodeType.config, config));
+        });
+      });
+
+      suite('#update()', function() {
+        test('config path', function() {
+          const model = testBuilder.getPath('model.tflite', 'workspace');
+          const config = testBuilder.getPath('model.cfg', 'workspace');
+
+          const content = `
+  [one-import-onnx]
+  input_path='model.tflite'
+          `;
+
+          testBuilder.writeFileSync('model.cfg', content, 'workspace');
+          testBuilder.writeFileSync('model.tflite', '', 'workspace');
+
+          const cfgList = [config];
+          const cfgToCfgObjMap = new CfgToCfgObjMap();
+          const baseModelToCfgMap = new BaseModelToCfgMap();
+          cfgToCfgObjMap.init(cfgList);
+          baseModelToCfgMap.init(cfgList, cfgToCfgObjMap);
+
+          assert.isDefined(baseModelToCfgMap.get(model));
+          assert.strictEqual(baseModelToCfgMap.get(model)!.length, 1);
+          assert.strictEqual(baseModelToCfgMap.get(model)![0], config);
+          assert.strictEqual(baseModelToCfgMap.size, 1);
+
+          const newConfig = testBuilder.getPath('model.new.cfg', 'workspace');
+          testBuilder.writeFileSync('model.new.cfg', content, 'workspace');
+
+          baseModelToCfgMap.update(NodeType.config, config, newConfig);
+
+          assert.isDefined(baseModelToCfgMap.get(model));
+          assert.strictEqual(baseModelToCfgMap.get(model)!.length, 1);
+          assert.strictEqual(baseModelToCfgMap.get(model)![0], newConfig);
+          assert.strictEqual(baseModelToCfgMap.size, 1);
+        });
+
+        test('model and config names', function() {
+          const content = `
+  [one-import-onnx]
+  input_path='model.tflite'
+          `;
+
+          const oldModel = testBuilder.getPath('model.tflite', 'workspace');
+          const config = testBuilder.getPath('model.cfg', 'workspace');
+          testBuilder.writeFileSync('model.cfg', content, 'workspace');
+          testBuilder.writeFileSync('model.tflite', '', 'workspace');
+
+          const cfgList = [config];
+          const cfgToCfgObjMap = new CfgToCfgObjMap();
+          const baseModelToCfgMap = new BaseModelToCfgMap();
+          cfgToCfgObjMap.init(cfgList);
+          baseModelToCfgMap.init(cfgList, cfgToCfgObjMap);
+
+          assert.strictEqual(baseModelToCfgMap.size, 1);
+          assert.isDefined(baseModelToCfgMap.get(oldModel));
+          assert.strictEqual(baseModelToCfgMap.get(oldModel)!.length, 1);
+          assert.strictEqual(baseModelToCfgMap.get(oldModel)![0], config);
+
+          const newModel = testBuilder.getPath('model.new.tflite', 'workspace');
+          const newContent = `
+  [one-import-onnx]
+  input_path='model.new.tflite'
+          `;
+
+          testBuilder.writeFileSync('model.cfg', newContent, 'workspace');
+          testBuilder.writeFileSync('model.new.tflite', '', 'workspace');
+
+          baseModelToCfgMap.update(NodeType.baseModel, oldModel, newModel);
+
+          assert.strictEqual(baseModelToCfgMap.size, 1);
+          assert.isUndefined(baseModelToCfgMap.get(oldModel));
+          assert.isDefined(baseModelToCfgMap.get(newModel));
+          assert.strictEqual(baseModelToCfgMap.get(newModel)!.length, 1);
+          assert.strictEqual(baseModelToCfgMap.get(newModel)![0], config);
+        });
+
+        test('NEG: not existing path', function() {
+          const content = `
+  [one-import-onnx]
+  input_path='model.tflite'
+          `;
+
+          const model = testBuilder.getPath('model.tflite', 'workspace');
+          const config = testBuilder.getPath('model.cfg', 'workspace');
+          testBuilder.writeFileSync('model.cfg', content, 'workspace');
+          testBuilder.writeFileSync('model.tflite', '', 'workspace');
+
+          const cfgList = [config];
+          const cfgToCfgObjMap = new CfgToCfgObjMap();
+          const baseModelToCfgMap = new BaseModelToCfgMap();
+          cfgToCfgObjMap.init(cfgList);
+          baseModelToCfgMap.init(cfgList, cfgToCfgObjMap);
+
+          assert.strictEqual(baseModelToCfgMap.size, 1);
+          assert.isDefined(baseModelToCfgMap.get(model));
+          assert.strictEqual(baseModelToCfgMap.get(model)!.length, 1);
+          assert.strictEqual(baseModelToCfgMap.get(model)![0], config);
+
+          assert.doesNotThrow(() => {
+            baseModelToCfgMap.update(NodeType.config, config, '/invalid/path');
+          });
+          assert.strictEqual(cfgToCfgObjMap.size, 1);
         });
       });
     });

--- a/src/Tests/OneExplorer/OneStorage.test.ts
+++ b/src/Tests/OneExplorer/OneStorage.test.ts
@@ -321,8 +321,8 @@ input_path=${modelName}
           const model = testBuilder.getPath('model.tflite', 'workspace');
           const config = testBuilder.getPath('model.cfg', 'workspace');
           const content = `
-  [one-import-onnx]
-  input_path='model.tflite'
+[one-import-tflite]
+input_path='model.tflite'
           `;
 
           testBuilder.writeFileSync('model.cfg', content, 'workspace');
@@ -346,8 +346,8 @@ input_path=${modelName}
           const model = testBuilder.getPath('model.tflite', 'workspace');
           const config = testBuilder.getPath('model.cfg', 'workspace');
           const content = `
-  [one-import-onnx]
-  input_path='model.tflite'
+[one-import-tflite]
+input_path='model.tflite'
           `;
 
           testBuilder.writeFileSync('model.cfg', content, 'workspace');
@@ -390,8 +390,8 @@ input_path=${modelName}
           const config = testBuilder.getPath('model.cfg', 'workspace');
 
           const content = `
-  [one-import-onnx]
-  input_path='model.tflite'
+[one-import-tflite]
+input_path='model.tflite'
           `;
 
           testBuilder.writeFileSync('model.cfg', content, 'workspace');
@@ -421,8 +421,8 @@ input_path=${modelName}
 
         test('model and config names', function() {
           const content = `
-  [one-import-onnx]
-  input_path='model.tflite'
+[one-import-tflite]
+input_path='model.tflite'
           `;
 
           const oldModel = testBuilder.getPath('model.tflite', 'workspace');
@@ -443,7 +443,7 @@ input_path=${modelName}
 
           const newModel = testBuilder.getPath('model.new.tflite', 'workspace');
           const newContent = `
-  [one-import-onnx]
+  [one-import-tflite]
   input_path='model.new.tflite'
           `;
 
@@ -461,8 +461,8 @@ input_path=${modelName}
 
         test('NEG: not existing path', function() {
           const content = `
-  [one-import-onnx]
-  input_path='model.tflite'
+[one-import-tflite]
+input_path='model.tflite'
           `;
 
           const model = testBuilder.getPath('model.tflite', 'workspace');


### PR DESCRIPTION
This commit refactors OneStorage class
to divide its functionalities into CfgToCfgObjMap and BaseModelToCfgMap.
It includes unit tests.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

----

Related to #1442
From #1446
Waiting for #1452