### PR TITLE
[ahub/sam] Exclude generated code

### DIFF
--- a/.ahub/sam/exclude.txt
+++ b/.ahub/sam/exclude.txt
@@ -1,3 +1,6 @@
 # External code
 /ONE-vscode/media/CircleGraph
 /ONE-vscode/media/CircleEditor
+
+# Generated code by Flatbuffers
+/ONE-vscode/src/CircleEditor/circle_schema_generated.ts


### PR DESCRIPTION
This will excludes circle_schema_generated.ts SAM report. 
It is generated by Flatbuffers.

ONE-vscode-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>