### PR TITLE
[draft] Add Weight Visualization

### DIFF
--- a/media/CircleGraph/view-sidebar.css
+++ b/media/CircleGraph/view-sidebar.css
@@ -70,6 +70,8 @@ https://github.com/lutzroeder/netron/blob/ae449ff55642636e6a1eef092eda34ffcba1c6
 .sidebar-view-item-value-line-content { white-space: pre; word-wrap: normal; overflow: auto; display: block; }
 .sidebar-view-item-value-expander { font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace; float: right; color: #aaa; cursor: pointer; user-select: none; -webkit-user-select: none; -moz-user-select: none; padding: 4px 6px 4px 6px; }
 .sidebar-view-item-value-expander:hover { color: #000; }
+.sidebar-view-item-value-number { font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace; text-align: center; float: left; font-size: 11px !important; width: 14px !important; height: 11px !important; }
+.sidebar-view-item-value-number::-webkit-outer-spin-button, .sidebar-view-item-value-number::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
 .sidebar-view-item-select {
     font-family: inherit; font-size: 12px;
     background-color: #fcfcfc; border: #fcfcfc; color: #333;


### PR DESCRIPTION
This pull request adds a weight visualization implementation example:
![image](https://user-images.githubusercontent.com/4605568/217222989-3ec769e4-3031-493a-a4a7-dcced3899206.png)
On expanding a compatible node's tensor (with dim >= 2) a weight visualization GUI appears in property side-bar.
To visualize a tensor as a 2d image you need to:

1. Select axes of the tensor that will be used as x and y of the image (use the checkboxes of "axes selector", exactly two axes should be selected, the first selected axis is (x) and the second is (y)).
2. Select the values of the other axes that will be fixed with "values selector" - all not selected axes should have a fixed value.
3. The weights will appear as a 2d heatmap below. Blue color is the minimum value, red color is the maximum value.
For example: you are visualizing a tensor of shape (32, 3, 3, 3).
Let's assume you have selected the 2 lower checkboxes and fixed first axis value as 10 and the second axis value as 1.
So the top left pixel of the image corresponds to tensor[10][1][0][0] value.
The bottom right pixel - tensor[10][1][2][2] value.