### PR TITLE
[MPQEditor] Implement 'cancelScrollToSelected'

### DIFF
--- a/src/MPQEditor/MPQCircleSelector.ts
+++ b/src/MPQEditor/MPQCircleSelector.ts
@@ -288,6 +288,16 @@ export class MPQSelectionPanel
   }
 
   /**
+   * @brief called to prevent the view from scrolling after every user selection
+   */
+  public cancelScrollToSelected() {
+    this._webview.postMessage({
+      command: MessageDefs.scrollToSelected,
+      value: false,
+    });
+  }
+
+  /**
    * CircleGraphEvent interface implementations
    */
   public onViewMessage(message: any) {
@@ -301,9 +311,11 @@ export class MPQSelectionPanel
         }
         break;
       case MessageDefs.finishload:
+        this.cancelScrollToSelected();
         this.onForwardSelection(this._lastSelected);
         break;
       case MessageDefs.visq:
+        this.cancelScrollToSelected();
         this.sendVisq(this._visqData);
         break;
     }


### PR DESCRIPTION
This commit implements 'cancelScrollToSelected' and uses it to prevent the view from scrolling after every user selection.
See related https://github.com/Samsung/ONE-vscode/pull/1505#issuecomment-1453488864.

Its correctness is tested in https://github.com/Samsung/ONE-vscode/pull/1543

Fresh draft: https://github.com/Samsung/ONE-vscode/pull/1543
Full draft: https://github.com/Samsung/ONE-vscode/pull/1505
Related: https://github.com/Samsung/ONE-vscode/issues/1491

ONE-vscode-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>