### PR TITLE
[Extension] Revisit recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,5 @@
 	// for the documentation about the extensions.json format
 	"recommendations": [
 		"dbaeumer.vscode-eslint",
-		"xaver.clang-format"
 	]
 }


### PR DESCRIPTION
This commit removes xaver.clang-format extension from extension recommendation list.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

From #1617