### PR TITLE
[OneExplorer] Fix trivial typos

### DIFF
--- a/src/OneExplorer/ArtifactLocator.ts
+++ b/src/OneExplorer/ArtifactLocator.ts
@@ -83,13 +83,13 @@ export interface ArtifactAttr {
  */
 export class Locator {
   /**
-   * The section of ini to find the targetted file
+   * The section of ini to find the targeted file
    * If not given, locator searches the whole section
    */
   section?: string;
 
   /**
-   * The key inside section to find the targetted file
+   * The key inside section to find the targeted file
    * If not given, locator searches the whole key
    */
   key?: string;

--- a/src/OneExplorer/ConfigObject.ts
+++ b/src/OneExplorer/ConfigObject.ts
@@ -93,7 +93,7 @@ export class ConfigObj {
   }
 
   /**
-   * @breif Get absolute path
+   * @brief Get absolute path
    * @param path Relative path of cfg file
    */
   getFullPath(relpath: string) {

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -79,7 +79,7 @@ export enum NodeType {
 
   /**
    * An ONE configuration file for onecc.
-   * Which imports a targetted 'baseModel' (NOTE baseModel:config has 1:N relationship)
+   * Which imports a targeted 'baseModel' (NOTE baseModel:config has 1:N relationship)
    */
   config,
 
@@ -605,7 +605,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
    * 'context.extension.extensionKind' indicates which side the extension is running.
    *
    * NOTE 'extensionKind' property in 'package.json' is different from
-   * 'context.extension.extensionKind'. extenionKind(package.json) is a field to manifest the
+   * 'context.extension.extensionKind'. extensionKind(package.json) is a field to manifest the
    * extension's preference. extension.extensionKind is an eventual runtime property.
    *
    * @ref https://github.com/Samsung/ONE-vscode/issues/1209
@@ -618,7 +618,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
    * 'context.extension.extensionKind' indicates which side the extension is running.
    *
    * NOTE 'extensionKind' property in 'package.json' is different from
-   * 'context.extension.extensionKind'. extenionKind(package.json) is a field to manifest the
+   * 'context.extension.extensionKind'. extensionKind(package.json) is a field to manifest the
    * extension's preference. extension.extensionKind is an eventual runtime property.
    *
    * @ref https://github.com/Samsung/ONE-vscode/issues/1209
@@ -909,7 +909,7 @@ input_path=${modelName}.${extName}
       })
       .then((value) => {
         if (!value) {
-          Logger.debug("OneExplorer", "User hit the excape key!");
+          Logger.debug("OneExplorer", "User hit the escape key!");
           return;
         }
 

--- a/src/OneExplorer/OneStorage.ts
+++ b/src/OneExplorer/OneStorage.ts
@@ -187,7 +187,7 @@ class BaseModelToCfgMap {
  * PURPOSE
  *
  * To build each 'Node' of OneTreeDataProvider,
- * it is neccessary to access the file system, read the files and build objects(ConfigObj, ...).
+ * it is necessary to access the file system, read the files and build objects(ConfigObj, ...).
  * By keeping some file system information as data structure (list, map),
  * some duplicated works can be reduced.
  *
@@ -318,7 +318,7 @@ export class OneStorage {
   public static insert(node: Node) {
     // NOTE
     // Only _nodeMap is built by calling this function
-    // _baseModelToCfgsMap and _cfgToCfgObjMap are built at constuctors
+    // _baseModelToCfgsMap and _cfgToCfgObjMap are built at constructors
     OneStorage.get()._nodeMap.set(node.path, node);
   }
 


### PR DESCRIPTION
This commit fixes trivial typos in src/OneExplorer directory.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>