### PR TITLE
[OneExplorer] Fix ArtifactLocator

### DIFF
--- a/src/OneExplorer/ArtifactLocator.ts
+++ b/src/OneExplorer/ArtifactLocator.ts
@@ -141,6 +141,10 @@ export class Locator {
       "FIX CALLER: dir argument must be an absolute path"
     );
 
+    if (typeof iniObj !== "object") {
+      return [];
+    }
+
     // Get file names from iniObj
     const getFileNames = (): string[] => {
       let fileNames: string[] = [];
@@ -151,7 +155,8 @@ export class Locator {
       // Find valid iniObj[section] as object
       const sectionObjs: object[] = sections
         .filter((section) => section in iniObj)
-        .map((section) => iniObj[section as keyof typeof iniObj]);
+        .map((section) => iniObj[section as keyof typeof iniObj])
+        .filter((sectionObj) => typeof sectionObj === "object");
 
       sectionObjs.forEach((sectionObj) => {
         // If a key not given, search all keys

--- a/src/Tests/OneExplorer/ConfigObject.test.ts
+++ b/src/Tests/OneExplorer/ConfigObject.test.ts
@@ -195,6 +195,32 @@ input_path=${modelName}
         }
       });
 
+      test("NEG: Parse wrong format ini file", function () {
+        const configName = "model.cfg";
+        const modelName = "model.tflite";
+
+        const content = `
+  [one-import-tflite]
+  input_path=${modelName}
+        `;
+
+        // Write a file inside temp directory
+        testBuilder.writeFileSync(configName, content);
+
+        // Get file paths inside the temp directory
+        const configPath = testBuilder.getPath(configName);
+        const configObj = ConfigObj.createConfigObj(
+          vscode.Uri.file(configPath)
+        );
+
+        // Validation
+        {
+          assert.isDefined(configObj);
+          assert.strictEqual(configObj!.getBaseModels.length, 0);
+          assert.strictEqual(configObj!.getProducts.length, 0);
+        }
+      });
+
       test("NEG: Parse config with invalid ext with one-import-tflite", function () {
         const configName = "model.cfg";
         // ERROR INJECTION

--- a/src/Tests/OneExplorer/OneStorage.test.ts
+++ b/src/Tests/OneExplorer/OneStorage.test.ts
@@ -470,8 +470,8 @@ input_path='model.tflite'
 
           const newModel = testBuilder.getPath("model.new.tflite", "workspace");
           const newContent = `
-  [one-import-tflite]
-  input_path='model.new.tflite'
+[one-import-tflite]
+input_path='model.new.tflite'
           `;
 
           testBuilder.writeFileSync("model.cfg", newContent, "workspace");


### PR DESCRIPTION
This commit fixes ArtifactLocator not to parse wrongly formatted ini file.

For example,
>
>  [one-import-tflite]
>  input_path="model.tflite"

This is parsed by python 'ini' module as
[one-import-tflite]=true
...

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>