### PR TITLE
[OneExplorer] Seperate delete command

### DIFF
--- a/package.json
+++ b/package.json
@@ -297,7 +297,7 @@
         "when": "activeCustomEditorId == one.editor.cfg"
       },
       {
-        "command": "one.explorer.delete",
+        "command": "one.explorer.deleteOnShortcut",
         "key": "delete",
         "when": "OneExplorerView.active"
       }

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -595,22 +595,24 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
       vscode.commands.registerCommand("one.explorer.delete", (node: Node) =>
         provider.delete(node)
       ),
-      vscode.commands.registerCommand("one.explorer.delete", async () => {
-        if (provider.getSelectedNodes()?.length !== 1) {
-          // Delete is only supported for single selection
-          // Do not show an error or warning message for UI's sake
-          // TODO: handle for multiple selection
-          return;
-        } else {
-          const node = provider.getSelectedNodes()![0];
-          Logger.info("OneExplorer", "Shortcut", `Delete ${node.uri.fsPath}`);
+      vscode.commands.registerCommand(
+        "one.explorer.deleteOnShortcut",
+        async () => {
+          if (provider.getSelectedNodes()?.length !== 1) {
+            // Delete is only supported for single selection
+            // Do not show an error or warning message for UI's sake
+            // TODO: handle for multiple selection
+            return;
+          } else {
+            const node = provider.getSelectedNodes()![0];
+            Logger.info("OneExplorer", "Shortcut", `Delete ${node.uri.fsPath}`);
 
-          await provider.delete(node);
-          // TODO: handle for multiple selection
-          // TODO: improve refresh performance
-          provider.refresh(node.parent);
+            await provider.delete(node);
+            // TODO: handle for multiple selection
+            provider.refresh(node.parent);
+          }
         }
-      }),
+      ),
       vscode.commands.registerCommand("one.explorer.rename", (node: Node) =>
         provider.rename(node)
       ),


### PR DESCRIPTION
This commit fixes seperates delete and deleteOnShortcut commands. They works differently as the chosen nodes are different. 'delete' command targets the node on which it's right-clicked, whereas 'deleteOnShortcut' command target the nodes on which they're selected.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

Resolves #1591