### PR TITLE
[OneExplorer] Revisit ConfigObject

### DIFF
--- a/src/OneExplorer/ConfigObject.ts
+++ b/src/OneExplorer/ConfigObject.ts
@@ -112,12 +112,19 @@ export class ConfigObj {
     return found ? true : false;
   }
 
+  private init() {
+    this.obj = {
+      baseModels: ConfigObj.parseBaseModels(this.uri.fsPath, this.rawObj),
+      products: ConfigObj.parseProducts(this.uri.fsPath, this.rawObj),
+    };
+  }
+
   private constructor(uri: vscode.Uri, rawObj: Cfg) {
     this.uri = uri;
     this.rawObj = rawObj;
     this.obj = {
-      baseModels: ConfigObj.parseBaseModels(uri.fsPath, rawObj),
-      products: ConfigObj.parseProducts(uri.fsPath, rawObj),
+      baseModels: [],
+      products: [],
     };
   }
 
@@ -172,7 +179,10 @@ export class ConfigObj {
       return null;
     }
 
-    return new ConfigObj(uri, obj as Cfg);
+    const cfgObj = new ConfigObj(uri, obj as Cfg);
+    cfgObj.init();
+
+    return cfgObj;
   }
 
   /**


### PR DESCRIPTION
This commit removes logics from constructor.
Doing so many things in constructor is a bad practice because any unexpected error cannot be handled.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>