### PR TITLE
[Toolchain] Implement getModelInfo in ToolchainProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,6 +250,10 @@
         "title": "Profile"
       },
       {
+        "command": "one.toolchain.getModelInfo",
+        "title": "Get Model Info"
+      },
+      {
         "command": "one.device.refresh",
         "title": "Refresh all devices",
         "category": "ONE",
@@ -475,6 +479,10 @@
         },
         {
           "command": "one.toolchain.profileModel",
+          "when": "false"
+        },
+        {
+          "command": "one.toolchain.getModelInfo",
           "when": "false"
         },
         {

--- a/src/Tests/Toolchain/ToolchainProvider.test.ts
+++ b/src/Tests/Toolchain/ToolchainProvider.test.ts
@@ -322,6 +322,16 @@ suite("Toolchain", function () {
       });
     });
 
+    suite("#getModelInfo", function () {
+      test("NEG: gets model information with uninitialized default toolchain", function () {
+        const provider = new ToolchainProvider();
+        const model = "model.bin";
+        DefaultToolchain.getInstance().unset();
+        const ret = provider.getModelInfo(model);
+        assert.equal(ret, undefined);
+      });
+    });
+
     suite("#setDefaultToolchain", function () {
       test("request setDefaultToolchain", function () {
         const provider = new ToolchainProvider();

--- a/src/Toolchain/ToolchainProvider.ts
+++ b/src/Toolchain/ToolchainProvider.ts
@@ -144,6 +144,9 @@ export class ToolchainProvider implements vscode.TreeDataProvider<BaseNode> {
       vscode.commands.registerCommand("one.toolchain.profileModel", (model) =>
         provider.profile(model)
       ),
+      vscode.commands.registerCommand("one.toolchain.getModelInfo", (model) =>
+        provider.getModelInfo(model)
+      ),
       vscode.commands.registerCommand(
         "one.toolchain.setDefaultToolchain",
         (toolchain) => provider.setDefaultToolchain(toolchain)
@@ -415,6 +418,42 @@ export class ToolchainProvider implements vscode.TreeDataProvider<BaseNode> {
     toolchainEnv.profile(toolchain, model, options).then(
       () => {
         notifySuccess();
+      },
+      () => {
+        notifyError();
+      }
+    );
+    return;
+  }
+
+  public getModelInfo(model: string): string | undefined {
+    /* istanbul ignore next */
+    const notifySuccess = () => {
+      vscode.window.showInformationMessage(
+        "Getting model information success."
+      );
+    };
+    /* istanbul ignore next */
+    const notifyError = () => {
+      this.error("Getting model information has failed.");
+    };
+
+    const [toolchainEnv, toolchain] = this.checkAvailableToolchain();
+    if (toolchainEnv === undefined || toolchain === undefined) {
+      return;
+    }
+
+    Logger.info(
+      this.tag,
+      `Run show with ${model} file using ${
+        toolchain.info.name
+      }-${toolchain.info.version?.str()} toolchain.`
+    );
+
+    toolchainEnv.getModelInfo(toolchain, model, "target-arch").then(
+      (result: string) => {
+        notifySuccess();
+        return result;
       },
       () => {
         notifyError();


### PR DESCRIPTION
This commit implements getModelInfo function in ToolchainProvider. This function calls the getModelInfo function in ToolchainEnv. It also adds vscode command for getModelInfo.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related issue: #1562