### PR TITLE
[Toolchain] Fix the problem of one toolchain installation failure

### DIFF
--- a/src/Backend/One/OneToolchain.ts
+++ b/src/Backend/One/OneToolchain.ts
@@ -135,7 +135,7 @@ class OneCompiler implements Compiler {
         ["madison", `${this.toolchainName}`],
         { encoding: "utf8" },
         "awk",
-        ['{printf $1" "$3}'],
+        ['{printf $3" "}'],
         { encoding: "utf8" }
       );
     } catch (error) {


### PR DESCRIPTION
This commit removes the package name from the apt-cache result.
Installation fails indefinitely due to an unexpected package name.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>