### PR TITLE
[Execute] Expand node entries at HostPC parent node

### DIFF
--- a/src/Execute/DeviceViewProvider.ts
+++ b/src/Execute/DeviceViewProvider.ts
@@ -137,7 +137,7 @@ export class DeviceViewProvider
         rtnList.push(
           new DeviceViewNode(
             device.name,
-            vscode.TreeItemCollapsibleState.Collapsed,
+            vscode.TreeItemCollapsibleState.Expanded,
             NodeType.device,
             element.managerName
           )


### PR DESCRIPTION
This commit expands node entries at HostPC parent node by default.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>