### PR TITLE
[JsonTracer] Deprecate JsonTracer

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,16 +100,6 @@
         "priority": "default"
       },
       {
-        "viewType": "one.editor.jsonTracer",
-        "displayName": "Json Tracer",
-        "selector": [
-          {
-            "filenamePattern": "*.timeline.json"
-          }
-        ],
-        "priority": "option"
-      },
-      {
         "viewType": "one.viewer.metadata",
         "displayName": "Metadata Viewer",
         "selector": [

--- a/src/OneExplorer/ConfigObject.ts
+++ b/src/OneExplorer/ConfigObject.ts
@@ -333,7 +333,7 @@ export class ConfigObj {
       artifactAttr: {
         ext: ".trace.json",
         icon: new vscode.ThemeIcon("graph"),
-        openViewType: "one.editor.jsonTracer",
+        openViewType: "default",
         canHide: true,
       },
       locator: new Locator((value: string) => {
@@ -347,7 +347,7 @@ export class ConfigObj {
       artifactAttr: {
         ext: ".json",
         icon: new vscode.ThemeIcon("graph"),
-        openViewType: "one.editor.jsonTracer",
+        openViewType: "default",
         canHide: true,
       },
       locator: new Locator(


### PR DESCRIPTION
This commit deprecates JsonTracer and shows trace files with default text viewer.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>