### PR TITLE
[OneExplorer] Implement configuration run by Ctrl+F7

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,9 +156,14 @@
       },
       {
         "command": "one.explorer.runCfg",
-        "title": "Run with the toolchain",
+        "title": "Run with the toolchain (Ctrl+F7)",
         "category": "ONE",
         "icon": "$(play)"
+      },
+      {
+        "command": "one.explorer.runSingleSelectedCfg",
+        "title": "Run selected with the toolchain",
+        "category": "ONE"
       },
       {
         "command": "one.explorer.rename",
@@ -245,6 +250,13 @@
         "command": "one.viewer.metadata.showFromOneExplorer",
         "title": "ONE: Show Metadata",
         "category": "ONE"
+      }
+    ],
+    "keybindings": [
+      {
+          "command": "one.explorer.runSingleSelectedCfg",
+          "key": "ctrl+f7",
+          "when": "OneExplorerView.active && one.explorer:hasSelectedCfg"
       }
     ],
     "menus": {


### PR DESCRIPTION
This commit implements configuration run by  'Ctrl+F7' shortcut.

Issue: #1488
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>