### PR TITLE
[ci] Version up the vscode engine to v1.63.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "vsce": "^2.7.0"
       },
       "engines": {
-        "vscode": "^1.57.0"
+        "vscode": "^1.63.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.4.0",
   "publisher": "Samsung",
   "engines": {
-    "vscode": "^1.57.0"
+    "vscode": "^1.63.0"
   },
   "categories": [
     "Other"


### PR DESCRIPTION
VSCode supports pre-release versions of extensions since v1.63.0. So this commit changes the version of vscode engine to v1.63.0.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>