### PR TITLE
[ci] Change the build-release workflow name

### DIFF
--- a/.github/workflows/official-release.yml
+++ b/.github/workflows/official-release.yml
@@ -1,4 +1,4 @@
-name: Build release
+name: Official release
 
 on:
   workflow_dispatch:    # Allow manual triggers


### PR DESCRIPTION
This commit changes the build-release workflow name to official-release workflow.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>