### PR TITLE
[MPQEditor] Implement media for VISQ

### DIFF
--- a/media/MPQEditor/index.html
+++ b/media/MPQEditor/index.html
@@ -58,6 +58,15 @@ limitations under the License.
             </vscode-button>
         </div>
         <div class="rightbtns">
+            <vscode-text-field id="VisqInputPath" startIcon="true" placeholder="visq path" readonly="true">
+                <span slot="start" class="codicon codicon-question" style="cursor: pointer">
+                    <span class="help">
+                        visq.json file with layer-wise quantization errors
+                    </span>
+                </span>
+                <span id="visq-file" slot="end" class="codicon codicon-search" style="cursor: pointer"></span>
+                <span id="visq-delete" slot="end" class="codicon codicon-chrome-close" style="cursor: pointer"></span>
+            </vscode-text-field>
             <vscode-checkbox id="circle-graph">Show Graph</vscode-checkbox>
         </div>
     </div>

--- a/media/MPQEditor/index.js
+++ b/media/MPQEditor/index.js
@@ -36,6 +36,9 @@ function main() {
       case "modelGraphIsShown":
         handleModelGraphIsShown(message.shown);
         break;
+      case "VisqFileLoaded":
+        handleVisqFileLoaded(message.visqFile);
+        break;
       default:
         break;
     }
@@ -56,6 +59,10 @@ function handleModelGraphIsShown(shown) {
 
 function handleModelNodesChanged(names) {
   document.getElementById("AddSpecificLayer").disabled = names.length < 1;
+}
+
+function handleVisqFileLoaded(visqFile) {
+  document.getElementById("VisqInputPath").value = visqFile;
 }
 
 function registerMainControls() {
@@ -91,6 +98,28 @@ function registerMainControls() {
         type: "addSpecificLayerFromDialog",
       });
     });
+
+  document
+    .getElementById("VisqInputPath")
+    .addEventListener("input", function () {
+      vscode.postMessage({
+        type: "VisqInputPathChanged",
+        path: document.getElementById("VisqInputPath").value,
+      });
+    });
+
+  document.getElementById("visq-file").addEventListener("click", function () {
+    vscode.postMessage({
+      type: "loadVisqFile",
+    });
+  });
+
+  document.getElementById("visq-delete").addEventListener("click", function () {
+    document.getElementById("VisqInputPath").value = "";
+    vscode.postMessage({
+      type: "removeVisqFile",
+    });
+  });
 
   document.getElementById("AddSpecificLayer").disabled = true;
 }

--- a/media/MPQEditor/style.css
+++ b/media/MPQEditor/style.css
@@ -30,3 +30,22 @@ float: left;
 .rightbtns {
 float: right;
 }
+
+.codicon.codicon-question .help {
+visibility: hidden;
+width: auto;
+background-color: var(--vscode-editorSuggestWidget-background);
+color: var(--vscode-editorSuggestWidget-foreground);
+border: 2px solid var(--vscode-editorSuggestWidget-border);
+font-size: small;
+text-align: left;
+position: absolute;
+z-index: 1;
+margin-left: 10px;
+padding: 6px 6px 10px 8px;
+font-family: var(--vscode-font-family);
+}
+
+.codicon.codicon-question:hover .help {
+visibility: visible;
+}


### PR DESCRIPTION
This commit implements mpqeditor media changes for showing VISQ data for MPQ.

Its correctness is tested in https://github.com/Samsung/ONE-vscode/pull/1543

Fresh draft: https://github.com/Samsung/ONE-vscode/pull/1543
Full draft: https://github.com/Samsung/ONE-vscode/pull/1505
Related: https://github.com/Samsung/ONE-vscode/issues/1491

ONE-vscode-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>
