### PR TITLE
[CfgEditor] Fill .cfg parameters  by default values

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,6 +251,11 @@
         "command": "one.viewer.metadata.showFromOneExplorer",
         "title": "ONE: Show Metadata",
         "category": "ONE"
+      },
+      {
+        "command": "one.editor.cfg.setDefaultValues",
+        "title": "ONE: Set Default Values",
+        "category": "ONE"
       }
     ],
     "keybindings": [
@@ -258,6 +263,11 @@
           "command": "one.explorer.runSingleSelectedCfg",
           "key": "ctrl+f7",
           "when": "OneExplorerView.active && one.explorer:hasSelectedCfg"
+      },
+      {
+        "command": "one.cfgEditor.setDefaultValues",
+        "key": "ctrl+shift+/",
+        "when": "activeCustomEditorId == one.editor.cfg"
       }
     ],
     "menus": {


### PR DESCRIPTION
This commit fills .cfg paramters by default values using keyboard shortcut.

This commit fills default values in .cfg file (input and output paths for import/optimization/quantization).
Currently its optimal usage would be:
1) create new configuration
2) check needful steps 
3) press 'ctrl+shift +/' for filling .cfg parameters to default values. ('ctrl+d' is busy)

Issue: #1487
ONE-vscode-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>