### PR TITLE
[ONEToolchain] Use user github token in ONE Toolchain

### DIFF
--- a/package.json
+++ b/package.json
@@ -489,7 +489,16 @@
           ".cfg"
         ]
       }
-    ]
+    ],
+    "configuration": {
+      "title": "ONE-vscode",
+      "properties": {
+        "one.toolchain.githubToken": {
+          "type": "string",
+          "description": "Sets User GitHub Token"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/Backend/One/OneToolchain.ts
+++ b/src/Backend/One/OneToolchain.ts
@@ -33,7 +33,13 @@ import { Version } from "../Version";
 class OneDebianToolchain extends DebianToolchain {
   run(cfg: string): Command {
     this.prepare();
+    const configs = vscode.workspace.getConfiguration();
+    const value = configs.get("one.toolchain.githubToken", "");
     let cmd = new Command("onecc-docker");
+    if (value !== "") {
+      cmd.push("-t");
+      cmd.push(value);
+    }
     cmd.push("-C");
     cmd.push(cfg);
     return cmd;


### PR DESCRIPTION
In some environments, a GitHub Token is required to access the one-compiler release page. It adds a property for GitHub Token and use it when onecc-docker tool is executed.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related issue: #1553 