### PR TITLE
[ci] Apply reusable workflow in release workflows

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -181,53 +181,25 @@ jobs:
               body: `:heavy_check_mark: Unit test passed`
             })
 
-  # Same job with publish-extension.yml
-  create-vsce-package:
+  publish-extension:
     needs:
       - post-license-result
       - check-copyright
       - check-compile
       - check-test
-    runs-on: ubuntu-latest
-    outputs:
-      package_name: ${{ steps.search_package.outputs.package_name }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '16'
-      - name: Install node packages
-        run: |
-          npm install
-      - name: Install vsce tool
-        run: |
-          npm install -g vsce
-      - name: Build vsix package
-        run: |
-          vsce package ${{ github.event.inputs.tag }}
-      # TODO Enable publish job
-      - name: Publish vsix package
-        if: ${{ false }}
-        run: |
-          vsce publish
-      - id: search_package
-        run: |
-          fname=$(find . -name "*.vsix" | xargs -I {} basename {})
-          echo "::set-output name=package_name::$fname"
-      - name: Upload vsix package
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.search_package.outputs.package_name }}
-          path: ./${{ steps.search_package.outputs.package_name }}
+    uses: ./.github/workflows/publish-extension.yml
+    with:
+      prerelease: ${{ github.event.inputs.prerelease }}
+    secrets: inherit
 
   release:
-    needs: create-vsce-package
+    needs: publish-extension
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
-          name: ${{ needs.create-vsce-package.outputs.package_name }}
+          name: ${{ needs.publish-extension.outputs.package_name }}
       - name: Release
         id: create_release
         uses: actions/create-release@v1
@@ -245,6 +217,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./${{ needs.create-vsce-package.outputs.package_name }}
-          asset_name: ${{ needs.create-vsce-package.outputs.package_name }}
+          asset_path: ./${{ needs.publish-extension.outputs.package_name }}
+          asset_name: ${{ needs.publish-extension.outputs.package_name }}
           asset_content_type: application/vsix

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,12 @@
+name: Nightly release
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 05:00 AM (KST) Mon-Fri
+    - cron: '00 20 * * 0-4'
+
+jobs:
+  publish-extension:
+    uses: ./.github/workflows/publish-extension.yml
+    secrets: inherit

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,36 +1,47 @@
 name: Publish extension
 
 on:
-  repository_dispatch:
-    types: [ publish-extension ]
-  schedule:
-    # 05:00 AM (KST) Mon-Fri
-    - cron: '00 20 * * 0-4'
+  workflow_call:
+    inputs:
+      prerelease:
+        description: 'Identify the release as a prerelease (default: false)'
+        type: string
+        default: false
+    outputs:
+      package_name:
+        description: 'Package name'
+        value: ${{ jobs.publish-extension.outputs.package_name }}
 
 jobs:
   publish-extension:
     runs-on: ubuntu-latest
+    outputs:
+      package_name: ${{ steps.search_package.outputs.package_name }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: 16
       - name: Install node packages
         run: |
           npm install
       - name: Install vsce tool
         run: |
           npm install -g vsce
-      - name: Build vsix package
+      - name: Create vsix package (pre-release)
+        if: ${{ inputs.prerelease == 'true' }}
+        run: |
+          vsce package --pre-release
+      - name: Create vsix package
+        if: ${{ inputs.prerelease == 'false' }}
         run: |
           vsce package
-      # TODO Enable publish job
-      - name: Publish vsix package
-        if: ${{ false }}
+      - id: search_package
         run: |
-          vsce publish
+          fname=$(find . -name "*.vsix" | xargs -I {} basename {})
+          echo "package_name=${fname}" >> $GITHUB_OUTPUT
       - name: Upload vsix package
         uses: actions/upload-artifact@v3
         with:
-          name: one-vscode-extension
-          path: ./*.vsix
+          name: ${{ steps.search_package.outputs.package_name }}
+          path: ./${{ steps.search_package.outputs.package_name }}


### PR DESCRIPTION
This commit change publish-extension to reusable workflow. And it introduces nightly-release for nightly build on behalf of publish-extension.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>