### PR TITLE
Register mpq editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,16 @@
           }
         ],
         "priority": "default"
+      },
+      {
+        "viewType": "one.editor.mpq",
+        "displayName": "MPQ Editor",
+        "selector": [
+          {
+            "filenamePattern": "*.mpq.json"
+          }
+        ],
+        "priority": "default"
       }
     ],
     "commands": [
@@ -256,6 +266,11 @@
         "command": "one.editor.cfg.setDefaultValues",
         "title": "ONE: Set Default Values",
         "category": "ONE"
+      },
+      {
+        "command": "one.editor.mpq.createFromDefaultExplorer",
+        "title": "Create MPQ json",
+        "category": "ONE"
       }
     ],
     "keybindings": [
@@ -370,6 +385,11 @@
           "command": "one.viewer.metadata.showFromDefaultExplorer",
           "when": "resourceExtname in one.metadata.supportedFiles && !explorerResourceIsFolder",
           "group": "7_metadata@1"
+        },
+        {
+          "command": "one.editor.mpq.createFromDefaultExplorer",
+          "when": "resourceExtname == .circle",
+          "group": "1_tools"
         }
       ],
       "commandPalette": [
@@ -451,6 +471,10 @@
         },
         {
           "command": "one.viewer.metadata.showFromOneExplorer",
+          "when": "false"
+        },
+        {
+          "command": "one.editor.mpq.createFromDefaultExplorer",
           "when": "false"
         }
       ]


### PR DESCRIPTION
This commit registers *.mpq.json and showFromDefaultExplorer for  mpq editor.

Its correctness is tested in https://github.com/Samsung/ONE-vscode/pull/1511.

Fresh draft: https://github.com/Samsung/ONE-vscode/pull/1511
Previous draft: https://github.com/Samsung/ONE-vscode/pull/1505
Related: https://github.com/Samsung/ONE-vscode/issues/1491

ONE-vscode-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>