### PR TITLE
[API] Clarify APIs

### DIFF
--- a/src/Backend/API.ts
+++ b/src/Backend/API.ts
@@ -20,7 +20,6 @@ import { Backend } from "./Backend";
 import { gToolchainEnvMap, ToolchainEnv } from "../Toolchain/ToolchainEnv";
 import { Logger } from "../Utils/Logger";
 import { Executor } from "./Executor";
-import { OneToolchain } from "./One/OneToolchain";
 
 /**
  * Interface of backend map
@@ -35,47 +34,53 @@ let globalBackendMap: BackendMap = {};
 // List of Executor extensions registered
 let globalExecutorArray: Executor[] = [];
 
-function backendRegistrationApi() {
-  const logTag = "backendRegistrationApi";
-  let registrationAPI = {
-    registerBackend(backend: Backend) {
-      const backendName = backend.name();
-      assert(backendName.length > 0);
-      globalBackendMap[backendName] = backend;
-      const compiler = backend.compiler();
-      if (compiler) {
-        gToolchainEnvMap[backend.name()] = new ToolchainEnv(compiler);
-      }
-      const executor = backend.executor();
-      if (executor) {
-        globalExecutorArray.push(executor);
-      }
-      Logger.info(
-        logTag,
-        "Backend",
-        backendName,
-        "was registered into ONE-vscode."
-      );
-      // NOTE: This might not 100% guaratee the activating extension has been done.
-      //   - link: https://github.com/Samsung/ONE-vscode/pull/1101#issuecomment-1195099002
-      // TODO: Consider better way to refresh toolchainView after backend's registration.
-      vscode.commands.executeCommand("one.toolchain.refresh");
-      vscode.commands.executeCommand("one.device.refresh");
-    },
-    registerExecutor(executor: Executor) {
-      globalExecutorArray.push(executor);
-      Logger.info(
-        logTag,
-        "Executor",
-        executor.name(),
-        "was registered into ONE-vscode."
-      );
-    },
-  };
+const logTag = "API";
 
-  registrationAPI.registerBackend(new OneToolchain());
+const registerBackend = (backend: Backend) => {
+  const backendName = backend.name();
+  assert(backendName.length > 0);
+  globalBackendMap[backendName] = backend;
+  const compiler = backend.compiler();
+  if (compiler) {
+    gToolchainEnvMap[backend.name()] = new ToolchainEnv(compiler);
+  }
+  const executor = backend.executor();
+  if (executor) {
+    globalExecutorArray.push(executor);
+  }
 
-  return registrationAPI;
-}
+  Logger.info(
+    logTag,
+    "Backend",
+    backendName,
+    "was registered into ONE-vscode."
+  );
 
-export { globalBackendMap, globalExecutorArray, backendRegistrationApi };
+  // NOTE: This might not 100% guaratee the activating extension has been done.
+  //   - link: https://github.com/Samsung/ONE-vscode/pull/1101#issuecomment-1195099002
+  // TODO: Consider better way to refresh toolchainView after backend's registration.
+  vscode.commands.executeCommand("one.toolchain.refresh");
+  vscode.commands.executeCommand("one.device.refresh");
+};
+
+const registerExecutor = (executor: Executor) => {
+  globalExecutorArray.push(executor);
+  Logger.info(
+    "API",
+    "Executor",
+    executor.name(),
+    "was registered into ONE-vscode."
+  );
+
+  // NOTE: This might not 100% guaratee the activating extension has been done.
+  //   - link: https://github.com/Samsung/ONE-vscode/pull/1101#issuecomment-1195099002
+  // TODO: Consider better way to refresh toolchainView after backend's registration.
+  vscode.commands.executeCommand("one.device.refresh");
+};
+
+export const API = {
+  registerBackend,
+  registerExecutor,
+};
+
+export { globalBackendMap, globalExecutorArray };

--- a/src/Tests/Backend/Backend.test.ts
+++ b/src/Tests/Backend/Backend.test.ts
@@ -16,11 +16,7 @@
 
 import { assert } from "chai";
 
-import {
-  backendRegistrationApi,
-  globalBackendMap,
-  globalExecutorArray,
-} from "../../Backend/API";
+import { API, globalBackendMap, globalExecutorArray } from "../../Backend/API";
 import { Backend } from "../../Backend/Backend";
 import { Compiler, CompilerBase } from "../../Backend/Compiler";
 import { Executor, ExecutorBase } from "../../Backend/Executor";
@@ -59,9 +55,8 @@ class ExecutorMockup extends ExecutorBase {
 }
 
 suite("Backend", function () {
-  suite("backendRegistrationApi", function () {
+  suite("backendAPI", function () {
     test("registers a OneToolchain", function () {
-      backendRegistrationApi();
       let oneBackend = new OneToolchain();
       assert.strictEqual(Object.entries(globalBackendMap).length, 1);
       assert.strictEqual(globalExecutorArray.length, 0);
@@ -75,13 +70,11 @@ suite("Backend", function () {
       }
     });
     test("registers a backend", function () {
-      let registrationAPI = backendRegistrationApi();
-
       assert.strictEqual(Object.entries(globalBackendMap).length, 1);
       assert.strictEqual(globalExecutorArray.length, 0);
 
       let backend = new BackendMockup();
-      registrationAPI.registerBackend(backend);
+      API.registerBackend(backend);
 
       const entries = Object.entries(globalBackendMap);
       assert.strictEqual(entries.length, 2);
@@ -101,11 +94,9 @@ suite("Backend", function () {
       assert.deepStrictEqual(backend.executors(), globalExecutorArray);
     });
     test("registers a executor", function () {
-      let registrationAPI = backendRegistrationApi();
-
       assert.strictEqual(globalExecutorArray.length, 0);
       let executorMockup = new ExecutorMockup();
-      registrationAPI.registerExecutor(executorMockup);
+      API.registerExecutor(executorMockup);
 
       assert.strictEqual(globalExecutorArray.length, 1);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,8 @@
 
 import * as vscode from "vscode";
 
-import { backendRegistrationApi } from "./Backend/API";
+import { API } from "./Backend/API";
+import { OneToolchain } from "./Backend/One/OneToolchain";
 import { CfgEditorPanel } from "./CfgEditor/CfgEditorPanel";
 import { CircleEditorProvider } from "./CircleEditor/CircleEditorProvider";
 import { CircleViewerProvider } from "./CircleGraph/CircleViewer";
@@ -82,8 +83,10 @@ export function activate(context: vscode.ExtensionContext) {
   MPQEditorProvider.register(context);
   MPQSelectionPanel.register(context);
 
+  API.registerBackend(new OneToolchain());
+
   // returning backend registration function that will be called by backend extensions
-  return backendRegistrationApi();
+  return API;
 }
 
 /* istanbul ignore next */


### PR DESCRIPTION
This commit revisits API to split ONE-toolchain backend registration from the api itself. It aim to show the extension's api functions clearly.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>