### PR TITLE
[third_party] Add catapult as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/catapult"]
+	path = third_party/catapult
+	url = https://github.com/catapult-project/catapult.git


### PR DESCRIPTION
This commit adds catapult as submodule to use trace2html.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>