### PR TITLE
[Toolchain] Implement inference in ToolchainProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -242,6 +242,10 @@
         "title": "Run"
       },
       {
+        "command": "one.toolchain.inferModel",
+        "title": "Infer"
+      },
+      {
         "command": "one.device.refresh",
         "title": "Refresh all devices",
         "category": "ONE",
@@ -459,6 +463,10 @@
         },
         {
           "command": "one.toolchain.runCfg",
+          "when": "false"
+        },
+        {
+          "command": "one.toolchain.inferModel",
           "when": "false"
         },
         {

--- a/src/Tests/Toolchain/ToolchainProvider.test.ts
+++ b/src/Tests/Toolchain/ToolchainProvider.test.ts
@@ -302,6 +302,16 @@ suite("Toolchain", function () {
       });
     });
 
+    suite("#infer", function () {
+      test("NEG: requests run with uninitialized default toolchain", function () {
+        const provider = new ToolchainProvider();
+        const model = "model.bin";
+        DefaultToolchain.getInstance().unset();
+        const ret = provider.infer(model);
+        assert.equal(ret, undefined);
+      });
+    });
+
     suite("#setDefaultToolchain", function () {
       test("request setDefaultToolchain", function () {
         const provider = new ToolchainProvider();

--- a/src/Toolchain/ToolchainProvider.ts
+++ b/src/Toolchain/ToolchainProvider.ts
@@ -138,6 +138,9 @@ export class ToolchainProvider implements vscode.TreeDataProvider<BaseNode> {
       vscode.commands.registerCommand("one.toolchain.runCfg", (cfg) =>
         provider.run(cfg)
       ),
+      vscode.commands.registerCommand("one.toolchain.inferModel", (model) =>
+        provider.infer(model)
+      ),
       vscode.commands.registerCommand(
         "one.toolchain.setDefaultToolchain",
         (toolchain) => provider.setDefaultToolchain(toolchain)
@@ -342,6 +345,43 @@ export class ToolchainProvider implements vscode.TreeDataProvider<BaseNode> {
       return this._run(cfg);
     }
     return false;
+  }
+
+  public infer(
+    model: string,
+    options?: Map<string, string>
+  ): string | undefined {
+    /* istanbul ignore next */
+    const notifySuccess = () => {
+      vscode.window.showInformationMessage("Inference success.");
+    };
+    /* istanbul ignore next */
+    const notifyError = () => {
+      this.error("Inference has failed.");
+    };
+
+    const [toolchainEnv, toolchain] = this.checkAvailableToolchain();
+    if (toolchainEnv === undefined || toolchain === undefined) {
+      return;
+    }
+
+    Logger.info(
+      this.tag,
+      `Infer ${model} file using ${
+        toolchain.info.name
+      }-${toolchain.info.version?.str()} toolchain.`
+    );
+
+    toolchainEnv.infer(toolchain, model, options).then(
+      (result: string) => {
+        notifySuccess();
+        return result;
+      },
+      () => {
+        notifyError();
+      }
+    );
+    return;
   }
 
   public setDefaultToolchain(tnode: ToolchainNode): boolean {


### PR DESCRIPTION
This commit implements inference function in ToolchainProvider. This function calls the inferenct function of ToolchainEnv. It also adds vscode command for inference.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related issue: #1562 