### PR TITLE
[Action] Remove clang-format-8 installation

### DIFF
--- a/.github/workflows/check-pr-format.yml
+++ b/.github/workflows/check-pr-format.yml
@@ -20,7 +20,6 @@ jobs:
       - run: npm run lintjs
       - run: npm run lintcss
       - run: npm run linthtml
-      - run: sudo apt-get install clang-format-8
       - run: sudo apt-get install jq
       - run: bash infra/format
 


### PR DESCRIPTION
This commit removes redundant clang-format-8 installation

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

From #1617 