### PR TITLE
[MPQEditor] Implement 'updateDocumentBy'

### DIFF
--- a/src/MPQEditor/MPQEditor.ts
+++ b/src/MPQEditor/MPQEditor.ts
@@ -210,4 +210,20 @@ export class MPQEditorProvider implements vscode.CustomTextEditorProvider {
 
     //TODO process messages
   }
+
+  /**
+   * @brief Update document by text
+   */
+  public static async updateDocumentBy(
+    document: vscode.TextDocument,
+    text: string
+  ) {
+    const edit = new vscode.WorkspaceEdit();
+    edit.replace(
+      document.uri,
+      new vscode.Range(0, 0, document.lineCount, 0),
+      text
+    );
+    await vscode.workspace.applyEdit(edit);
+  }
 }

--- a/src/Tests/MPQEditor/MPQEditor.test.ts
+++ b/src/Tests/MPQEditor/MPQEditor.test.ts
@@ -16,6 +16,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import * as vscode from "vscode";
 
 import { assert } from "chai";
 import { MPQEditorProvider } from "../../MPQEditor/MPQEditor";
@@ -129,6 +130,37 @@ suite("MPQEditor", function () {
             assert.isTrue(uri === undefined);
           }
         );
+      });
+    });
+
+    suite("#updateDocumentBy", function () {
+      test("update document by", async function () {
+        const dirPath: string = testBuilder.dirInTemp;
+        const mpqName: string = "model-test-updateDocumentBy.mpq.json";
+        const circleName: string = "model-test-updateDocumentBy.circle";
+
+        const uri = await MPQEditorProvider.createDefaultMPQ(
+          mpqName,
+          dirPath,
+          circleName
+        );
+        assert.isTrue(uri !== undefined);
+
+        let document = await vscode.workspace.openTextDocument(uri!);
+
+        const newJson = `{"default_quantization_dtype": "int16",
+          "default_granularity": "layer",
+          "layers": [],
+          "model_path": "sample_1.circle"}`;
+
+        await MPQEditorProvider.updateDocumentBy(document, newJson);
+
+        document.save();
+        const newJsonText: string = document.getText();
+        const newCont = JSON.parse(newJsonText);
+        assert.strictEqual(newCont["default_quantization_dtype"], "int16");
+        assert.strictEqual(newCont["default_granularity"], "layer");
+        assert.strictEqual(newCont["model_path"], "sample_1.circle");
       });
     });
   });


### PR DESCRIPTION
This commit implements 'updateDocumentBy' and adds tests for it.

Fresh draft: https://github.com/Samsung/ONE-vscode/pull/1511
Previous draft: https://github.com/Samsung/ONE-vscode/pull/1505
Related: https://github.com/Samsung/ONE-vscode/issues/1491

ONE-vscode-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>