### PR TITLE
[MPQEditor] Implement createFromDefaultExplorer

### DIFF
--- a/src/MPQEditor/MPQEditor.ts
+++ b/src/MPQEditor/MPQEditor.ts
@@ -47,6 +47,12 @@ export class MPQEditorProvider implements vscode.CustomTextEditorProvider {
         }
       ),
       // Add command registration here
+      vscode.commands.registerCommand(
+        "one.editor.mpq.createFromDefaultExplorer",
+        (uri) => {
+          MPQEditorProvider.createMPQJson(uri);
+        }
+      ),
     ];
 
     registrations.forEach((disposable) =>


### PR DESCRIPTION
This commit implements createFromDefaultExplorer command for manual mixed precision task.

Its correctness is tested in https://github.com/Samsung/ONE-vscode/pull/1511.

Fresh draft: https://github.com/Samsung/ONE-vscode/pull/1511
Previous draft: https://github.com/Samsung/ONE-vscode/pull/1505
Related: https://github.com/Samsung/ONE-vscode/issues/1491

ONE-vscode-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>