### PR TITLE
[Toolchain] Change inference function name

### DIFF
--- a/src/Tests/Toolchain/ToolchainEnv.test.ts
+++ b/src/Tests/Toolchain/ToolchainEnv.test.ts
@@ -283,13 +283,13 @@ suite("Toolchain", function () {
       });
     });
 
-    suite("#inference()", function () {
-      test("NEG: requests unimplemented inference", async function () {
+    suite("#infer()", function () {
+      test("NEG: requests unimplemented infer", async function () {
         let env = new ToolchainEnv(compiler);
         const invalidToolchain = env.listInstalled();
         assert.isAbove(invalidToolchain.length, 0);
         const model = "model.bin";
-        await env.inference(invalidToolchain[0], model).catch(() => {
+        await env.infer(invalidToolchain[0], model).catch(() => {
           assert.isTrue(true);
         });
       });

--- a/src/Toolchain/ToolchainEnv.ts
+++ b/src/Toolchain/ToolchainEnv.ts
@@ -189,7 +189,7 @@ class ToolchainEnv extends Env {
     });
   }
 
-  public inference(
+  public infer(
     toolchain: Toolchain,
     model: string,
     options?: Map<string, string>


### PR DESCRIPTION
This commit changes inference() to infer().

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related issue: #1562