### PR TITLE
Remove chai from product code

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { assert } from "chai";
+import * as assert from "assert";
 import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";

--- a/src/OneExplorer/OneStorage.ts
+++ b/src/OneExplorer/OneStorage.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { assert } from "chai";
+import * as assert from "assert";
 import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
@@ -63,7 +63,7 @@ class CfgToCfgObjMap {
       case NodeType.product:
       case NodeType.directory:
       default:
-        assert.isOk(false, `Cannot reach here`);
+        assert.fail(`Cannot reach here`);
         break;
     }
   }
@@ -93,7 +93,7 @@ class CfgToCfgObjMap {
       case NodeType.product:
       case NodeType.directory:
       default:
-        assert.isOk(false, `Cannot reach here`);
+        assert.fail(`Cannot reach here`);
         break;
     }
   }
@@ -145,7 +145,7 @@ class BaseModelToCfgMap {
       case NodeType.product:
       case NodeType.directory:
       default:
-        assert.isOk(false, `Cannot reach here`);
+        assert.fail(`Cannot reach here`);
         break;
     }
   }
@@ -175,7 +175,7 @@ class BaseModelToCfgMap {
       case NodeType.product:
       case NodeType.directory:
       default:
-        assert.isOk(false, `Cannot reach here`);
+        assert.fail(`Cannot reach here`);
         break;
     }
   }

--- a/src/Tests/MockCompiler.ts
+++ b/src/Tests/MockCompiler.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { assert } from "chai";
+import * as assert from "assert";
 import { Command } from "../Backend/Command";
 
 import { CompilerBase } from "../Backend/Compiler";
@@ -69,7 +69,7 @@ class MockCompiler extends CompilerBase {
     if (count === 0) {
       return [];
     }
-    assert(count === 1, "Count must be 1");
+    assert.strictEqual(count, 1, "Count must be 1");
     if (toolchainType === mockCompilerType1) {
       return [this.availableToolchain];
     }


### PR DESCRIPTION
This commit reverts "[OneExplorer] Use chai instead of assert (#1441)" and similar changes. 'chai' doesn't turn off at release mode, so it MUST NOT BE USED IN PRODUCT CODE.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

For #1463