### PR TITLE
[OneExplorer] Use jsontracer in trace.json file

### DIFF
--- a/src/OneExplorer/ConfigObject.ts
+++ b/src/OneExplorer/ConfigObject.ts
@@ -333,7 +333,7 @@ export class ConfigObj {
       artifactAttr: {
         ext: ".trace.json",
         icon: new vscode.ThemeIcon("graph"),
-        openViewType: "one.viewer.mondrian",
+        openViewType: "one.editor.jsonTracer",
         canHide: true,
       },
       locator: new Locator((value: string) => {


### PR DESCRIPTION
This commit uses jsontracer in trace.json file.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>