### PR TITLE
[ci] Publish extension to marketplace in official release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -190,6 +190,7 @@ jobs:
     uses: ./.github/workflows/publish-extension.yml
     with:
       prerelease: ${{ github.event.inputs.prerelease }}
+      publish: ${{ !inputs.draft && !inputs.prerelease }}
     secrets: inherit
 
   release:

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -7,10 +7,17 @@ on:
         description: 'Identify the release as a prerelease (default: false)'
         type: string
         default: false
+      publish:
+        description: 'Publish extension to marketplace'
+        type: boolean
+        default: false
     outputs:
       package_name:
         description: 'Package name'
         value: ${{ jobs.publish-extension.outputs.package_name }}
+    secrets:
+      VSCE_PAT:
+        required: true
 
 jobs:
   publish-extension:
@@ -40,6 +47,12 @@ jobs:
         run: |
           fname=$(find . -name "*.vsix" | xargs -I {} basename {})
           echo "package_name=${fname}" >> $GITHUB_OUTPUT
+      - name: Publish vsix package
+        if: ${{ inputs.publish }}
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          vsce publish -i ${{ steps.search_package.outputs.package_name }}
       - name: Upload vsix package
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This commit publishes vsix extension file to marketplace with Samsung Publisher in Official release workflow.
This job requires VSCE_PAT secret environment variable.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related issue: #1473 
Draft workflow: https://github.com/jyoungyun/vscode-test/actions/runs/3938041397/jobs/6736269110