### PR TITLE
[MPQEditor] Implement 'createDefaultMPQ'

### DIFF
--- a/src/MPQEditor/MPQEditor.ts
+++ b/src/MPQEditor/MPQEditor.ts
@@ -52,6 +52,38 @@ export class MPQEditorProvider implements vscode.CustomTextEditorProvider {
   }
 
   /**
+   * @brief create file with default mpq configuration
+   * @returns valid uri of file on success or undefined on failure
+   */
+  public static async createDefaultMPQ(
+    mpqName: string,
+    dirPath: string,
+    circleName: string
+  ): Promise<vscode.Uri | undefined> {
+    const content = `{"default_quantization_dtype": "uint8",
+      "default_granularity": "channel",
+      "layers": [],
+      "model_path": "${circleName}"}`;
+
+    // 'uri' path is not occupied, assured by validateInputPath
+    const uri = vscode.Uri.file(`${dirPath}/${mpqName}`);
+
+    const edit = new vscode.WorkspaceEdit();
+    edit.createFile(uri);
+    edit.insert(uri, new vscode.Position(0, 0), content);
+
+    try {
+      await vscode.workspace.applyEdit(edit);
+      let document = await vscode.workspace.openTextDocument(uri);
+      document.save();
+    } catch (error) {
+      return undefined;
+    }
+
+    return uri;
+  }
+
+  /**
    * @brief A helper function to validate mpqName
    * @note It checks whether
    * (1) 'mpqName' already exists in 'dirPath' directory

--- a/src/Tests/MPQEditor/MPQEditor.test.ts
+++ b/src/Tests/MPQEditor/MPQEditor.test.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import * as fs from "fs";
+import * as path from "path";
+
 import { assert } from "chai";
 import { MPQEditorProvider } from "../../MPQEditor/MPQEditor";
 import { TestBuilder } from "../TestBuilder";
@@ -90,6 +93,42 @@ suite("MPQEditor", function () {
       test("NEG: findMPQName throws on empty string", function () {
         const dirPath: string = testBuilder.dirInTemp;
         assert.throws(() => MPQEditorProvider.findMPQName("", dirPath));
+      });
+    });
+
+    suite("#createDefaultMPQ", function () {
+      test("test createDefaultMPQ", function () {
+        // create dummy mpq.json file
+        const dirPath: string = testBuilder.dirInTemp;
+        const mpqName: string = "model-test-createMPQ.mpq.json";
+        const circleName: string = "model-test-createMPQ.circle";
+        MPQEditorProvider.createDefaultMPQ(mpqName, dirPath, circleName).then(
+          (uri) => {
+            assert.isTrue(uri !== undefined);
+            const mpqPath: string = path.join(dirPath, mpqName);
+            assert.isTrue(fs.existsSync(mpqPath));
+            const contents: string = fs.readFileSync(mpqPath, "utf-8");
+            const cont: any = JSON.parse(contents);
+            assert.strictEqual(cont["default_quantization_dtype"], "uint8");
+            assert.strictEqual(cont["default_granularity"], "channel");
+            assert.strictEqual(cont["model_path"], circleName);
+          }
+        );
+      });
+      test("NEG: test createDefaultMPQ on exsisting file", function () {
+        // create dummy mpq.json file
+        const dirPath: string = testBuilder.dirInTemp;
+        const mpqName: string = "model-test-createMPQ_NEG.mpq.json";
+        const circleName: string = "model-test-createMPQ_NEG.circle";
+
+        const content = `empty content`;
+        testBuilder.writeFileSync(mpqName, content);
+
+        MPQEditorProvider.createDefaultMPQ(mpqName, dirPath, circleName).then(
+          (uri) => {
+            assert.isTrue(uri === undefined);
+          }
+        );
       });
     });
   });


### PR DESCRIPTION
This commit implements 'createDefaultMPQ' and adds tests for it.

Fresh draft: https://github.com/Samsung/ONE-vscode/pull/1511
Previous draft: https://github.com/Samsung/ONE-vscode/pull/1505
Related: https://github.com/Samsung/ONE-vscode/issues/1491

ONE-vscode-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>