### PR TITLE
[OneExplorer] Append the extname to the contextValue

### DIFF
--- a/package.json
+++ b/package.json
@@ -329,22 +329,22 @@
       "view/item/context": [
         {
           "command": "one.explorer.runCfg",
-          "when": "view == OneExplorerView && viewItem == config",
+          "when": "view == OneExplorerView && viewItem =~ /config/",
           "group": "1_run"
         },
         {
           "command": "one.explorer.runCfg",
-          "when": "view == OneExplorerView && viewItem == config",
+          "when": "view == OneExplorerView && viewItem =~ /config/",
           "group": "inline"
         },
         {
           "command": "one.explorer.rename",
-          "when": "view == OneExplorerView && viewItem == config",
+          "when": "view == OneExplorerView && viewItem =~ /config/",
           "group": "7_modification"
         },
         {
           "command": "one.explorer.refactor",
-          "when": "view == OneExplorerView && viewItem == baseModel",
+          "when": "view == OneExplorerView && viewItem =~ /baseModel/",
           "group": "7_modification"
         },
         {
@@ -359,17 +359,17 @@
         },
         {
           "command": "one.explorer.openAsText",
-          "when": "view == OneExplorerView && viewItem == config",
+          "when": "view == OneExplorerView && viewItem =~ /config/",
           "group": "3_open@1"
         },
         {
           "command": "one.explorer.revealInDefaultExplorer",
-          "when": "view == OneExplorerView && viewItem != directory",
+          "when": "view == OneExplorerView && !(viewItem =~ /directory/)",
           "group": "3_open@3"
         },
         {
           "command": "one.explorer.createCfg",
-          "when": "view == OneExplorerView && viewItem == baseModel",
+          "when": "view == OneExplorerView && viewItem =~ /baseModel/",
           "group": "inline"
         },
         {

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -463,7 +463,15 @@ export class OneNode extends vscode.TreeItem {
     //
     // However, resourceExtname returns info of vscode Explorer view (not of OneExplorer).
     //    "when": "view == OneExplorerView && viewItem == config"
-    this.contextValue = node.typeAsString;
+
+    // NOTE
+    // this.contextValue has a format of {NodeType}.{Ext}
+    // EXAMPLE
+    //   directory
+    //   basemode.tflite
+    //   product.tvn
+    const extname = path.extname(node.uri.fsPath);
+    this.contextValue = node.typeAsString + extname;
   }
 }
 


### PR DESCRIPTION
This commit appends the extname to the contextValue. The OneExplorer does not support `resourceExtname` context key. This issue can be resolved using the extname in the contextValue.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft PR: #1584 