### PR TITLE
Add catapult-trace2html dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@typescript-eslint/eslint-plugin": "^4.9.0",
         "@typescript-eslint/parser": "^4.9.0",
         "@vscode/test-electron": "^2.1.3",
+        "catapult-trace2html": "^1.0.0",
         "chai": "^4.3.6",
         "csslint": "^1.0.5",
         "eslint": "^7.15.0",
@@ -1644,6 +1645,12 @@
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
         }
       ]
+    },
+    "node_modules/catapult-trace2html": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/catapult-trace2html/-/catapult-trace2html-1.0.0.tgz",
+      "integrity": "sha512-7oRzVBc+WEa5QQfLnq0kagmVlUlqE1f35vovkF169Mn1XNygs/ZHPsKSxsLMeE+egbBlEnZFiEpvHp6fqp34bw==",
+      "dev": true
     },
     "node_modules/chai": {
       "version": "4.3.6",
@@ -8236,6 +8243,12 @@
       "version": "1.0.30001363",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001363.tgz",
       "integrity": "sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg==",
+      "dev": true
+    },
+    "catapult-trace2html": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/catapult-trace2html/-/catapult-trace2html-1.0.0.tgz",
+      "integrity": "sha512-7oRzVBc+WEa5QQfLnq0kagmVlUlqE1f35vovkF169Mn1XNygs/ZHPsKSxsLMeE+egbBlEnZFiEpvHp6fqp34bw==",
       "dev": true
     },
     "chai": {

--- a/package.json
+++ b/package.json
@@ -590,6 +590,7 @@
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
     "@vscode/test-electron": "^2.1.3",
+    "catapult-trace2html": "^1.0.0",
     "chai": "^4.3.6",
     "csslint": "^1.0.5",
     "eslint": "^7.15.0",


### PR DESCRIPTION
This commit adds catapult-trace2html dependency.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>