### PR TITLE
[Toolchain] Ask user to set github token

### DIFF
--- a/package.json
+++ b/package.json
@@ -559,7 +559,7 @@
       "properties": {
         "one.toolchain.githubToken": {
           "type": "string",
-          "description": "Your github token is needed in order to gain access to ONE toolchain."
+          "description": "GitHub token is needed in order to gain access to ONE toolchain."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -559,7 +559,7 @@
       "properties": {
         "one.toolchain.githubToken": {
           "type": "string",
-          "description": "Sets User GitHub Token"
+          "description": "Your github token is needed in order to gain access to ONE toolchain."
         }
       }
     }

--- a/src/Backend/One/OneToolchain.ts
+++ b/src/Backend/One/OneToolchain.ts
@@ -18,6 +18,7 @@ import * as cp from "child_process";
 import * as vscode from "vscode";
 
 import { pipedSpawnSync } from "../../Utils/PipedSpawnSync";
+import { Balloon } from "../../Utils/Balloon";
 import { Backend } from "../Backend";
 import { Command } from "../Command";
 import { Compiler } from "../Compiler";
@@ -34,6 +35,10 @@ class OneDebianToolchain extends DebianToolchain {
   run(cfg: string): Command {
     const configs = vscode.workspace.getConfiguration();
     const value = configs.get("one.toolchain.githubToken", "");
+    if (!value) {
+      Balloon.showGithubTokenErrorMessage();
+    }
+
     let cmd = new Command("onecc-docker");
     if (value !== "") {
       cmd.push("-t");

--- a/src/Utils/Balloon.ts
+++ b/src/Utils/Balloon.ts
@@ -58,4 +58,21 @@ export class Balloon {
       func(msg, "OK");
     }
   }
+
+  static showGithubTokenErrorMessage() {
+    vscode.window
+      .showInformationMessage(
+        "Your github token is unset. You are REQUIRED to set your github token to run ONE toolchain.",
+        { modal: true },
+        { title: "Open Settings" }
+      )
+      .then((selection) => {
+        if (selection && selection.title === "Open Settings") {
+          vscode.commands.executeCommand(
+            "workbench.action.openSettings",
+            "one.toolchain.githubToken"
+          );
+        }
+      });
+  }
 }

--- a/src/Utils/Balloon.ts
+++ b/src/Utils/Balloon.ts
@@ -62,7 +62,7 @@ export class Balloon {
   static showGithubTokenErrorMessage() {
     vscode.window
       .showInformationMessage(
-        "Your github token is unset. You are REQUIRED to set your github token to run ONE toolchain.",
+        "Please set you github token in case your network require an extra access to Samsung/ONE git repository.",
         { modal: false },
         { title: "Open Settings" }
       )

--- a/src/Utils/Balloon.ts
+++ b/src/Utils/Balloon.ts
@@ -63,7 +63,7 @@ export class Balloon {
     vscode.window
       .showInformationMessage(
         "Your github token is unset. You are REQUIRED to set your github token to run ONE toolchain.",
-        { modal: true },
+        { modal: false },
         { title: "Open Settings" }
       )
       .then((selection) => {


### PR DESCRIPTION
To use ONE Toolchain, user need to set github token in vscode settings. Currently, it fails on run without token.
Let's give direction to the user explicitly.


ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>


---

For #1601