### PR TITLE
[OneExplorer] Activate keybindings with condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -301,12 +301,12 @@
       {
         "command": "one.explorer.deleteOnShortcut",
         "key": "delete",
-        "when": "view.OneExplorerView.visible && !explorerResourceReadonly && !inputFocus"
+        "when": "view.OneExplorerView.visible && !inputFocus"
       },
       {
         "command": "one.explorer.renameOnShortcut",
         "key": "F2",
-        "when": "view.OneExplorerView.visible && one.explorer:hasSelectedCfg && !explorerResourceReadonly && !inputFocus"
+        "when": "view.OneExplorerView.visible && one.explorer:hasSelectedCfg && !inputFocus"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -291,7 +291,7 @@
       {
         "command": "one.explorer.runSingleSelectedCfg",
         "key": "ctrl+f7",
-        "when": "OneExplorerView.active && one.explorer:hasSelectedCfg"
+        "when": "view.OneExplorerView.visible && one.explorer:hasSelectedCfg"
       },
       {
         "command": "one.cfgEditor.setDefaultValues",
@@ -301,12 +301,12 @@
       {
         "command": "one.explorer.deleteOnShortcut",
         "key": "delete",
-        "when": "OneExplorerView.active"
+        "when": "view.OneExplorerView.visible && !explorerResourceReadonly && !inputFocus"
       },
       {
         "command": "one.explorer.renameOnShortcut",
         "key": "F2",
-        "when": "OneExplorerView.active && one.explorer:hasSelectedCfg"
+        "when": "view.OneExplorerView.visible && one.explorer:hasSelectedCfg && !explorerResourceReadonly && !inputFocus"
       }
     ],
     "menus": {


### PR DESCRIPTION
This commit makes our keybindings activate only when ONE Explorer is visible and no input focus.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---


For #1652