### PR TITLE
Use a free server number in npm test-no-screen command

### DIFF
--- a/package.json
+++ b/package.json
@@ -511,7 +511,7 @@
     "linthtml": "htmlhint media src",
     "unittest": "node ./out/Tests/runTest.js",
     "test": "npm run unittest",
-    "test-no-screen": "DISPLAY=:44 xvfb-run --server-num 44 npm run test",
+    "test-no-screen": "DISPLAY=:44 xvfb-run -a --server-num 44 npm run test",
     "coverage": "npm run test coverage",
     "clean": "rm -rf out"
   },


### PR DESCRIPTION
This commit uses a free server number, starting to 44. Sometimes the 44 server number is not available to run xvfb-run tool. It solves this issue.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>