### PR TITLE
[OneExplorer] Add rename shortcut 

### DIFF
--- a/package.json
+++ b/package.json
@@ -300,6 +300,11 @@
         "command": "one.explorer.delete",
         "key": "delete",
         "when": "OneExplorerView.active"
+      },
+      {
+        "command": "one.explorer.renameOnShortcut",
+        "key": "F2",
+        "when": "OneExplorerView.active && one.explorer:hasSelectedCfg"
       }
     ],
     "menus": {


### PR DESCRIPTION
This commit supports shortcut for renaming.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>