### PR TITLE
[MPQEditor] Implement 'validateMPQName'

### DIFF
--- a/src/MPQEditor/MPQEditor.ts
+++ b/src/MPQEditor/MPQEditor.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import * as fs from "fs";
+import * as path from "path";
 import * as vscode from "vscode";
 
 import { getNonce } from "../Utils/external/Nonce";
@@ -46,6 +48,30 @@ export class MPQEditorProvider implements vscode.CustomTextEditorProvider {
     registrations.forEach((disposable) =>
       context.subscriptions.push(disposable)
     );
+  }
+
+  /**
+   * @brief A helper function to validate mpqName
+   * @note It checks whether
+   * (1) 'mpqName' already exists in 'dirPath' directory
+   * (2) 'mpqName' has valid extension
+   * @returns 'undefined' on success or the cause of failure otherwise
+   */
+  public static validateMPQName(
+    dirPath: string,
+    mpqName: string
+  ): string | undefined {
+    const mpqPath: string = path.join(dirPath, mpqName);
+
+    if (!mpqPath.endsWith(MPQEditorProvider.fileExtension)) {
+      return "A file extension must be " + MPQEditorProvider.fileExtension;
+    }
+
+    if (fs.existsSync(mpqPath)) {
+      return `A file or folder ${mpqPath} already exists at this location. Please choose a different name.`;
+    }
+
+    return undefined;
   }
 
   constructor(private readonly context: vscode.ExtensionContext) {}

--- a/src/Tests/MPQEditor/MPQEditor.test.ts
+++ b/src/Tests/MPQEditor/MPQEditor.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assert } from "chai";
+import { MPQEditorProvider } from "../../MPQEditor/MPQEditor";
+import { TestBuilder } from "../TestBuilder";
+
+suite("MPQEditor", function () {
+  suite("MPQEditorProvider", function () {
+    let testBuilder: TestBuilder;
+
+    setup(() => {
+      testBuilder = new TestBuilder(this);
+      testBuilder.setUp();
+    });
+
+    teardown(() => {
+      testBuilder.tearDown();
+    });
+
+    suite("#validateMPQName", function () {
+      test("test validateMPQName", function () {
+        const dirPath: string = testBuilder.dirInTemp;
+        const mpqName: string = "model-test-validateMPQName.mpq.json";
+
+        const retValue = MPQEditorProvider.validateMPQName(dirPath, mpqName);
+        assert.isUndefined(retValue);
+      });
+
+      test("NEG: test validateMPQName which exists", function () {
+        const dirPath: string = testBuilder.dirInTemp;
+        const mpqName: string =
+          "model-test-validateMPQName_NEG_EXISTS.mpq.json";
+        const content = `empty content`;
+
+        testBuilder.writeFileSync(mpqName, content);
+        const retValue = MPQEditorProvider.validateMPQName(dirPath, mpqName);
+        assert.isDefined(retValue);
+      });
+
+      test("NEG: test validateMPQName with wrong extension", function () {
+        const dirPath: string = testBuilder.dirInTemp;
+        const mpqName: string = "model-test-validateMPQName_NEG_EXT.json";
+
+        const retValue = MPQEditorProvider.validateMPQName(dirPath, mpqName);
+        assert.isDefined(retValue);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This commit implements 'validateMPQName' and adds tests for it.

Fresh draft: https://github.com/Samsung/ONE-vscode/pull/1511
Previous draft: https://github.com/Samsung/ONE-vscode/pull/1505
Related: https://github.com/Samsung/ONE-vscode/issues/1491

ONE-vscode-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>