### PR TITLE
[OneStorage] Fix unit tests

### DIFF
--- a/src/Tests/OneExplorer/OneStorage.test.ts
+++ b/src/Tests/OneExplorer/OneStorage.test.ts
@@ -50,6 +50,7 @@ input_path=${modelName}
 
           testBuilder.writeFileSync(configName, content, "workspace");
           testBuilder.writeFileSync(modelName, "", "workspace");
+          OneStorage.reset();
 
           const configPath = testBuilder.getPath(configName, "workspace");
           const modelPath = testBuilder.getPath(modelName, "workspace");
@@ -72,6 +73,7 @@ input_path=${modelName}
           const modelName = "model.tflite";
 
           testBuilder.writeFileSync(modelName, "", "workspace");
+          OneStorage.reset();
 
           {
             assert.isUndefined(OneStorage.getCfgs("invalid/path"));
@@ -82,6 +84,7 @@ input_path=${modelName}
           const modelName = "model.circle";
 
           testBuilder.writeFileSync(modelName, "", "workspace");
+          OneStorage.reset();
 
           const modelPath = testBuilder.getPath(modelName, "workspace");
           {
@@ -103,6 +106,7 @@ input_path=${modelName}
           // Write a file inside temp directory
           testBuilder.writeFileSync(configName, content, "workspace");
           testBuilder.writeFileSync(modelName, "", "workspace");
+          OneStorage.reset();
 
           // Get file paths inside the temp directory
           const configPath = testBuilder.getPath(configName, "workspace");
@@ -128,6 +132,7 @@ input_path=${modelName}
           const modelName = "model.circle";
 
           testBuilder.writeFileSync(modelName, "", "workspace");
+          OneStorage.reset();
 
           const modelPath = testBuilder.getPath(modelName, "workspace");
           {


### PR DESCRIPTION
This commit inserts OneStorage.reset() if a test case includes any file system change.
OneStorage's singleton instance reflects the filesystem context at the time it is first referred.
Therefore, to update OneStorage instance, OneStorage.reset() must be called after the writeFileSync in test.

Then, how come those tests passed so far? One possible guess is that Github Action's runner somehow keeps previous test's filesystem,
so that those tests have been randomly succeeded.
Let's fix the test.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>