### PR TITLE
Tidy using clang-format

### DIFF
--- a/infra/format
+++ b/infra/format
@@ -4,7 +4,6 @@ INVALID_EXIT=0
 FILES_TO_CHECK=()
 DIRECTORIES_TO_BE_TESTED=()
 DIRECTORIES_NOT_TO_BE_TESTED=()
-CLANG_FORMAT_CANDIDATES=()
 PATCH_FILE=format.patch
 
 THIS_PROJECT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -13,12 +12,9 @@ echo $PROJECT_PATH
 
 function Usage()
 {
-  echo "Usage: $0 $(basename ${BASH_SOURCE[0]}) [OPTIONS] [<file|dir> ...]"
+  echo "Usage: $0 $(basename ${BASH_SOURCE[0]}) [<file|dir> ...]"
   echo "If no arguments are specified, it formats codes in src folder"
   echo "If <file>s are given, it reformats the files"
-  echo ""
-  echo "Options:"
-  echo "      --clang-format <TOOL>     clang format bin (default: clang-format-3.9, clang-format)"
 }
 
 DIRECTORIES_TO_BE_TESTED="src media"
@@ -30,14 +26,6 @@ do
     -h|--help|help)
       Usage
       exit 0
-      ;;
-    --clang-format)
-      CLANG_FORMAT_CANDIDATES=($2)
-      shift 2
-      ;;
-    --clang-format=*)
-      CLANG_FORMAT_CANDIDATES=(${1#*=})
-      shift
       ;;
     *)
       DIRECTORIES_TO_BE_TESTED+=($1)
@@ -67,21 +55,6 @@ function exclude_symbolic_links() {
 }
 
 function check_ts_files() {
-  CLANG_FORMAT_CANDIDATES+=("clang-format-8")
-  for CLANG_FORMAT_CANDIDATE in ${CLANG_FORMAT_CANDIDATES[@]}; do
-    if command_exists ${CLANG_FORMAT_CANDIDATE} ; then
-      CLANG_FORMAT="${CLANG_FORMAT_CANDIDATE}"
-      break
-    fi
-  done
-
-  if [[ -z ${CLANG_FORMAT}  ]]; then
-    echo "[ERROR] clang-format-8 is unavailable"
-    echo
-    echo "        Please install clang-format-8 before running format check"
-    exit 1
-  fi
-
   # Check .ts files
   FILES_TO_CHECK_TS=()
   for f in ${FILES_TO_CHECK[@]}; do
@@ -97,7 +70,6 @@ function check_ts_files() {
   # Skip by '.FORMATDENY' file
   for s in ${DIRECTORIES_NOT_TO_BE_TESTED[@]}; do
     FILES_TO_CHECK_TS=(${FILES_TO_CHECK_TS[*]/$s*/})
-    FILES_TO_CHECK_TS_BY_CLANG_FORMAT_8=(${FILES_TO_CHECK_TS_BY_CLANG_FORMAT_8[*]/$s*/})
   done
 
   if [[ ${#FILES_TO_CHECK_TS} -ne 0 ]]; then


### PR DESCRIPTION
This will tidy unused clang-format related in format tool.

ONE-vscode-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>