### PR TITLE
[Toolchain] Implement getModelInfo in ToolchainEnv

### DIFF
--- a/src/Tests/Toolchain/ToolchainEnv.test.ts
+++ b/src/Tests/Toolchain/ToolchainEnv.test.ts
@@ -306,5 +306,17 @@ suite("Toolchain", function () {
         });
       });
     });
+
+    suite("#getModelInfo()", function () {
+      test("NEG: requests unimplemented getModelInfo", async function () {
+        let env = new ToolchainEnv(compiler);
+        const invalidToolchain = env.listInstalled();
+        assert.isAbove(invalidToolchain.length, 0);
+        const model = "model.bin";
+        await env.getModelInfo(invalidToolchain[0], model, "test").catch(() => {
+          assert.isTrue(true);
+        });
+      });
+    });
   });
 });

--- a/src/Toolchain/ToolchainEnv.ts
+++ b/src/Toolchain/ToolchainEnv.ts
@@ -220,6 +220,22 @@ class ToolchainEnv extends Env {
       this.executeEnv(jobs);
     });
   }
+
+  public getModelInfo(
+    toolchain: Toolchain,
+    model: string,
+    type: string
+  ): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      const jobs: Array<Job> = [];
+      const job = new JobConfig(toolchain.runShow(model, type));
+      job.workDir = path.dirname(model);
+      job.successCallback = () => resolve(job.result ? job.result : "");
+      job.failureCallback = () => reject();
+      jobs.push(job);
+      this.executeEnv(jobs);
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
This commit implements getModelInfo() in ToolchainEnv.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related issue: #1562 