### PR TITLE
Draft : [EdgeTPU] To distinguish between compiled tflite files with the edgetpu compiler in Explorer

### DIFF
--- a/media/CfgEditor/cfgeditor.html
+++ b/media/CfgEditor/cfgeditor.html
@@ -84,6 +84,7 @@ limitations under the License.
                         <vscode-radio value="tflite">tflite</vscode-radio>
                         <vscode-radio value="onnx">onnx</vscode-radio>
                         <vscode-radio value="bcq" disabled="true">bcq</vscode-radio>
+                        <vscode-radio value="edgetpu">edge_tpu</vscode-radio>
                     </vscode-radio-group>
                 </div>
             </div>
@@ -216,7 +217,117 @@ limitations under the License.
                         <span class="help">
                             LSTM operation in ONNX file is unrolled so that there is no control flow in the graph
                         </span>
-                    </span>                    
+                    </span>                     
+                </div>
+            </div>
+            <div class="basic" id="optionImportEdgeTPUBasic">
+                <div class="title">
+                    Basic Options
+                </div>
+                <!-- 여기에 EdgeTPU Compile에 필요한 기본옵션을 추가하기 -->
+                <div class="option">
+                    <vscode-text-field id="EdgeTPUInputPath" startIcon="true" size="50" placeholder="">
+                        Input Path
+                        <span id="EdgeTPUInputPathSearch" slot="end" class="codicon codicon-search" style="cursor: pointer"></span>
+                    </vscode-text-field>
+                </div>
+                <div class="option">
+                    <vscode-text-field id="EdgeTPUOutputPath" startIcon="true" size="50" placeholder="" disabled="true">
+                        Output Path
+                        <span id="EdgeTPUOutputPathSearch" slot="end" class="codicon codicon-search" style="cursor: pointer"></span>
+                    </vscode-text-field>
+                </div>
+            </div>
+            <div class="advanced" id="optionImportEdgeTPUAdvanced">
+                <div class="title">
+                    Advanced Options
+                </div>
+                <!-- 여기에 EdgeTPU Compile에 필요한 기본옵션을 추가하기 -->
+                <div class="option">
+                    <vscode-checkbox id="EdgeTPUHelp">
+                        Help
+                    </vscode-checkbox>
+                    <span class="codicon codicon-question" style="cursor: pointer">
+                        <span class="help">                    
+                            Print the command line help and exit.
+                        </span>
+                    </span> 
+                </div>
+                <div class="option">
+                    <vscode-text-field id="EdgeTPUIntermediateTensorsInputArrays" startIcon="true" size="50" placeholder="semi-colon separated input names">
+                        Intermediate_tensors
+                    </vscode-text-field> 
+                </div>
+                <div class="option">
+                    <vscode-checkbox id="EdgeTPUShowOperations">
+                        Show Operations (Optional)
+                    </vscode-checkbox>  
+                    <span class="codicon codicon-question" style="cursor: pointer">
+                        <span class="help">
+                            Print the log showing operations that mapped to the Edge TPU.
+                        </span>
+                    </span>
+                </div>               
+                <div class="option">
+                    <div>
+                        Min Runtime Version (Optional)
+                        <span class="codicon codicon-question" style="cursor: pointer">
+                            <span class="help">
+                                Specify the lowest Edge TPU runtime version you want the model to be compatible with. <br />
+                                Version Information
+                                <table class="version-information">
+                                    <thead>
+                                        <tr>
+                                            <th> Compiler version </th>
+                                            <th> Runtime version </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>16.0</td>
+                                            <td>14</td>
+                                        </tr>
+                                        <tr>
+                                            <td>15.0</td>
+                                            <td>13</td>
+                                        </tr>
+                                        <tr>
+                                            <td>14.1</td>
+                                            <td>13</td>
+                                        </tr>
+                                        <tr>
+                                            <td>2.1.302470888</td>
+                                            <td>13</td>
+                                        </tr>
+                                        <tr>
+                                            <td>2.0.291256449</td>
+                                            <td>13</td>
+                                        </tr>
+                                        <tr>
+                                            <td>2.0.267685300</td>
+                                            <td>12</td>
+                                        </tr>
+                                        <tr>
+                                            <td>1.0</td>
+                                            <td>10</td>
+                                        </tr>
+                                    </tbody>
+                                </table>    
+                            </span>
+                        </span>
+                    </div>
+                    <vscode-dropdown id="EdgeTPUMinRuntimeVersion">   
+                    </vscode-dropdown>
+                </div>
+                <div class="option">
+                    <vscode-checkbox id="EdgeTPUSearchDelegate">
+                        Search Delegate
+                    </vscode-checkbox>
+                    <span class="codicon codicon-question" style="cursor: pointer">
+                        <span class="help">
+                            Enable repeated search for a new compilation stopping point earlier in the graph, to avoid rare compiler failures when it encounters an unsupported operation.
+                        </span>
+                    </span>
                 </div>
             </div>
         </div>

--- a/media/CfgEditor/displaycfg.js
+++ b/media/CfgEditor/displaycfg.js
@@ -41,6 +41,9 @@ export function displayCfgToEditor(cfg) {
     } else if (onecc["one-import-bcq"] === "True") {
       document.getElementById("checkboxImport").checked = true;
       // TODO Enable when one-import-bcq is supported
+    } else if (onecc["one-import-edgetpu"] === "True") {
+      document.getElementById("checkboxImport").checked = true;
+      document.getElementById("importInputModelType").value = "edgetpu";
     } else {
       document.getElementById("checkboxImport").checked = false;
     }
@@ -136,8 +139,34 @@ export function displayCfgToEditor(cfg) {
   document.getElementById("ONNXUnrollLSTM").checked = cfgBoolean(
     oneImportONNX?.["unroll_lstm"]
   );
-
+  
   // TODO Support one-import-bcq
+
+  // TODO Support import EdgeTPU
+  const oneImportEdgeTPU = cfg["one-import-edgetpu"];
+  document.getElementById("EdgeTPUInputPath").value = cfgString(
+    oneImportEdgeTPU?.["input_path"]
+  );
+  document.getElementById("EdgeTPUOutputPath").value = cfgString(
+    oneImportEdgeTPU?.["output_path"]
+  );  
+  document.getElementById("EdgeTPUHelp").checked = cfgBoolean(
+    oneImportEdgeTPU?.["help"]
+  );
+  document.getElementById("EdgeTPUIntermediateTensorsInputArrays").value = cfgString(
+    oneImportEdgeTPU?.["intermediate_tensors"]
+  );
+  document.getElementById("EdgeTPUShowOperations").checked = cfgBoolean(
+    oneImportEdgeTPU?.["show_operations"]
+  );
+  document.getElementById("EdgeTPUMinRuntimeVersion").value = cfgString(
+    oneImportEdgeTPU?.["min_runtime_version"],
+    "14"
+  );
+  document.getElementById("EdgeTPUSearchDelegate").checked = cfgBoolean(
+    oneImportEdgeTPU?.["search_delegate"]
+  );
+
 
   updateImportUI();
 

--- a/media/CfgEditor/index.js
+++ b/media/CfgEditor/index.js
@@ -25,6 +25,7 @@ import {
   updateImportPB,
   updateImportSAVED,
   updateImportTFLITE,
+  updateImportEdgeTPU,
   updateOptimize,
   updateProfile,
   updateQuantizeActionType,
@@ -78,6 +79,9 @@ function main() {
             break;
           case "ImportONNX":
             updateImportONNX();
+            break;
+          case "ImportEdgeTPU":
+            updateImportEdgeTPU();
             break;
           case "Optimize":
             updateOptimize();
@@ -222,6 +226,7 @@ function registerImportOptions() {
   registerKERASOptions();
   registerTFLITEOptions();
   registerONNXOptions();
+  registerEdgeTPUOptions();
 }
 
 function registerPBOptions() {
@@ -328,6 +333,50 @@ function registerONNXOptions() {
   onnxUnrollLSTM.addEventListener("click", function () {
     updateImportONNX();
     applyUpdates();
+  });
+}
+
+function registerEdgeTPUOptions() {
+  const edgeTPUInputPath = document.getElementById("EdgeTPUInputPath");
+  const edgeTPUHelp = document.getElementById("EdgeTPUHelp");
+  const edgeTPUIntermediateTensors = document.getElementById("EdgeTPUIntermediateTensorsInputArrays");
+  const edgeTPUShowOperations = document.getElementById(
+    "EdgeTPUShowOperations"
+  );
+  const edgeTPUMinRuntimeVersion = document.getElementById(
+    "EdgeTPUMinRuntimeVersion"
+  );  
+  const edgeTPUSearchDelegate = document.getElementById(
+    "EdgeTPUSearchDelegate"
+  );
+  
+  edgeTPUInputPath.addEventListener("input", function () {
+    updateImportEdgeTPU();
+    applyUpdates();
+  });
+  edgeTPUHelp.addEventListener("click", function () {
+    updateImportEdgeTPU();
+    applyUpdates();
+  });
+  edgeTPUIntermediateTensors.addEventListener("input",function(){
+    updateImportEdgeTPU();
+    applyUpdates();
+  });
+  edgeTPUShowOperations.addEventListener("click", function () {
+    updateImportEdgeTPU();
+    applyUpdates();
+  });
+  edgeTPUMinRuntimeVersion.addEventListener("input", function () {
+    updateImportEdgeTPU();
+    applyUpdates();
+  });
+  edgeTPUSearchDelegate.addEventListener("click", function () {
+    updateImportEdgeTPU();
+    applyUpdates();
+  });
+  edgeTPUSearchDelegate.addEventListener("click", function () {
+    updateImportEdgeTPU();
+    applyUpdates();   
   });
 }
 
@@ -753,6 +802,18 @@ function registerCodiconEvents() {
         oldPath: document.getElementById("CopyQuantOutputPath").value,
         postStep: "QuantizeCopy",
         postElemID: "CopyQuantOutputPath",
+      });
+    });
+  document
+    .getElementById("EdgeTPUInputPathSearch")
+    .addEventListener("click", function () {
+      postMessageToVsCode({
+        type: "getPathByDialog",
+        isFolder: false,
+        ext: ["tflite"],
+        oldPath: document.getElementById("EdgeTPUInputPath").value,
+        postStep: "ImportEdgeTPU",
+        postElemID: "EdgeTPUInputPath",
       });
     });
 }

--- a/media/CfgEditor/updateContent.js
+++ b/media/CfgEditor/updateContent.js
@@ -65,6 +65,12 @@ export function updateSteps() {
     param: "one-import-onnx",
     value: "False",
   });
+  postMessageToVsCode({
+    type: "setParam",
+    section: "onecc",
+    param: "one-import-edgetpu",
+    value: "False",
+  });
   if (document.getElementById("checkboxImport").checked) {
     switch (document.getElementById("importInputModelType").value) {
       case "pb":
@@ -90,6 +96,14 @@ export function updateSteps() {
           type: "setParam",
           section: "onecc",
           param: "one-import-onnx",
+          value: "True",
+        });
+        break;
+      case "edgetpu":
+        postMessageToVsCode({
+          type: "setParam",
+          section: "onecc",
+          param: "one-import-edgetpu",
           value: "True",
         });
         break;
@@ -148,6 +162,9 @@ export function updateImportInputModelType() {
       break;
     case "onnx":
       updateImportONNX();
+      break;
+    case "edgetpu":
+      updateImportEdgeTPU();
       break;
     default:
       break;
@@ -270,6 +287,66 @@ export function updateImportONNX() {
   postMessageToVsCode({
     type: "setSection",
     section: "one-import-onnx",
+    param: content,
+  });
+}
+
+function addPostfixToFileName(filePath = "", postfix = "") {
+  if (filePath.trim() === "") {
+    return "";
+  }
+  const parts = filePath.split(".");
+  let newFilePath = "";
+  if (parts.length < 2) {
+    newFilePath = `${filePath}${postfix}`;
+  } else {
+    const fileName = parts.slice(0, -1).join(".");
+    const fileExtension = parts[parts.length - 1];
+    const newFileName = `${fileName}${postfix}`;
+    newFilePath = `${newFileName}.${fileExtension}`;
+  }
+
+  return newFilePath;
+}
+
+export function updateImportEdgeTPU() {
+  let content = "";
+  content += iniKeyValueString(
+    "input_path",
+    document.getElementById("EdgeTPUInputPath").value
+  );
+  content += iniKeyValueString(
+    "output_path",
+    addPostfixToFileName(
+      document.getElementById("EdgeTPUInputPath").value,
+      "_edgetpu"
+    )
+  );
+  content += iniKeyValueString(
+    "help",
+    document.getElementById("EdgeTPUHelp").checked
+  );
+  content += iniKeyValueString(
+    "intermediate_tensors",
+    document.getElementById("EdgeTPUIntermediateTensorsInputArrays").value,
+  );
+  content += iniKeyValueString(
+    "show_operations",
+    document.getElementById("EdgeTPUShowOperations").checked
+  );
+  content += iniKeyValueString(
+    "min_runtime_version",
+    document.getElementById("EdgeTPUMinRuntimeVersion").value,    
+    "14"
+  );
+  content += iniKeyValueString(
+    "search_delegate",
+    document.getElementById("EdgeTPUSearchDelegate").checked
+  );
+
+  postMessageToVsCode({
+    type: "setSection",
+    section: "one-import-edgetpu",
     param: content,
   });
 }

--- a/media/CfgEditor/updateUI.js
+++ b/media/CfgEditor/updateUI.js
@@ -25,7 +25,16 @@ export function updateImportUI() {
   const onnxAdvancedOptions = document.getElementById(
     "optionImportONNXAdvanced"
   );
+  const edgeTPUBasicOptions = document.getElementById(
+    "optionImportEdgeTPUBasic"
+  );
+  const edgeTPUAdvancedOptions = document.getElementById(
+    "optionImportEdgeTPUAdvanced"
+  );
+  const edgeTPUMinRuntimeVersion = document.getElementById("EdgeTPUMinRuntimeVersion");
 
+  const versionList = [10, 11, 12, 13, 14];
+  
   pbBasicOptions.style.display = "none";
   pbAdvancedOptions.style.display = "none";
   savedBasicOptions.style.display = "none";
@@ -33,6 +42,8 @@ export function updateImportUI() {
   tfliteBasicOptions.style.display = "none";
   onnxBasicOptions.style.display = "none";
   onnxAdvancedOptions.style.display = "none";
+  edgeTPUBasicOptions.style.display = "none";
+  edgeTPUAdvancedOptions.style.display = "none";
 
   switch (modelType.value) {
     case "pb":
@@ -51,6 +62,16 @@ export function updateImportUI() {
     case "onnx":
       onnxBasicOptions.style.display = "block";
       onnxAdvancedOptions.style.display = "block";
+      break;
+    case "edgetpu":
+      if(edgeTPUMinRuntimeVersion.childElementCount !== versionList.length){
+        versionList.forEach(version => {
+          var option = new Option(version); 
+          edgeTPUMinRuntimeVersion.append(option);
+        });
+      }
+      edgeTPUBasicOptions.style.display = "block";
+      edgeTPUAdvancedOptions.style.display = "block";
       break;
     default:
       break;

--- a/src/CfgEditor/CfgData.ts
+++ b/src/CfgEditor/CfgData.ts
@@ -22,6 +22,7 @@ const sections = [
   "one-import-tflite",
   "one-import-bcq",
   "one-import-onnx",
+  "one-import-edgetpu",
   "one-optimize",
   "one-quantize",
   "one-codegen",

--- a/src/OneExplorer/ConfigObject.ts
+++ b/src/OneExplorer/ConfigObject.ts
@@ -26,16 +26,34 @@ import { Logger } from "../Utils/Logger";
 import { Artifact, Locator, LocatorRunner } from "./ArtifactLocator";
 
 type Cfg = {
+  "onecc":CfgOnecc;
   "one-import-tflite": CfgOneImportTflite;
   "one-import-onnx": CfgOneImportOnnx;
   "one-import-tf": CfgOneImportTf;
+  "one-import-edgetpu": CfgOneImportEdgeTPU;
 };
 type CfgKeys = keyof Cfg;
 
 // TODO Update
+type CfgOnecc = {
+  "one-import-tflite":string;
+  "one-import-tf":string;
+  "one-import-bcq":string;
+  "one-import-onnx":string;
+  "one-import-edgetpu":string;
+  "one-optimize":string;
+  "one-quantize":string;
+  "one-codegen":string;
+  "one-profile":string;
+}
 type CfgOneImportTflite = any;
 type CfgOneImportOnnx = any;
 type CfgOneImportTf = any;
+type CfgOneImportEdgeTPU = {
+  "input_path":string;
+  "output_path":string;
+  "help":string;
+}
 
 /**
  * @brief A helper class to get parsed artifacts (baseModels, products)

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -237,6 +237,16 @@ class DirectoryNode extends Node {
   }
 
   /**
+   * 
+   * @param fpath Target fpath to determine
+   * @returns 
+   */
+  private isCompiledWithEdgeTPUCompiler(fpath:string): boolean{
+    const result = OneStorage.isCompiledWithEdgeTPUCompiler(fpath);  
+    return result;
+  }
+
+  /**
    * Build a sub-tree under the node
    *
    * directory          <- this
@@ -262,7 +272,7 @@ class DirectoryNode extends Node {
       } else if (
         fstat.isFile() &&
         (fname.endsWith(".pb") ||
-          fname.endsWith(".tflite") ||
+          (fname.endsWith(".tflite")&&!this.isCompiledWithEdgeTPUCompiler(fpath)) ||
           fname.endsWith(".onnx"))
       ) {
         const baseModelNode = NodeFactory.create(


### PR DESCRIPTION
Related issue : #1622 
# Before we start...

we designed the `.cfg` file as shown in the picture below.
If the "one-import-edgetpu" value in the "onec" section is true, it means that you want to compile with the edge tpu compiler.
"output_path" in the "one-import-edgetpu" section means the location of the compiled product.
![image](https://github.com/Samsung/ONE-vscode/assets/43038815/8bfa513f-f4fb-46ae-990a-c5376cca1bc2)
and this method does not depend on "flatbuffer".

# How?

This method uses the "one-import-edgetpu" value in the "onecc" section and the "output_path" value in the "one-import-edgetpu" section to determine whether a file was compiled with the Edge TPU compiler.

1. Before creating the TreeView component, we first utilize the getCfgList() function from OneStorage to fetch a list of `cfg` files.
2.  Following this, we collect and save the output path generated by the EdgeTPU compiler into a variable. [code](https://github.com/SSDC-onE-FiVE/ONE-vscode/blob/7a65fdf345f911dae279382bd52611f22c83f8d3/src/OneExplorer/OneStorage.ts#L284C1-L301C4)
3.  Then, within the _buildChildren() code, we implement a conditional check to determine if the file is a `.tflite` file representing the `baseModel`. [code](https://github.com/SSDC-onE-FiVE/ONE-vscode/blob/7a65fdf345f911dae279382bd52611f22c83f8d3/src/OneExplorer/OneExplorer.ts#L257)
4. In this check, we verify whether the model exists within the previously collected variables. [code](https://github.com/SSDC-onE-FiVE/ONE-vscode/blob/7a65fdf345f911dae279382bd52611f22c83f8d3/src/OneExplorer/OneExplorer.ts#L244)
5. If we find the model in the collection, we've made the decision not to categorize it as a 'baseModel' because it originates from the EdgeTPU Compiler.

# Advantage
- Simple
- Allows custom output_path of edgetpu-compiler's product

#  Problem
- It depends on the output_path in the `.cfg` file. so if it change, explorer can't find the products

# Finally
This is not the perfect way to solve this problem. we keep thinking about it, and as a result, we found a way to use "flatbuffer". However, due to performance time problems, optimization of "flat buffers", or  other methods, must be devised.

