### PR TITLE
[CircleEditor] Update Circle Schema

### DIFF
--- a/media/CircleEditor/external/circle-schema.js
+++ b/media/CircleEditor/external/circle-schema.js
@@ -13,7 +13,14 @@ $root.circle.TensorType = {
     INT16: 7,
     COMPLEX64: 8,
     INT8: 9,
-    FLOAT64: 10
+    FLOAT64: 10,
+    COMPLEX128: 11,
+    UINT64: 12,
+    RESOURCE: 13,
+    VARIANT: 14,
+    UINT32: 15,
+    UINT16: 16,
+    INT4: 17
 };
 
 $root.circle.CustomQuantization = class CustomQuantization {
@@ -184,6 +191,25 @@ $root.circle.SparsityParameters = class SparsityParameters {
     }
 };
 
+$root.circle.VariantSubType = class VariantSubType {
+
+    static decode(reader, position) {
+        const $ = new $root.circle.VariantSubType();
+        $.shape = reader.typedArray(position, 4, Int32Array);
+        $.type = reader.int8_(position, 6, 0);
+        $.has_rank = reader.bool_(position, 8, false);
+        return $;
+    }
+
+    static decodeText(reader, json) {
+        const $ = new $root.circle.VariantSubType();
+        $.shape = reader.typedArray(json.shape, Int32Array);
+        $.type = $root.circle.TensorType[json.type];
+        $.has_rank = reader.value(json.has_rank, false);
+        return $;
+    }
+};
+
 $root.circle.Tensor = class Tensor {
 
     static decode(reader, position) {
@@ -196,6 +222,8 @@ $root.circle.Tensor = class Tensor {
         $.is_variable = reader.bool_(position, 14, false);
         $.sparsity = reader.table(position, 16, $root.circle.SparsityParameters.decode);
         $.shape_signature = reader.typedArray(position, 18, Int32Array);
+        $.has_rank = reader.bool_(position, 20, false);
+        $.variant_tensors = reader.tableArray(position, 22, $root.circle.VariantSubType.decode);
         return $;
     }
 
@@ -209,11 +237,16 @@ $root.circle.Tensor = class Tensor {
         $.is_variable = reader.value(json.is_variable, false);
         $.sparsity = reader.object(json.sparsity, $root.circle.SparsityParameters.decodeText);
         $.shape_signature = reader.typedArray(json.shape_signature, Int32Array);
+        $.has_rank = reader.value(json.has_rank, false);
+        $.variant_tensors = reader.objectArray(json.variant_tensors, $root.circle.VariantSubType.decodeText);
         return $;
     }
 };
 
 $root.circle.BuiltinOperator = {
+    BCQ_GATHER: -4,
+    BCQ_FULLY_CONNECTED: -3,
+    INSTANCE_NORM: -2,
     ADD: 0,
     AVERAGE_POOL_2D: 1,
     CONCATENATION: 2,
@@ -341,9 +374,41 @@ $root.circle.BuiltinOperator = {
     DENSIFY: 124,
     SEGMENT_SUM: 125,
     BATCH_MATMUL: 126,
-    BCQ_GATHER: 252,
-    BCQ_FULLY_CONNECTED: 253,
-    INSTANCE_NORM: 254
+    PLACEHOLDER_FOR_GREATER_OP_CODES: 127,
+    CUMSUM: 128,
+    CALL_ONCE: 129,
+    BROADCAST_TO: 130,
+    RFFT2D: 131,
+    CONV_3D: 132,
+    IMAG: 133,
+    REAL: 134,
+    COMPLEX_ABS: 135,
+    HASHTABLE: 136,
+    HASHTABLE_FIND: 137,
+    HASHTABLE_IMPORT: 138,
+    HASHTABLE_SIZE: 139,
+    REDUCE_ALL: 140,
+    CONV_3D_TRANSPOSE: 141,
+    VAR_HANDLE: 142,
+    READ_VARIABLE: 143,
+    ASSIGN_VARIABLE: 144,
+    BROADCAST_ARGS: 145,
+    RANDOM_STANDARD_NORMAL: 146,
+    BUCKETIZE: 147,
+    RANDOM_UNIFORM: 148,
+    MULTINOMIAL: 149,
+    GELU: 150,
+    DYNAMIC_UPDATE_SLICE: 151,
+    RELU_0_TO_1: 152,
+    UNSORTED_SEGMENT_PROD: 153,
+    UNSORTED_SEGMENT_MAX: 154,
+    UNSORTED_SEGMENT_SUM: 155,
+    ATAN2: 156,
+    UNSORTED_SEGMENT_MIN: 157,
+    SIGN: 158,
+    BITCAST: 159,
+    BITWISE_XOR: 160,
+    RIGHT_SHIFT: 161
 };
 
 $root.circle.BuiltinOptions = class {
@@ -451,6 +516,31 @@ $root.circle.BuiltinOptions = class {
             case 99: return $root.circle.DensifyOptions.decode(reader, position);
             case 100: return $root.circle.SegmentSumOptions.decode(reader, position);
             case 101: return $root.circle.BatchMatMulOptions.decode(reader, position);
+            case 102: return $root.circle.CumsumOptions.decode(reader, position);
+            case 103: return $root.circle.CallOnceOptions.decode(reader, position);
+            case 104: return $root.circle.BroadcastToOptions.decode(reader, position);
+            case 105: return $root.circle.Rfft2dOptions.decode(reader, position);
+            case 106: return $root.circle.Conv3DOptions.decode(reader, position);
+            case 107: return $root.circle.HashtableOptions.decode(reader, position);
+            case 108: return $root.circle.HashtableFindOptions.decode(reader, position);
+            case 109: return $root.circle.HashtableImportOptions.decode(reader, position);
+            case 110: return $root.circle.HashtableSizeOptions.decode(reader, position);
+            case 111: return $root.circle.VarHandleOptions.decode(reader, position);
+            case 112: return $root.circle.ReadVariableOptions.decode(reader, position);
+            case 113: return $root.circle.AssignVariableOptions.decode(reader, position);
+            case 114: return $root.circle.RandomOptions.decode(reader, position);
+            case 115: return $root.circle.BucketizeOptions.decode(reader, position);
+            case 116: return $root.circle.GeluOptions.decode(reader, position);
+            case 117: return $root.circle.DynamicUpdateSliceOptions.decode(reader, position);
+            case 118: return $root.circle.UnsortedSegmentProdOptions.decode(reader, position);
+            case 119: return $root.circle.UnsortedSegmentMaxOptions.decode(reader, position);
+            case 120: return $root.circle.UnsortedSegmentMinOptions.decode(reader, position);
+            case 121: return $root.circle.UnsortedSegmentSumOptions.decode(reader, position);
+            case 122: return $root.circle.ATan2Options.decode(reader, position);
+            case 123: return $root.circle.SignOptions.decode(reader, position);
+            case 124: return $root.circle.BitcastOptions.decode(reader, position);
+            case 125: return $root.circle.BitwiseXorOptions.decode(reader, position);
+            case 126: return $root.circle.RightShiftOptions.decode(reader, position);
             case 252: return $root.circle.BCQGatherOptions.decode(reader, position);
             case 253: return $root.circle.BCQFullyConnectedOptions.decode(reader, position);
             case 254: return $root.circle.InstanceNormOptions.decode(reader, position);
@@ -561,6 +651,31 @@ $root.circle.BuiltinOptions = class {
             case 'DensifyOptions': return $root.circle.DensifyOptions.decodeText(reader, json);
             case 'SegmentSumOptions': return $root.circle.SegmentSumOptions.decodeText(reader, json);
             case 'BatchMatMulOptions': return $root.circle.BatchMatMulOptions.decodeText(reader, json);
+            case 'CumsumOptions': return $root.circle.CumsumOptions.decodeText(reader, json);
+            case 'CallOnceOptions': return $root.circle.CallOnceOptions.decodeText(reader, json);
+            case 'BroadcastToOptions': return $root.circle.BroadcastToOptions.decodeText(reader, json);
+            case 'Rfft2dOptions': return $root.circle.Rfft2dOptions.decodeText(reader, json);
+            case 'Conv3DOptions': return $root.circle.Conv3DOptions.decodeText(reader, json);
+            case 'HashtableOptions': return $root.circle.HashtableOptions.decodeText(reader, json);
+            case 'HashtableFindOptions': return $root.circle.HashtableFindOptions.decodeText(reader, json);
+            case 'HashtableImportOptions': return $root.circle.HashtableImportOptions.decodeText(reader, json);
+            case 'HashtableSizeOptions': return $root.circle.HashtableSizeOptions.decodeText(reader, json);
+            case 'VarHandleOptions': return $root.circle.VarHandleOptions.decodeText(reader, json);
+            case 'ReadVariableOptions': return $root.circle.ReadVariableOptions.decodeText(reader, json);
+            case 'AssignVariableOptions': return $root.circle.AssignVariableOptions.decodeText(reader, json);
+            case 'RandomOptions': return $root.circle.RandomOptions.decodeText(reader, json);
+            case 'BucketizeOptions': return $root.circle.BucketizeOptions.decodeText(reader, json);
+            case 'GeluOptions': return $root.circle.GeluOptions.decodeText(reader, json);
+            case 'DynamicUpdateSliceOptions': return $root.circle.DynamicUpdateSliceOptions.decodeText(reader, json);
+            case 'UnsortedSegmentProdOptions': return $root.circle.UnsortedSegmentProdOptions.decodeText(reader, json);
+            case 'UnsortedSegmentMaxOptions': return $root.circle.UnsortedSegmentMaxOptions.decodeText(reader, json);
+            case 'UnsortedSegmentMinOptions': return $root.circle.UnsortedSegmentMinOptions.decodeText(reader, json);
+            case 'UnsortedSegmentSumOptions': return $root.circle.UnsortedSegmentSumOptions.decodeText(reader, json);
+            case 'ATan2Options': return $root.circle.ATan2Options.decodeText(reader, json);
+            case 'SignOptions': return $root.circle.SignOptions.decodeText(reader, json);
+            case 'BitcastOptions': return $root.circle.BitcastOptions.decodeText(reader, json);
+            case 'BitwiseXorOptions': return $root.circle.BitwiseXorOptions.decodeText(reader, json);
+            case 'RightShiftOptions': return $root.circle.RightShiftOptions.decodeText(reader, json);
             case 'BCQGatherOptions': return $root.circle.BCQGatherOptions.decodeText(reader, json);
             case 'BCQFullyConnectedOptions': return $root.circle.BCQFullyConnectedOptions.decodeText(reader, json);
             case 'InstanceNormOptions': return $root.circle.InstanceNormOptions.decodeText(reader, json);
@@ -602,6 +717,35 @@ $root.circle.Conv2DOptions = class Conv2DOptions {
         $.stride_w = reader.value(json.stride_w, 0);
         $.stride_h = reader.value(json.stride_h, 0);
         $.fused_activation_function = $root.circle.ActivationFunctionType[json.fused_activation_function];
+        $.dilation_w_factor = reader.value(json.dilation_w_factor, 1);
+        $.dilation_h_factor = reader.value(json.dilation_h_factor, 1);
+        return $;
+    }
+};
+
+$root.circle.Conv3DOptions = class Conv3DOptions {
+
+    static decode(reader, position) {
+        const $ = new $root.circle.Conv3DOptions();
+        $.padding = reader.int8_(position, 4, 0);
+        $.stride_d = reader.int32_(position, 6, 0);
+        $.stride_w = reader.int32_(position, 8, 0);
+        $.stride_h = reader.int32_(position, 10, 0);
+        $.fused_activation_function = reader.int8_(position, 12, 0);
+        $.dilation_d_factor = reader.int32_(position, 14, 1);
+        $.dilation_w_factor = reader.int32_(position, 16, 1);
+        $.dilation_h_factor = reader.int32_(position, 18, 1);
+        return $;
+    }
+
+    static decodeText(reader, json) {
+        const $ = new $root.circle.Conv3DOptions();
+        $.padding = $root.circle.Padding[json.padding];
+        $.stride_d = reader.value(json.stride_d, 0);
+        $.stride_w = reader.value(json.stride_w, 0);
+        $.stride_h = reader.value(json.stride_h, 0);
+        $.fused_activation_function = $root.circle.ActivationFunctionType[json.fused_activation_function];
+        $.dilation_d_factor = reader.value(json.dilation_d_factor, 1);
         $.dilation_w_factor = reader.value(json.dilation_w_factor, 1);
         $.dilation_h_factor = reader.value(json.dilation_h_factor, 1);
         return $;
@@ -840,12 +984,14 @@ $root.circle.AddOptions = class AddOptions {
     static decode(reader, position) {
         const $ = new $root.circle.AddOptions();
         $.fused_activation_function = reader.int8_(position, 4, 0);
+        $.pot_scale_int16 = reader.bool_(position, 6, true);
         return $;
     }
 
     static decodeText(reader, json) {
         const $ = new $root.circle.AddOptions();
         $.fused_activation_function = $root.circle.ActivationFunctionType[json.fused_activation_function];
+        $.pot_scale_int16 = reader.value(json.pot_scale_int16, true);
         return $;
     }
 };
@@ -938,6 +1084,7 @@ $root.circle.UnidirectionalSequenceLSTMOptions = class UnidirectionalSequenceLST
         $.proj_clip = reader.float32_(position, 8, 0);
         $.time_major = reader.bool_(position, 10, false);
         $.asymmetric_quantize_inputs = reader.bool_(position, 12, false);
+        $.diagonal_recurrent_tensors = reader.bool_(position, 14, false);
         return $;
     }
 
@@ -948,6 +1095,7 @@ $root.circle.UnidirectionalSequenceLSTMOptions = class UnidirectionalSequenceLST
         $.proj_clip = reader.value(json.proj_clip, 0);
         $.time_major = reader.value(json.time_major, false);
         $.asymmetric_quantize_inputs = reader.value(json.asymmetric_quantize_inputs, false);
+        $.diagonal_recurrent_tensors = reader.value(json.diagonal_recurrent_tensors, false);
         return $;
     }
 };
@@ -1003,12 +1151,14 @@ $root.circle.ResizeNearestNeighborOptions = class ResizeNearestNeighborOptions {
     static decode(reader, position) {
         const $ = new $root.circle.ResizeNearestNeighborOptions();
         $.align_corners = reader.bool_(position, 4, false);
+        $.half_pixel_centers = reader.bool_(position, 6, false);
         return $;
     }
 
     static decodeText(reader, json) {
         const $ = new $root.circle.ResizeNearestNeighborOptions();
         $.align_corners = reader.value(json.align_corners, false);
+        $.half_pixel_centers = reader.value(json.half_pixel_centers, false);
         return $;
     }
 };
@@ -1149,12 +1299,14 @@ $root.circle.SubOptions = class SubOptions {
     static decode(reader, position) {
         const $ = new $root.circle.SubOptions();
         $.fused_activation_function = reader.int8_(position, 4, 0);
+        $.pot_scale_int16 = reader.bool_(position, 6, true);
         return $;
     }
 
     static decodeText(reader, json) {
         const $ = new $root.circle.SubOptions();
         $.fused_activation_function = $root.circle.ActivationFunctionType[json.fused_activation_function];
+        $.pot_scale_int16 = reader.value(json.pot_scale_int16, true);
         return $;
     }
 };
@@ -1213,12 +1365,14 @@ $root.circle.GatherOptions = class GatherOptions {
     static decode(reader, position) {
         const $ = new $root.circle.GatherOptions();
         $.axis = reader.int32_(position, 4, 0);
+        $.batch_dims = reader.int32_(position, 6, 0);
         return $;
     }
 
     static decodeText(reader, json) {
         const $ = new $root.circle.GatherOptions();
         $.axis = reader.value(json.axis, 0);
+        $.batch_dims = reader.value(json.batch_dims, 0);
         return $;
     }
 };
@@ -1542,6 +1696,7 @@ $root.circle.TransposeConvOptions = class TransposeConvOptions {
         $.padding = reader.int8_(position, 4, 0);
         $.stride_w = reader.int32_(position, 6, 0);
         $.stride_h = reader.int32_(position, 8, 0);
+        $.fused_activation_function = reader.int8_(position, 10, 0);
         return $;
     }
 
@@ -1550,6 +1705,7 @@ $root.circle.TransposeConvOptions = class TransposeConvOptions {
         $.padding = $root.circle.Padding[json.padding];
         $.stride_w = reader.value(json.stride_w, 0);
         $.stride_h = reader.value(json.stride_h, 0);
+        $.fused_activation_function = $root.circle.ActivationFunctionType[json.fused_activation_function];
         return $;
     }
 };
@@ -2050,6 +2206,21 @@ $root.circle.IfOptions = class IfOptions {
     }
 };
 
+$root.circle.CallOnceOptions = class CallOnceOptions {
+
+    static decode(reader, position) {
+        const $ = new $root.circle.CallOnceOptions();
+        $.init_subgraph_index = reader.int32_(position, 4, 0);
+        return $;
+    }
+
+    static decodeText(reader, json) {
+        const $ = new $root.circle.CallOnceOptions();
+        $.init_subgraph_index = reader.value(json.init_subgraph_index, 0);
+        return $;
+    }
+};
+
 $root.circle.WhileOptions = class WhileOptions {
 
     static decode(reader, position) {
@@ -2151,6 +2322,7 @@ $root.circle.BatchMatMulOptions = class BatchMatMulOptions {
         const $ = new $root.circle.BatchMatMulOptions();
         $.adjoint_lhs = reader.bool_(position, 4, false);
         $.adjoint_rhs = reader.bool_(position, 6, false);
+        $.asymmetric_quantize_inputs = reader.bool_(position, 8, false);
         return $;
     }
 
@@ -2158,6 +2330,328 @@ $root.circle.BatchMatMulOptions = class BatchMatMulOptions {
         const $ = new $root.circle.BatchMatMulOptions();
         $.adjoint_lhs = reader.value(json.adjoint_lhs, false);
         $.adjoint_rhs = reader.value(json.adjoint_rhs, false);
+        $.asymmetric_quantize_inputs = reader.value(json.asymmetric_quantize_inputs, false);
+        return $;
+    }
+};
+
+$root.circle.CumsumOptions = class CumsumOptions {
+
+    static decode(reader, position) {
+        const $ = new $root.circle.CumsumOptions();
+        $.exclusive = reader.bool_(position, 4, false);
+        $.reverse = reader.bool_(position, 6, false);
+        return $;
+    }
+
+    static decodeText(reader, json) {
+        const $ = new $root.circle.CumsumOptions();
+        $.exclusive = reader.value(json.exclusive, false);
+        $.reverse = reader.value(json.reverse, false);
+        return $;
+    }
+};
+
+$root.circle.BroadcastToOptions = class BroadcastToOptions {
+
+    static decode(/* reader, position */) {
+        const $ = new $root.circle.BroadcastToOptions();
+        return $;
+    }
+
+    static decodeText(/* reader, json */) {
+        const $ = new $root.circle.BroadcastToOptions();
+        return $;
+    }
+};
+
+$root.circle.Rfft2dOptions = class Rfft2dOptions {
+
+    static decode(/* reader, position */) {
+        const $ = new $root.circle.Rfft2dOptions();
+        return $;
+    }
+
+    static decodeText(/* reader, json */) {
+        const $ = new $root.circle.Rfft2dOptions();
+        return $;
+    }
+};
+
+$root.circle.HashtableOptions = class HashtableOptions {
+
+    static decode(reader, position) {
+        const $ = new $root.circle.HashtableOptions();
+        $.table_id = reader.int32_(position, 4, 0);
+        $.key_dtype = reader.int8_(position, 6, 0);
+        $.value_dtype = reader.int8_(position, 8, 0);
+        return $;
+    }
+
+    static decodeText(reader, json) {
+        const $ = new $root.circle.HashtableOptions();
+        $.table_id = reader.value(json.table_id, 0);
+        $.key_dtype = $root.circle.TensorType[json.key_dtype];
+        $.value_dtype = $root.circle.TensorType[json.value_dtype];
+        return $;
+    }
+};
+
+$root.circle.HashtableFindOptions = class HashtableFindOptions {
+
+    static decode(/* reader, position */) {
+        const $ = new $root.circle.HashtableFindOptions();
+        return $;
+    }
+
+    static decodeText(/* reader, json */) {
+        const $ = new $root.circle.HashtableFindOptions();
+        return $;
+    }
+};
+
+$root.circle.HashtableImportOptions = class HashtableImportOptions {
+
+    static decode(/* reader, position */) {
+        const $ = new $root.circle.HashtableImportOptions();
+        return $;
+    }
+
+    static decodeText(/* reader, json */) {
+        const $ = new $root.circle.HashtableImportOptions();
+        return $;
+    }
+};
+
+$root.circle.HashtableSizeOptions = class HashtableSizeOptions {
+
+    static decode(/* reader, position */) {
+        const $ = new $root.circle.HashtableSizeOptions();
+        return $;
+    }
+
+    static decodeText(/* reader, json */) {
+        const $ = new $root.circle.HashtableSizeOptions();
+        return $;
+    }
+};
+
+$root.circle.VarHandleOptions = class VarHandleOptions {
+
+    static decode(reader, position) {
+        const $ = new $root.circle.VarHandleOptions();
+        $.container = reader.string_(position, 4, null);
+        $.shared_name = reader.string_(position, 6, null);
+        return $;
+    }
+
+    static decodeText(reader, json) {
+        const $ = new $root.circle.VarHandleOptions();
+        $.container = reader.value(json.container, null);
+        $.shared_name = reader.value(json.shared_name, null);
+        return $;
+    }
+};
+
+$root.circle.ReadVariableOptions = class ReadVariableOptions {
+
+    static decode(/* reader, position */) {
+        const $ = new $root.circle.ReadVariableOptions();
+        return $;
+    }
+
+    static decodeText(/* reader, json */) {
+        const $ = new $root.circle.ReadVariableOptions();
+        return $;
+    }
+};
+
+$root.circle.AssignVariableOptions = class AssignVariableOptions {
+
+    static decode(/* reader, position */) {
+        const $ = new $root.circle.AssignVariableOptions();
+        return $;
+    }
+
+    static decodeText(/* reader, json */) {
+        const $ = new $root.circle.AssignVariableOptions();
+        return $;
+    }
+};
+
+$root.circle.RandomOptions = class RandomOptions {
+
+    static decode(reader, position) {
+        const $ = new $root.circle.RandomOptions();
+        $.seed = reader.int64_(position, 4, 0);
+        $.seed2 = reader.int64_(position, 6, 0);
+        return $;
+    }
+
+    static decodeText(reader, json) {
+        const $ = new $root.circle.RandomOptions();
+        $.seed = reader.value(json.seed, 0);
+        $.seed2 = reader.value(json.seed2, 0);
+        return $;
+    }
+};
+
+$root.circle.BucketizeOptions = class BucketizeOptions {
+
+    static decode(reader, position) {
+        const $ = new $root.circle.BucketizeOptions();
+        $.boundaries = reader.typedArray(position, 4, Float32Array);
+        return $;
+    }
+
+    static decodeText(reader, json) {
+        const $ = new $root.circle.BucketizeOptions();
+        $.boundaries = reader.typedArray(json.boundaries, Float32Array);
+        return $;
+    }
+};
+
+$root.circle.GeluOptions = class GeluOptions {
+
+    static decode(reader, position) {
+        const $ = new $root.circle.GeluOptions();
+        $.approximate = reader.bool_(position, 4, false);
+        return $;
+    }
+
+    static decodeText(reader, json) {
+        const $ = new $root.circle.GeluOptions();
+        $.approximate = reader.value(json.approximate, false);
+        return $;
+    }
+};
+
+$root.circle.DynamicUpdateSliceOptions = class DynamicUpdateSliceOptions {
+
+    static decode(/* reader, position */) {
+        const $ = new $root.circle.DynamicUpdateSliceOptions();
+        return $;
+    }
+
+    static decodeText(/* reader, json */) {
+        const $ = new $root.circle.DynamicUpdateSliceOptions();
+        return $;
+    }
+};
+
+$root.circle.UnsortedSegmentProdOptions = class UnsortedSegmentProdOptions {
+
+    static decode(/* reader, position */) {
+        const $ = new $root.circle.UnsortedSegmentProdOptions();
+        return $;
+    }
+
+    static decodeText(/* reader, json */) {
+        const $ = new $root.circle.UnsortedSegmentProdOptions();
+        return $;
+    }
+};
+
+$root.circle.UnsortedSegmentMaxOptions = class UnsortedSegmentMaxOptions {
+
+    static decode(/* reader, position */) {
+        const $ = new $root.circle.UnsortedSegmentMaxOptions();
+        return $;
+    }
+
+    static decodeText(/* reader, json */) {
+        const $ = new $root.circle.UnsortedSegmentMaxOptions();
+        return $;
+    }
+};
+
+$root.circle.UnsortedSegmentSumOptions = class UnsortedSegmentSumOptions {
+
+    static decode(/* reader, position */) {
+        const $ = new $root.circle.UnsortedSegmentSumOptions();
+        return $;
+    }
+
+    static decodeText(/* reader, json */) {
+        const $ = new $root.circle.UnsortedSegmentSumOptions();
+        return $;
+    }
+};
+
+$root.circle.ATan2Options = class ATan2Options {
+
+    static decode(/* reader, position */) {
+        const $ = new $root.circle.ATan2Options();
+        return $;
+    }
+
+    static decodeText(/* reader, json */) {
+        const $ = new $root.circle.ATan2Options();
+        return $;
+    }
+};
+
+$root.circle.UnsortedSegmentMinOptions = class UnsortedSegmentMinOptions {
+
+    static decode(/* reader, position */) {
+        const $ = new $root.circle.UnsortedSegmentMinOptions();
+        return $;
+    }
+
+    static decodeText(/* reader, json */) {
+        const $ = new $root.circle.UnsortedSegmentMinOptions();
+        return $;
+    }
+};
+
+$root.circle.SignOptions = class SignOptions {
+
+    static decode(/* reader, position */) {
+        const $ = new $root.circle.SignOptions();
+        return $;
+    }
+
+    static decodeText(/* reader, json */) {
+        const $ = new $root.circle.SignOptions();
+        return $;
+    }
+};
+
+$root.circle.BitcastOptions = class BitcastOptions {
+
+    static decode(/* reader, position */) {
+        const $ = new $root.circle.BitcastOptions();
+        return $;
+    }
+
+    static decodeText(/* reader, json */) {
+        const $ = new $root.circle.BitcastOptions();
+        return $;
+    }
+};
+
+$root.circle.BitwiseXorOptions = class BitwiseXorOptions {
+
+    static decode(/* reader, position */) {
+        const $ = new $root.circle.BitwiseXorOptions();
+        return $;
+    }
+
+    static decodeText(/* reader, json */) {
+        const $ = new $root.circle.BitwiseXorOptions();
+        return $;
+    }
+};
+
+$root.circle.RightShiftOptions = class RightShiftOptions {
+
+    static decode(/* reader, position */) {
+        const $ = new $root.circle.RightShiftOptions();
+        return $;
+    }
+
+    static decodeText(/* reader, json */) {
+        const $ = new $root.circle.RightShiftOptions();
         return $;
     }
 };
@@ -2217,17 +2711,19 @@ $root.circle.OperatorCode = class OperatorCode {
 
     static decode(reader, position) {
         const $ = new $root.circle.OperatorCode();
-        $.builtin_code = reader.uint8_(position, 4, 0);
+        $.deprecated_builtin_code = reader.int8_(position, 4, 0);
         $.custom_code = reader.string_(position, 6, null);
         $.version = reader.int32_(position, 8, 1);
+        $.builtin_code = reader.int32_(position, 10, 0);
         return $;
     }
 
     static decodeText(reader, json) {
         const $ = new $root.circle.OperatorCode();
-        $.builtin_code = $root.circle.BuiltinOperator[json.builtin_code];
+        $.deprecated_builtin_code = reader.value(json.deprecated_builtin_code, 0);
         $.custom_code = reader.value(json.custom_code, null);
         $.version = reader.value(json.version, 1);
+        $.builtin_code = $root.circle.BuiltinOperator[json.builtin_code];
         return $;
     }
 };
@@ -2327,6 +2823,46 @@ $root.circle.Metadata = class Metadata {
     }
 };
 
+$root.circle.TensorMap = class TensorMap {
+
+    static decode(reader, position) {
+        const $ = new $root.circle.TensorMap();
+        $.name = reader.string_(position, 4, null);
+        $.tensor_index = reader.uint32_(position, 6, 0);
+        return $;
+    }
+
+    static decodeText(reader, json) {
+        const $ = new $root.circle.TensorMap();
+        $.name = reader.value(json.name, null);
+        $.tensor_index = reader.value(json.tensor_index, 0);
+        return $;
+    }
+};
+
+$root.circle.SignatureDef = class SignatureDef {
+
+    static decode(reader, position) {
+        const $ = new $root.circle.SignatureDef();
+        $.inputs = reader.tableArray(position, 4, $root.circle.TensorMap.decode);
+        $.outputs = reader.tableArray(position, 6, $root.circle.TensorMap.decode);
+        $.signature_key = reader.string_(position, 8, null);
+        $.deprecated_tag = reader.string_(position, 10, null);
+        $.subgraph_index = reader.uint32_(position, 12, 0);
+        return $;
+    }
+
+    static decodeText(reader, json) {
+        const $ = new $root.circle.SignatureDef();
+        $.inputs = reader.objectArray(json.inputs, $root.circle.TensorMap.decodeText);
+        $.outputs = reader.objectArray(json.outputs, $root.circle.TensorMap.decodeText);
+        $.signature_key = reader.value(json.signature_key, null);
+        $.deprecated_tag = reader.value(json.deprecated_tag, null);
+        $.subgraph_index = reader.value(json.subgraph_index, 0);
+        return $;
+    }
+};
+
 $root.circle.Model = class Model {
 
     static identifier(reader) {
@@ -2350,6 +2886,7 @@ $root.circle.Model = class Model {
         $.buffers = reader.tableArray(position, 12, $root.circle.Buffer.decode);
         $.metadata_buffer = reader.typedArray(position, 14, Int32Array);
         $.metadata = reader.tableArray(position, 16, $root.circle.Metadata.decode);
+        $.signature_defs = reader.tableArray(position, 18, $root.circle.SignatureDef.decode);
         return $;
     }
 
@@ -2362,6 +2899,7 @@ $root.circle.Model = class Model {
         $.buffers = reader.objectArray(json.buffers, $root.circle.Buffer.decodeText);
         $.metadata_buffer = reader.typedArray(json.metadata_buffer, Int32Array);
         $.metadata = reader.objectArray(json.metadata, $root.circle.Metadata.decodeText);
+        $.signature_defs = reader.objectArray(json.signature_defs, $root.circle.SignatureDef.decodeText);
         return $;
     }
 };

--- a/src/CircleEditor/circle_schema_generated.ts
+++ b/src/CircleEditor/circle_schema_generated.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 /*
  * This file is generated with
- *  https://github.com/Samsung/ONE/blob/8e41a5031dabc9b6d265cdf1cd8dd8bba598c614/res/CircleSchema/0.4/circle_schema.fbs
+ *  https://github.com/Samsung/ONE/blob/e09738db8a7f873005d26a21465dfabca12abf88/res/CircleSchema/0.6/circle_schema.fbs
  *  by flatbuffers v2.0.7
  */
 
@@ -40,6 +40,8 @@ export enum TensorType {
   RESOURCE = 13,
   VARIANT = 14,
   UINT32 = 15,
+  UINT16 = 16,
+  INT4 = 17,
 }
 
 export enum QuantizationDetails {
@@ -284,6 +286,21 @@ export enum BuiltinOperator {
   ASSIGN_VARIABLE = 144,
   BROADCAST_ARGS = 145,
   RANDOM_STANDARD_NORMAL = 146,
+  BUCKETIZE = 147,
+  RANDOM_UNIFORM = 148,
+  MULTINOMIAL = 149,
+  GELU = 150,
+  DYNAMIC_UPDATE_SLICE = 151,
+  RELU_0_TO_1 = 152,
+  UNSORTED_SEGMENT_PROD = 153,
+  UNSORTED_SEGMENT_MAX = 154,
+  UNSORTED_SEGMENT_SUM = 155,
+  ATAN2 = 156,
+  UNSORTED_SEGMENT_MIN = 157,
+  SIGN = 158,
+  BITCAST = 159,
+  BITWISE_XOR = 160,
+  RIGHT_SHIFT = 161,
 }
 
 export enum BuiltinOptions {
@@ -402,6 +419,18 @@ export enum BuiltinOptions {
   ReadVariableOptions = 112,
   AssignVariableOptions = 113,
   RandomOptions = 114,
+  BucketizeOptions = 115,
+  GeluOptions = 116,
+  DynamicUpdateSliceOptions = 117,
+  UnsortedSegmentProdOptions = 118,
+  UnsortedSegmentMaxOptions = 119,
+  UnsortedSegmentMinOptions = 120,
+  UnsortedSegmentSumOptions = 121,
+  ATan2Options = 122,
+  SignOptions = 123,
+  BitcastOptions = 124,
+  BitwiseXorOptions = 125,
+  RightShiftOptions = 126,
   BCQGatherOptions = 252,
   BCQFullyConnectedOptions = 253,
   InstanceNormOptions = 254,
@@ -411,6 +440,7 @@ export function unionToBuiltinOptions(
   type: BuiltinOptions,
   accessor: (
     obj:
+      | ATan2Options
       | AbsOptions
       | AddNOptions
       | AddOptions
@@ -423,7 +453,10 @@ export function unionToBuiltinOptions(
       | BatchToSpaceNDOptions
       | BidirectionalSequenceLSTMOptions
       | BidirectionalSequenceRNNOptions
+      | BitcastOptions
+      | BitwiseXorOptions
       | BroadcastToOptions
+      | BucketizeOptions
       | CallOnceOptions
       | CallOptions
       | CastOptions
@@ -438,6 +471,7 @@ export function unionToBuiltinOptions(
       | DepthwiseConv2DOptions
       | DequantizeOptions
       | DivOptions
+      | DynamicUpdateSliceOptions
       | EmbeddingLookupSparseOptions
       | EqualOptions
       | ExpOptions
@@ -449,6 +483,7 @@ export function unionToBuiltinOptions(
       | FullyConnectedOptions
       | GatherNdOptions
       | GatherOptions
+      | GeluOptions
       | GreaterEqualOptions
       | GreaterOptions
       | HardSwishOptions
@@ -497,6 +532,7 @@ export function unionToBuiltinOptions(
       | ReverseSequenceOptions
       | ReverseV2Options
       | Rfft2dOptions
+      | RightShiftOptions
       | SVDFOptions
       | ScatterNdOptions
       | SegmentSumOptions
@@ -504,6 +540,7 @@ export function unionToBuiltinOptions(
       | SelectV2Options
       | SequenceRNNOptions
       | ShapeOptions
+      | SignOptions
       | SkipGramOptions
       | SliceOptions
       | SoftmaxOptions
@@ -524,11 +561,16 @@ export function unionToBuiltinOptions(
       | UnidirectionalSequenceLSTMOptions
       | UniqueOptions
       | UnpackOptions
+      | UnsortedSegmentMaxOptions
+      | UnsortedSegmentMinOptions
+      | UnsortedSegmentProdOptions
+      | UnsortedSegmentSumOptions
       | VarHandleOptions
       | WhereOptions
       | WhileOptions
       | ZerosLikeOptions
   ) =>
+    | ATan2Options
     | AbsOptions
     | AddNOptions
     | AddOptions
@@ -541,7 +583,10 @@ export function unionToBuiltinOptions(
     | BatchToSpaceNDOptions
     | BidirectionalSequenceLSTMOptions
     | BidirectionalSequenceRNNOptions
+    | BitcastOptions
+    | BitwiseXorOptions
     | BroadcastToOptions
+    | BucketizeOptions
     | CallOnceOptions
     | CallOptions
     | CastOptions
@@ -556,6 +601,7 @@ export function unionToBuiltinOptions(
     | DepthwiseConv2DOptions
     | DequantizeOptions
     | DivOptions
+    | DynamicUpdateSliceOptions
     | EmbeddingLookupSparseOptions
     | EqualOptions
     | ExpOptions
@@ -567,6 +613,7 @@ export function unionToBuiltinOptions(
     | FullyConnectedOptions
     | GatherNdOptions
     | GatherOptions
+    | GeluOptions
     | GreaterEqualOptions
     | GreaterOptions
     | HardSwishOptions
@@ -615,6 +662,7 @@ export function unionToBuiltinOptions(
     | ReverseSequenceOptions
     | ReverseV2Options
     | Rfft2dOptions
+    | RightShiftOptions
     | SVDFOptions
     | ScatterNdOptions
     | SegmentSumOptions
@@ -622,6 +670,7 @@ export function unionToBuiltinOptions(
     | SelectV2Options
     | SequenceRNNOptions
     | ShapeOptions
+    | SignOptions
     | SkipGramOptions
     | SliceOptions
     | SoftmaxOptions
@@ -642,12 +691,17 @@ export function unionToBuiltinOptions(
     | UnidirectionalSequenceLSTMOptions
     | UniqueOptions
     | UnpackOptions
+    | UnsortedSegmentMaxOptions
+    | UnsortedSegmentMinOptions
+    | UnsortedSegmentProdOptions
+    | UnsortedSegmentSumOptions
     | VarHandleOptions
     | WhereOptions
     | WhileOptions
     | ZerosLikeOptions
     | null
 ):
+  | ATan2Options
   | AbsOptions
   | AddNOptions
   | AddOptions
@@ -660,7 +714,10 @@ export function unionToBuiltinOptions(
   | BatchToSpaceNDOptions
   | BidirectionalSequenceLSTMOptions
   | BidirectionalSequenceRNNOptions
+  | BitcastOptions
+  | BitwiseXorOptions
   | BroadcastToOptions
+  | BucketizeOptions
   | CallOnceOptions
   | CallOptions
   | CastOptions
@@ -675,6 +732,7 @@ export function unionToBuiltinOptions(
   | DepthwiseConv2DOptions
   | DequantizeOptions
   | DivOptions
+  | DynamicUpdateSliceOptions
   | EmbeddingLookupSparseOptions
   | EqualOptions
   | ExpOptions
@@ -686,6 +744,7 @@ export function unionToBuiltinOptions(
   | FullyConnectedOptions
   | GatherNdOptions
   | GatherOptions
+  | GeluOptions
   | GreaterEqualOptions
   | GreaterOptions
   | HardSwishOptions
@@ -734,6 +793,7 @@ export function unionToBuiltinOptions(
   | ReverseSequenceOptions
   | ReverseV2Options
   | Rfft2dOptions
+  | RightShiftOptions
   | SVDFOptions
   | ScatterNdOptions
   | SegmentSumOptions
@@ -741,6 +801,7 @@ export function unionToBuiltinOptions(
   | SelectV2Options
   | SequenceRNNOptions
   | ShapeOptions
+  | SignOptions
   | SkipGramOptions
   | SliceOptions
   | SoftmaxOptions
@@ -761,6 +822,10 @@ export function unionToBuiltinOptions(
   | UnidirectionalSequenceLSTMOptions
   | UniqueOptions
   | UnpackOptions
+  | UnsortedSegmentMaxOptions
+  | UnsortedSegmentMinOptions
+  | UnsortedSegmentProdOptions
+  | UnsortedSegmentSumOptions
   | VarHandleOptions
   | WhereOptions
   | WhileOptions
@@ -1017,6 +1082,40 @@ export function unionToBuiltinOptions(
       return accessor(new AssignVariableOptions())! as AssignVariableOptions;
     case "RandomOptions":
       return accessor(new RandomOptions())! as RandomOptions;
+    case "BucketizeOptions":
+      return accessor(new BucketizeOptions())! as BucketizeOptions;
+    case "GeluOptions":
+      return accessor(new GeluOptions())! as GeluOptions;
+    case "DynamicUpdateSliceOptions":
+      return accessor(
+        new DynamicUpdateSliceOptions()
+      )! as DynamicUpdateSliceOptions;
+    case "UnsortedSegmentProdOptions":
+      return accessor(
+        new UnsortedSegmentProdOptions()
+      )! as UnsortedSegmentProdOptions;
+    case "UnsortedSegmentMaxOptions":
+      return accessor(
+        new UnsortedSegmentMaxOptions()
+      )! as UnsortedSegmentMaxOptions;
+    case "UnsortedSegmentMinOptions":
+      return accessor(
+        new UnsortedSegmentMinOptions()
+      )! as UnsortedSegmentMinOptions;
+    case "UnsortedSegmentSumOptions":
+      return accessor(
+        new UnsortedSegmentSumOptions()
+      )! as UnsortedSegmentSumOptions;
+    case "ATan2Options":
+      return accessor(new ATan2Options())! as ATan2Options;
+    case "SignOptions":
+      return accessor(new SignOptions())! as SignOptions;
+    case "BitcastOptions":
+      return accessor(new BitcastOptions())! as BitcastOptions;
+    case "BitwiseXorOptions":
+      return accessor(new BitwiseXorOptions())! as BitwiseXorOptions;
+    case "RightShiftOptions":
+      return accessor(new RightShiftOptions())! as RightShiftOptions;
     case "BCQGatherOptions":
       return accessor(new BCQGatherOptions())! as BCQGatherOptions;
     case "BCQFullyConnectedOptions":
@@ -1035,6 +1134,7 @@ export function unionListToBuiltinOptions(
   accessor: (
     index: number,
     obj:
+      | ATan2Options
       | AbsOptions
       | AddNOptions
       | AddOptions
@@ -1047,7 +1147,10 @@ export function unionListToBuiltinOptions(
       | BatchToSpaceNDOptions
       | BidirectionalSequenceLSTMOptions
       | BidirectionalSequenceRNNOptions
+      | BitcastOptions
+      | BitwiseXorOptions
       | BroadcastToOptions
+      | BucketizeOptions
       | CallOnceOptions
       | CallOptions
       | CastOptions
@@ -1062,6 +1165,7 @@ export function unionListToBuiltinOptions(
       | DepthwiseConv2DOptions
       | DequantizeOptions
       | DivOptions
+      | DynamicUpdateSliceOptions
       | EmbeddingLookupSparseOptions
       | EqualOptions
       | ExpOptions
@@ -1073,6 +1177,7 @@ export function unionListToBuiltinOptions(
       | FullyConnectedOptions
       | GatherNdOptions
       | GatherOptions
+      | GeluOptions
       | GreaterEqualOptions
       | GreaterOptions
       | HardSwishOptions
@@ -1121,6 +1226,7 @@ export function unionListToBuiltinOptions(
       | ReverseSequenceOptions
       | ReverseV2Options
       | Rfft2dOptions
+      | RightShiftOptions
       | SVDFOptions
       | ScatterNdOptions
       | SegmentSumOptions
@@ -1128,6 +1234,7 @@ export function unionListToBuiltinOptions(
       | SelectV2Options
       | SequenceRNNOptions
       | ShapeOptions
+      | SignOptions
       | SkipGramOptions
       | SliceOptions
       | SoftmaxOptions
@@ -1148,11 +1255,16 @@ export function unionListToBuiltinOptions(
       | UnidirectionalSequenceLSTMOptions
       | UniqueOptions
       | UnpackOptions
+      | UnsortedSegmentMaxOptions
+      | UnsortedSegmentMinOptions
+      | UnsortedSegmentProdOptions
+      | UnsortedSegmentSumOptions
       | VarHandleOptions
       | WhereOptions
       | WhileOptions
       | ZerosLikeOptions
   ) =>
+    | ATan2Options
     | AbsOptions
     | AddNOptions
     | AddOptions
@@ -1165,7 +1277,10 @@ export function unionListToBuiltinOptions(
     | BatchToSpaceNDOptions
     | BidirectionalSequenceLSTMOptions
     | BidirectionalSequenceRNNOptions
+    | BitcastOptions
+    | BitwiseXorOptions
     | BroadcastToOptions
+    | BucketizeOptions
     | CallOnceOptions
     | CallOptions
     | CastOptions
@@ -1180,6 +1295,7 @@ export function unionListToBuiltinOptions(
     | DepthwiseConv2DOptions
     | DequantizeOptions
     | DivOptions
+    | DynamicUpdateSliceOptions
     | EmbeddingLookupSparseOptions
     | EqualOptions
     | ExpOptions
@@ -1191,6 +1307,7 @@ export function unionListToBuiltinOptions(
     | FullyConnectedOptions
     | GatherNdOptions
     | GatherOptions
+    | GeluOptions
     | GreaterEqualOptions
     | GreaterOptions
     | HardSwishOptions
@@ -1239,6 +1356,7 @@ export function unionListToBuiltinOptions(
     | ReverseSequenceOptions
     | ReverseV2Options
     | Rfft2dOptions
+    | RightShiftOptions
     | SVDFOptions
     | ScatterNdOptions
     | SegmentSumOptions
@@ -1246,6 +1364,7 @@ export function unionListToBuiltinOptions(
     | SelectV2Options
     | SequenceRNNOptions
     | ShapeOptions
+    | SignOptions
     | SkipGramOptions
     | SliceOptions
     | SoftmaxOptions
@@ -1266,6 +1385,10 @@ export function unionListToBuiltinOptions(
     | UnidirectionalSequenceLSTMOptions
     | UniqueOptions
     | UnpackOptions
+    | UnsortedSegmentMaxOptions
+    | UnsortedSegmentMinOptions
+    | UnsortedSegmentProdOptions
+    | UnsortedSegmentSumOptions
     | VarHandleOptions
     | WhereOptions
     | WhileOptions
@@ -1273,6 +1396,7 @@ export function unionListToBuiltinOptions(
     | null,
   index: number
 ):
+  | ATan2Options
   | AbsOptions
   | AddNOptions
   | AddOptions
@@ -1285,7 +1409,10 @@ export function unionListToBuiltinOptions(
   | BatchToSpaceNDOptions
   | BidirectionalSequenceLSTMOptions
   | BidirectionalSequenceRNNOptions
+  | BitcastOptions
+  | BitwiseXorOptions
   | BroadcastToOptions
+  | BucketizeOptions
   | CallOnceOptions
   | CallOptions
   | CastOptions
@@ -1300,6 +1427,7 @@ export function unionListToBuiltinOptions(
   | DepthwiseConv2DOptions
   | DequantizeOptions
   | DivOptions
+  | DynamicUpdateSliceOptions
   | EmbeddingLookupSparseOptions
   | EqualOptions
   | ExpOptions
@@ -1311,6 +1439,7 @@ export function unionListToBuiltinOptions(
   | FullyConnectedOptions
   | GatherNdOptions
   | GatherOptions
+  | GeluOptions
   | GreaterEqualOptions
   | GreaterOptions
   | HardSwishOptions
@@ -1359,6 +1488,7 @@ export function unionListToBuiltinOptions(
   | ReverseSequenceOptions
   | ReverseV2Options
   | Rfft2dOptions
+  | RightShiftOptions
   | SVDFOptions
   | ScatterNdOptions
   | SegmentSumOptions
@@ -1366,6 +1496,7 @@ export function unionListToBuiltinOptions(
   | SelectV2Options
   | SequenceRNNOptions
   | ShapeOptions
+  | SignOptions
   | SkipGramOptions
   | SliceOptions
   | SoftmaxOptions
@@ -1386,6 +1517,10 @@ export function unionListToBuiltinOptions(
   | UnidirectionalSequenceLSTMOptions
   | UniqueOptions
   | UnpackOptions
+  | UnsortedSegmentMaxOptions
+  | UnsortedSegmentMinOptions
+  | UnsortedSegmentProdOptions
+  | UnsortedSegmentSumOptions
   | VarHandleOptions
   | WhereOptions
   | WhileOptions
@@ -1700,6 +1835,45 @@ export function unionListToBuiltinOptions(
       )! as AssignVariableOptions;
     case "RandomOptions":
       return accessor(index, new RandomOptions())! as RandomOptions;
+    case "BucketizeOptions":
+      return accessor(index, new BucketizeOptions())! as BucketizeOptions;
+    case "GeluOptions":
+      return accessor(index, new GeluOptions())! as GeluOptions;
+    case "DynamicUpdateSliceOptions":
+      return accessor(
+        index,
+        new DynamicUpdateSliceOptions()
+      )! as DynamicUpdateSliceOptions;
+    case "UnsortedSegmentProdOptions":
+      return accessor(
+        index,
+        new UnsortedSegmentProdOptions()
+      )! as UnsortedSegmentProdOptions;
+    case "UnsortedSegmentMaxOptions":
+      return accessor(
+        index,
+        new UnsortedSegmentMaxOptions()
+      )! as UnsortedSegmentMaxOptions;
+    case "UnsortedSegmentMinOptions":
+      return accessor(
+        index,
+        new UnsortedSegmentMinOptions()
+      )! as UnsortedSegmentMinOptions;
+    case "UnsortedSegmentSumOptions":
+      return accessor(
+        index,
+        new UnsortedSegmentSumOptions()
+      )! as UnsortedSegmentSumOptions;
+    case "ATan2Options":
+      return accessor(index, new ATan2Options())! as ATan2Options;
+    case "SignOptions":
+      return accessor(index, new SignOptions())! as SignOptions;
+    case "BitcastOptions":
+      return accessor(index, new BitcastOptions())! as BitcastOptions;
+    case "BitwiseXorOptions":
+      return accessor(index, new BitwiseXorOptions())! as BitwiseXorOptions;
+    case "RightShiftOptions":
+      return accessor(index, new RightShiftOptions())! as RightShiftOptions;
     case "BCQGatherOptions":
       return accessor(index, new BCQGatherOptions())! as BCQGatherOptions;
     case "BCQFullyConnectedOptions":
@@ -3143,6 +3317,171 @@ export class SparsityParametersT {
   }
 }
 
+export class VariantSubType {
+  bb: flatbuffers.ByteBuffer | null = null;
+  bb_pos = 0;
+  __init(i: number, bb: flatbuffers.ByteBuffer): VariantSubType {
+    this.bb_pos = i;
+    this.bb = bb;
+    return this;
+  }
+
+  static getRootAsVariantSubType(
+    bb: flatbuffers.ByteBuffer,
+    obj?: VariantSubType
+  ): VariantSubType {
+    return (obj || new VariantSubType()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static getSizePrefixedRootAsVariantSubType(
+    bb: flatbuffers.ByteBuffer,
+    obj?: VariantSubType
+  ): VariantSubType {
+    bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+    return (obj || new VariantSubType()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  shape(index: number): number | null {
+    const offset = this.bb!.__offset(this.bb_pos, 4);
+    return offset
+      ? this.bb!.readInt32(this.bb!.__vector(this.bb_pos + offset) + index * 4)
+      : 0;
+  }
+
+  shapeLength(): number {
+    const offset = this.bb!.__offset(this.bb_pos, 4);
+    return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
+  }
+
+  shapeArray(): Int32Array | null {
+    const offset = this.bb!.__offset(this.bb_pos, 4);
+    return offset
+      ? new Int32Array(
+          this.bb!.bytes().buffer,
+          this.bb!.bytes().byteOffset + this.bb!.__vector(this.bb_pos + offset),
+          this.bb!.__vector_len(this.bb_pos + offset)
+        )
+      : null;
+  }
+
+  type(): TensorType {
+    const offset = this.bb!.__offset(this.bb_pos, 6);
+    return offset
+      ? this.bb!.readInt8(this.bb_pos + offset)
+      : TensorType.FLOAT32;
+  }
+
+  hasRank(): boolean {
+    const offset = this.bb!.__offset(this.bb_pos, 8);
+    return offset ? !!this.bb!.readInt8(this.bb_pos + offset) : false;
+  }
+
+  static startVariantSubType(builder: flatbuffers.Builder) {
+    builder.startObject(3);
+  }
+
+  static addShape(
+    builder: flatbuffers.Builder,
+    shapeOffset: flatbuffers.Offset
+  ) {
+    builder.addFieldOffset(0, shapeOffset, 0);
+  }
+
+  static createShapeVector(
+    builder: flatbuffers.Builder,
+    data: number[] | Int32Array
+  ): flatbuffers.Offset;
+  /**
+   * @deprecated This Uint8Array overload will be removed in the future.
+   */
+  static createShapeVector(
+    builder: flatbuffers.Builder,
+    data: number[] | Uint8Array
+  ): flatbuffers.Offset;
+  static createShapeVector(
+    builder: flatbuffers.Builder,
+    data: number[] | Int32Array | Uint8Array
+  ): flatbuffers.Offset {
+    builder.startVector(4, data.length, 4);
+    for (let i = data.length - 1; i >= 0; i--) {
+      builder.addInt32(data[i]!);
+    }
+    return builder.endVector();
+  }
+
+  static startShapeVector(builder: flatbuffers.Builder, numElems: number) {
+    builder.startVector(4, numElems, 4);
+  }
+
+  static addType(builder: flatbuffers.Builder, type: TensorType) {
+    builder.addFieldInt8(1, type, TensorType.FLOAT32);
+  }
+
+  static addHasRank(builder: flatbuffers.Builder, hasRank: boolean) {
+    builder.addFieldInt8(2, +hasRank, +false);
+  }
+
+  static endVariantSubType(builder: flatbuffers.Builder): flatbuffers.Offset {
+    const offset = builder.endObject();
+    return offset;
+  }
+
+  static createVariantSubType(
+    builder: flatbuffers.Builder,
+    shapeOffset: flatbuffers.Offset,
+    type: TensorType,
+    hasRank: boolean
+  ): flatbuffers.Offset {
+    VariantSubType.startVariantSubType(builder);
+    VariantSubType.addShape(builder, shapeOffset);
+    VariantSubType.addType(builder, type);
+    VariantSubType.addHasRank(builder, hasRank);
+    return VariantSubType.endVariantSubType(builder);
+  }
+
+  unpack(): VariantSubTypeT {
+    return new VariantSubTypeT(
+      this.bb!.createScalarList(this.shape.bind(this), this.shapeLength()),
+      this.type(),
+      this.hasRank()
+    );
+  }
+
+  unpackTo(_o: VariantSubTypeT): void {
+    _o.shape = this.bb!.createScalarList(
+      this.shape.bind(this),
+      this.shapeLength()
+    );
+    _o.type = this.type();
+    _o.hasRank = this.hasRank();
+  }
+}
+
+export class VariantSubTypeT {
+  constructor(
+    public shape: number[] = [],
+    public type: TensorType = TensorType.FLOAT32,
+    public hasRank: boolean = false
+  ) {}
+
+  pack(builder: flatbuffers.Builder): flatbuffers.Offset {
+    const shape = VariantSubType.createShapeVector(builder, this.shape);
+
+    return VariantSubType.createVariantSubType(
+      builder,
+      shape,
+      this.type,
+      this.hasRank
+    );
+  }
+}
+
 export class Tensor {
   bb: flatbuffers.ByteBuffer | null = null;
   bb_pos = 0;
@@ -3262,8 +3601,30 @@ export class Tensor {
       : null;
   }
 
+  hasRank(): boolean {
+    const offset = this.bb!.__offset(this.bb_pos, 20);
+    return offset ? !!this.bb!.readInt8(this.bb_pos + offset) : false;
+  }
+
+  variantTensors(index: number, obj?: VariantSubType): VariantSubType | null {
+    const offset = this.bb!.__offset(this.bb_pos, 22);
+    return offset
+      ? (obj || new VariantSubType()).__init(
+          this.bb!.__indirect(
+            this.bb!.__vector(this.bb_pos + offset) + index * 4
+          ),
+          this.bb!
+        )
+      : null;
+  }
+
+  variantTensorsLength(): number {
+    const offset = this.bb!.__offset(this.bb_pos, 22);
+    return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
+  }
+
   static startTensor(builder: flatbuffers.Builder) {
-    builder.startObject(8);
+    builder.startObject(10);
   }
 
   static addShape(
@@ -3365,6 +3726,35 @@ export class Tensor {
     builder.startVector(4, numElems, 4);
   }
 
+  static addHasRank(builder: flatbuffers.Builder, hasRank: boolean) {
+    builder.addFieldInt8(8, +hasRank, +false);
+  }
+
+  static addVariantTensors(
+    builder: flatbuffers.Builder,
+    variantTensorsOffset: flatbuffers.Offset
+  ) {
+    builder.addFieldOffset(9, variantTensorsOffset, 0);
+  }
+
+  static createVariantTensorsVector(
+    builder: flatbuffers.Builder,
+    data: flatbuffers.Offset[]
+  ): flatbuffers.Offset {
+    builder.startVector(4, data.length, 4);
+    for (let i = data.length - 1; i >= 0; i--) {
+      builder.addOffset(data[i]!);
+    }
+    return builder.endVector();
+  }
+
+  static startVariantTensorsVector(
+    builder: flatbuffers.Builder,
+    numElems: number
+  ) {
+    builder.startVector(4, numElems, 4);
+  }
+
   static endTensor(builder: flatbuffers.Builder): flatbuffers.Offset {
     const offset = builder.endObject();
     return offset;
@@ -3382,6 +3772,11 @@ export class Tensor {
       this.bb!.createScalarList(
         this.shapeSignature.bind(this),
         this.shapeSignatureLength()
+      ),
+      this.hasRank(),
+      this.bb!.createObjList(
+        this.variantTensors.bind(this),
+        this.variantTensorsLength()
       )
     );
   }
@@ -3402,6 +3797,11 @@ export class Tensor {
       this.shapeSignature.bind(this),
       this.shapeSignatureLength()
     );
+    _o.hasRank = this.hasRank();
+    _o.variantTensors = this.bb!.createObjList(
+      this.variantTensors.bind(this),
+      this.variantTensorsLength()
+    );
   }
 }
 
@@ -3414,7 +3814,9 @@ export class TensorT {
     public quantization: QuantizationParametersT | null = null,
     public isVariable: boolean = false,
     public sparsity: SparsityParametersT | null = null,
-    public shapeSignature: number[] = []
+    public shapeSignature: number[] = [],
+    public hasRank: boolean = false,
+    public variantTensors: VariantSubTypeT[] = []
   ) {}
 
   pack(builder: flatbuffers.Builder): flatbuffers.Offset {
@@ -3427,6 +3829,10 @@ export class TensorT {
       builder,
       this.shapeSignature
     );
+    const variantTensors = Tensor.createVariantTensorsVector(
+      builder,
+      builder.createObjectOffsetList(this.variantTensors)
+    );
 
     Tensor.startTensor(builder);
     Tensor.addShape(builder, shape);
@@ -3437,6 +3843,8 @@ export class TensorT {
     Tensor.addIsVariable(builder, this.isVariable);
     Tensor.addSparsity(builder, sparsity);
     Tensor.addShapeSignature(builder, shapeSignature);
+    Tensor.addHasRank(builder, this.hasRank);
+    Tensor.addVariantTensors(builder, variantTensors);
 
     return Tensor.endTensor(builder);
   }
@@ -5984,8 +6392,13 @@ export class UnidirectionalSequenceLSTMOptions {
     return offset ? !!this.bb!.readInt8(this.bb_pos + offset) : false;
   }
 
+  diagonalRecurrentTensors(): boolean {
+    const offset = this.bb!.__offset(this.bb_pos, 14);
+    return offset ? !!this.bb!.readInt8(this.bb_pos + offset) : false;
+  }
+
   static startUnidirectionalSequenceLSTMOptions(builder: flatbuffers.Builder) {
-    builder.startObject(5);
+    builder.startObject(6);
   }
 
   static addFusedActivationFunction(
@@ -6018,6 +6431,13 @@ export class UnidirectionalSequenceLSTMOptions {
     builder.addFieldInt8(4, +asymmetricQuantizeInputs, +false);
   }
 
+  static addDiagonalRecurrentTensors(
+    builder: flatbuffers.Builder,
+    diagonalRecurrentTensors: boolean
+  ) {
+    builder.addFieldInt8(5, +diagonalRecurrentTensors, +false);
+  }
+
   static endUnidirectionalSequenceLSTMOptions(
     builder: flatbuffers.Builder
   ): flatbuffers.Offset {
@@ -6031,7 +6451,8 @@ export class UnidirectionalSequenceLSTMOptions {
     cellClip: number,
     projClip: number,
     timeMajor: boolean,
-    asymmetricQuantizeInputs: boolean
+    asymmetricQuantizeInputs: boolean,
+    diagonalRecurrentTensors: boolean
   ): flatbuffers.Offset {
     UnidirectionalSequenceLSTMOptions.startUnidirectionalSequenceLSTMOptions(
       builder
@@ -6047,6 +6468,10 @@ export class UnidirectionalSequenceLSTMOptions {
       builder,
       asymmetricQuantizeInputs
     );
+    UnidirectionalSequenceLSTMOptions.addDiagonalRecurrentTensors(
+      builder,
+      diagonalRecurrentTensors
+    );
     return UnidirectionalSequenceLSTMOptions.endUnidirectionalSequenceLSTMOptions(
       builder
     );
@@ -6058,7 +6483,8 @@ export class UnidirectionalSequenceLSTMOptions {
       this.cellClip(),
       this.projClip(),
       this.timeMajor(),
-      this.asymmetricQuantizeInputs()
+      this.asymmetricQuantizeInputs(),
+      this.diagonalRecurrentTensors()
     );
   }
 
@@ -6068,6 +6494,7 @@ export class UnidirectionalSequenceLSTMOptions {
     _o.projClip = this.projClip();
     _o.timeMajor = this.timeMajor();
     _o.asymmetricQuantizeInputs = this.asymmetricQuantizeInputs();
+    _o.diagonalRecurrentTensors = this.diagonalRecurrentTensors();
   }
 }
 
@@ -6077,7 +6504,8 @@ export class UnidirectionalSequenceLSTMOptionsT {
     public cellClip: number = 0.0,
     public projClip: number = 0.0,
     public timeMajor: boolean = false,
-    public asymmetricQuantizeInputs: boolean = false
+    public asymmetricQuantizeInputs: boolean = false,
+    public diagonalRecurrentTensors: boolean = false
   ) {}
 
   pack(builder: flatbuffers.Builder): flatbuffers.Offset {
@@ -6087,7 +6515,8 @@ export class UnidirectionalSequenceLSTMOptionsT {
       this.cellClip,
       this.projClip,
       this.timeMajor,
-      this.asymmetricQuantizeInputs
+      this.asymmetricQuantizeInputs,
+      this.diagonalRecurrentTensors
     );
   }
 }
@@ -9270,8 +9699,15 @@ export class TransposeConvOptions {
     return offset ? this.bb!.readInt32(this.bb_pos + offset) : 0;
   }
 
+  fusedActivationFunction(): ActivationFunctionType {
+    const offset = this.bb!.__offset(this.bb_pos, 10);
+    return offset
+      ? this.bb!.readInt8(this.bb_pos + offset)
+      : ActivationFunctionType.NONE;
+  }
+
   static startTransposeConvOptions(builder: flatbuffers.Builder) {
-    builder.startObject(3);
+    builder.startObject(4);
   }
 
   static addPadding(builder: flatbuffers.Builder, padding: Padding) {
@@ -9286,6 +9722,17 @@ export class TransposeConvOptions {
     builder.addFieldInt32(2, strideH, 0);
   }
 
+  static addFusedActivationFunction(
+    builder: flatbuffers.Builder,
+    fusedActivationFunction: ActivationFunctionType
+  ) {
+    builder.addFieldInt8(
+      3,
+      fusedActivationFunction,
+      ActivationFunctionType.NONE
+    );
+  }
+
   static endTransposeConvOptions(
     builder: flatbuffers.Builder
   ): flatbuffers.Offset {
@@ -9297,12 +9744,17 @@ export class TransposeConvOptions {
     builder: flatbuffers.Builder,
     padding: Padding,
     strideW: number,
-    strideH: number
+    strideH: number,
+    fusedActivationFunction: ActivationFunctionType
   ): flatbuffers.Offset {
     TransposeConvOptions.startTransposeConvOptions(builder);
     TransposeConvOptions.addPadding(builder, padding);
     TransposeConvOptions.addStrideW(builder, strideW);
     TransposeConvOptions.addStrideH(builder, strideH);
+    TransposeConvOptions.addFusedActivationFunction(
+      builder,
+      fusedActivationFunction
+    );
     return TransposeConvOptions.endTransposeConvOptions(builder);
   }
 
@@ -9310,7 +9762,8 @@ export class TransposeConvOptions {
     return new TransposeConvOptionsT(
       this.padding(),
       this.strideW(),
-      this.strideH()
+      this.strideH(),
+      this.fusedActivationFunction()
     );
   }
 
@@ -9318,6 +9771,7 @@ export class TransposeConvOptions {
     _o.padding = this.padding();
     _o.strideW = this.strideW();
     _o.strideH = this.strideH();
+    _o.fusedActivationFunction = this.fusedActivationFunction();
   }
 }
 
@@ -9325,7 +9779,8 @@ export class TransposeConvOptionsT {
   constructor(
     public padding: Padding = Padding.SAME,
     public strideW: number = 0,
-    public strideH: number = 0
+    public strideH: number = 0,
+    public fusedActivationFunction: ActivationFunctionType = ActivationFunctionType.NONE
   ) {}
 
   pack(builder: flatbuffers.Builder): flatbuffers.Offset {
@@ -9333,7 +9788,8 @@ export class TransposeConvOptionsT {
       builder,
       this.padding,
       this.strideW,
-      this.strideH
+      this.strideH,
+      this.fusedActivationFunction
     );
   }
 }
@@ -13203,26 +13659,26 @@ export class RandomOptions {
     );
   }
 
-  seed(): number {
+  seed(): bigint {
     const offset = this.bb!.__offset(this.bb_pos, 4);
-    return offset ? this.bb!.readInt32(this.bb_pos + offset) : 0;
+    return offset ? this.bb!.readInt64(this.bb_pos + offset) : BigInt("0");
   }
 
-  seed2(): number {
+  seed2(): bigint {
     const offset = this.bb!.__offset(this.bb_pos, 6);
-    return offset ? this.bb!.readInt32(this.bb_pos + offset) : 0;
+    return offset ? this.bb!.readInt64(this.bb_pos + offset) : BigInt("0");
   }
 
   static startRandomOptions(builder: flatbuffers.Builder) {
     builder.startObject(2);
   }
 
-  static addSeed(builder: flatbuffers.Builder, seed: number) {
-    builder.addFieldInt32(0, seed, 0);
+  static addSeed(builder: flatbuffers.Builder, seed: bigint) {
+    builder.addFieldInt64(0, seed, BigInt("0"));
   }
 
-  static addSeed2(builder: flatbuffers.Builder, seed2: number) {
-    builder.addFieldInt32(1, seed2, 0);
+  static addSeed2(builder: flatbuffers.Builder, seed2: bigint) {
+    builder.addFieldInt64(1, seed2, BigInt("0"));
   }
 
   static endRandomOptions(builder: flatbuffers.Builder): flatbuffers.Offset {
@@ -13232,8 +13688,8 @@ export class RandomOptions {
 
   static createRandomOptions(
     builder: flatbuffers.Builder,
-    seed: number,
-    seed2: number
+    seed: bigint,
+    seed2: bigint
   ): flatbuffers.Offset {
     RandomOptions.startRandomOptions(builder);
     RandomOptions.addSeed(builder, seed);
@@ -13252,10 +13708,843 @@ export class RandomOptions {
 }
 
 export class RandomOptionsT {
-  constructor(public seed: number = 0, public seed2: number = 0) {}
+  constructor(
+    public seed: bigint = BigInt("0"),
+    public seed2: bigint = BigInt("0")
+  ) {}
 
   pack(builder: flatbuffers.Builder): flatbuffers.Offset {
     return RandomOptions.createRandomOptions(builder, this.seed, this.seed2);
+  }
+}
+
+export class BucketizeOptions {
+  bb: flatbuffers.ByteBuffer | null = null;
+  bb_pos = 0;
+  __init(i: number, bb: flatbuffers.ByteBuffer): BucketizeOptions {
+    this.bb_pos = i;
+    this.bb = bb;
+    return this;
+  }
+
+  static getRootAsBucketizeOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: BucketizeOptions
+  ): BucketizeOptions {
+    return (obj || new BucketizeOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static getSizePrefixedRootAsBucketizeOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: BucketizeOptions
+  ): BucketizeOptions {
+    bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+    return (obj || new BucketizeOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  boundaries(index: number): number | null {
+    const offset = this.bb!.__offset(this.bb_pos, 4);
+    return offset
+      ? this.bb!.readFloat32(
+          this.bb!.__vector(this.bb_pos + offset) + index * 4
+        )
+      : 0;
+  }
+
+  boundariesLength(): number {
+    const offset = this.bb!.__offset(this.bb_pos, 4);
+    return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
+  }
+
+  boundariesArray(): Float32Array | null {
+    const offset = this.bb!.__offset(this.bb_pos, 4);
+    return offset
+      ? new Float32Array(
+          this.bb!.bytes().buffer,
+          this.bb!.bytes().byteOffset + this.bb!.__vector(this.bb_pos + offset),
+          this.bb!.__vector_len(this.bb_pos + offset)
+        )
+      : null;
+  }
+
+  static startBucketizeOptions(builder: flatbuffers.Builder) {
+    builder.startObject(1);
+  }
+
+  static addBoundaries(
+    builder: flatbuffers.Builder,
+    boundariesOffset: flatbuffers.Offset
+  ) {
+    builder.addFieldOffset(0, boundariesOffset, 0);
+  }
+
+  static createBoundariesVector(
+    builder: flatbuffers.Builder,
+    data: number[] | Float32Array
+  ): flatbuffers.Offset;
+  /**
+   * @deprecated This Uint8Array overload will be removed in the future.
+   */
+  static createBoundariesVector(
+    builder: flatbuffers.Builder,
+    data: number[] | Uint8Array
+  ): flatbuffers.Offset;
+  static createBoundariesVector(
+    builder: flatbuffers.Builder,
+    data: number[] | Float32Array | Uint8Array
+  ): flatbuffers.Offset {
+    builder.startVector(4, data.length, 4);
+    for (let i = data.length - 1; i >= 0; i--) {
+      builder.addFloat32(data[i]!);
+    }
+    return builder.endVector();
+  }
+
+  static startBoundariesVector(builder: flatbuffers.Builder, numElems: number) {
+    builder.startVector(4, numElems, 4);
+  }
+
+  static endBucketizeOptions(builder: flatbuffers.Builder): flatbuffers.Offset {
+    const offset = builder.endObject();
+    return offset;
+  }
+
+  static createBucketizeOptions(
+    builder: flatbuffers.Builder,
+    boundariesOffset: flatbuffers.Offset
+  ): flatbuffers.Offset {
+    BucketizeOptions.startBucketizeOptions(builder);
+    BucketizeOptions.addBoundaries(builder, boundariesOffset);
+    return BucketizeOptions.endBucketizeOptions(builder);
+  }
+
+  unpack(): BucketizeOptionsT {
+    return new BucketizeOptionsT(
+      this.bb!.createScalarList(
+        this.boundaries.bind(this),
+        this.boundariesLength()
+      )
+    );
+  }
+
+  unpackTo(_o: BucketizeOptionsT): void {
+    _o.boundaries = this.bb!.createScalarList(
+      this.boundaries.bind(this),
+      this.boundariesLength()
+    );
+  }
+}
+
+export class BucketizeOptionsT {
+  constructor(public boundaries: number[] = []) {}
+
+  pack(builder: flatbuffers.Builder): flatbuffers.Offset {
+    const boundaries = BucketizeOptions.createBoundariesVector(
+      builder,
+      this.boundaries
+    );
+
+    return BucketizeOptions.createBucketizeOptions(builder, boundaries);
+  }
+}
+
+export class GeluOptions {
+  bb: flatbuffers.ByteBuffer | null = null;
+  bb_pos = 0;
+  __init(i: number, bb: flatbuffers.ByteBuffer): GeluOptions {
+    this.bb_pos = i;
+    this.bb = bb;
+    return this;
+  }
+
+  static getRootAsGeluOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: GeluOptions
+  ): GeluOptions {
+    return (obj || new GeluOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static getSizePrefixedRootAsGeluOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: GeluOptions
+  ): GeluOptions {
+    bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+    return (obj || new GeluOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  approximate(): boolean {
+    const offset = this.bb!.__offset(this.bb_pos, 4);
+    return offset ? !!this.bb!.readInt8(this.bb_pos + offset) : false;
+  }
+
+  static startGeluOptions(builder: flatbuffers.Builder) {
+    builder.startObject(1);
+  }
+
+  static addApproximate(builder: flatbuffers.Builder, approximate: boolean) {
+    builder.addFieldInt8(0, +approximate, +false);
+  }
+
+  static endGeluOptions(builder: flatbuffers.Builder): flatbuffers.Offset {
+    const offset = builder.endObject();
+    return offset;
+  }
+
+  static createGeluOptions(
+    builder: flatbuffers.Builder,
+    approximate: boolean
+  ): flatbuffers.Offset {
+    GeluOptions.startGeluOptions(builder);
+    GeluOptions.addApproximate(builder, approximate);
+    return GeluOptions.endGeluOptions(builder);
+  }
+
+  unpack(): GeluOptionsT {
+    return new GeluOptionsT(this.approximate());
+  }
+
+  unpackTo(_o: GeluOptionsT): void {
+    _o.approximate = this.approximate();
+  }
+}
+
+export class GeluOptionsT {
+  constructor(public approximate: boolean = false) {}
+
+  pack(builder: flatbuffers.Builder): flatbuffers.Offset {
+    return GeluOptions.createGeluOptions(builder, this.approximate);
+  }
+}
+
+export class DynamicUpdateSliceOptions {
+  bb: flatbuffers.ByteBuffer | null = null;
+  bb_pos = 0;
+  __init(i: number, bb: flatbuffers.ByteBuffer): DynamicUpdateSliceOptions {
+    this.bb_pos = i;
+    this.bb = bb;
+    return this;
+  }
+
+  static getRootAsDynamicUpdateSliceOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: DynamicUpdateSliceOptions
+  ): DynamicUpdateSliceOptions {
+    return (obj || new DynamicUpdateSliceOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static getSizePrefixedRootAsDynamicUpdateSliceOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: DynamicUpdateSliceOptions
+  ): DynamicUpdateSliceOptions {
+    bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+    return (obj || new DynamicUpdateSliceOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static startDynamicUpdateSliceOptions(builder: flatbuffers.Builder) {
+    builder.startObject(0);
+  }
+
+  static endDynamicUpdateSliceOptions(
+    builder: flatbuffers.Builder
+  ): flatbuffers.Offset {
+    const offset = builder.endObject();
+    return offset;
+  }
+
+  static createDynamicUpdateSliceOptions(
+    builder: flatbuffers.Builder
+  ): flatbuffers.Offset {
+    DynamicUpdateSliceOptions.startDynamicUpdateSliceOptions(builder);
+    return DynamicUpdateSliceOptions.endDynamicUpdateSliceOptions(builder);
+  }
+
+  unpack(): DynamicUpdateSliceOptionsT {
+    return new DynamicUpdateSliceOptionsT();
+  }
+
+  unpackTo(_o: DynamicUpdateSliceOptionsT): void {}
+}
+
+export class DynamicUpdateSliceOptionsT {
+  constructor() {}
+
+  pack(builder: flatbuffers.Builder): flatbuffers.Offset {
+    return DynamicUpdateSliceOptions.createDynamicUpdateSliceOptions(builder);
+  }
+}
+
+export class UnsortedSegmentProdOptions {
+  bb: flatbuffers.ByteBuffer | null = null;
+  bb_pos = 0;
+  __init(i: number, bb: flatbuffers.ByteBuffer): UnsortedSegmentProdOptions {
+    this.bb_pos = i;
+    this.bb = bb;
+    return this;
+  }
+
+  static getRootAsUnsortedSegmentProdOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: UnsortedSegmentProdOptions
+  ): UnsortedSegmentProdOptions {
+    return (obj || new UnsortedSegmentProdOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static getSizePrefixedRootAsUnsortedSegmentProdOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: UnsortedSegmentProdOptions
+  ): UnsortedSegmentProdOptions {
+    bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+    return (obj || new UnsortedSegmentProdOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static startUnsortedSegmentProdOptions(builder: flatbuffers.Builder) {
+    builder.startObject(0);
+  }
+
+  static endUnsortedSegmentProdOptions(
+    builder: flatbuffers.Builder
+  ): flatbuffers.Offset {
+    const offset = builder.endObject();
+    return offset;
+  }
+
+  static createUnsortedSegmentProdOptions(
+    builder: flatbuffers.Builder
+  ): flatbuffers.Offset {
+    UnsortedSegmentProdOptions.startUnsortedSegmentProdOptions(builder);
+    return UnsortedSegmentProdOptions.endUnsortedSegmentProdOptions(builder);
+  }
+
+  unpack(): UnsortedSegmentProdOptionsT {
+    return new UnsortedSegmentProdOptionsT();
+  }
+
+  unpackTo(_o: UnsortedSegmentProdOptionsT): void {}
+}
+
+export class UnsortedSegmentProdOptionsT {
+  constructor() {}
+
+  pack(builder: flatbuffers.Builder): flatbuffers.Offset {
+    return UnsortedSegmentProdOptions.createUnsortedSegmentProdOptions(builder);
+  }
+}
+
+export class UnsortedSegmentMaxOptions {
+  bb: flatbuffers.ByteBuffer | null = null;
+  bb_pos = 0;
+  __init(i: number, bb: flatbuffers.ByteBuffer): UnsortedSegmentMaxOptions {
+    this.bb_pos = i;
+    this.bb = bb;
+    return this;
+  }
+
+  static getRootAsUnsortedSegmentMaxOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: UnsortedSegmentMaxOptions
+  ): UnsortedSegmentMaxOptions {
+    return (obj || new UnsortedSegmentMaxOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static getSizePrefixedRootAsUnsortedSegmentMaxOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: UnsortedSegmentMaxOptions
+  ): UnsortedSegmentMaxOptions {
+    bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+    return (obj || new UnsortedSegmentMaxOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static startUnsortedSegmentMaxOptions(builder: flatbuffers.Builder) {
+    builder.startObject(0);
+  }
+
+  static endUnsortedSegmentMaxOptions(
+    builder: flatbuffers.Builder
+  ): flatbuffers.Offset {
+    const offset = builder.endObject();
+    return offset;
+  }
+
+  static createUnsortedSegmentMaxOptions(
+    builder: flatbuffers.Builder
+  ): flatbuffers.Offset {
+    UnsortedSegmentMaxOptions.startUnsortedSegmentMaxOptions(builder);
+    return UnsortedSegmentMaxOptions.endUnsortedSegmentMaxOptions(builder);
+  }
+
+  unpack(): UnsortedSegmentMaxOptionsT {
+    return new UnsortedSegmentMaxOptionsT();
+  }
+
+  unpackTo(_o: UnsortedSegmentMaxOptionsT): void {}
+}
+
+export class UnsortedSegmentMaxOptionsT {
+  constructor() {}
+
+  pack(builder: flatbuffers.Builder): flatbuffers.Offset {
+    return UnsortedSegmentMaxOptions.createUnsortedSegmentMaxOptions(builder);
+  }
+}
+
+export class UnsortedSegmentSumOptions {
+  bb: flatbuffers.ByteBuffer | null = null;
+  bb_pos = 0;
+  __init(i: number, bb: flatbuffers.ByteBuffer): UnsortedSegmentSumOptions {
+    this.bb_pos = i;
+    this.bb = bb;
+    return this;
+  }
+
+  static getRootAsUnsortedSegmentSumOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: UnsortedSegmentSumOptions
+  ): UnsortedSegmentSumOptions {
+    return (obj || new UnsortedSegmentSumOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static getSizePrefixedRootAsUnsortedSegmentSumOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: UnsortedSegmentSumOptions
+  ): UnsortedSegmentSumOptions {
+    bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+    return (obj || new UnsortedSegmentSumOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static startUnsortedSegmentSumOptions(builder: flatbuffers.Builder) {
+    builder.startObject(0);
+  }
+
+  static endUnsortedSegmentSumOptions(
+    builder: flatbuffers.Builder
+  ): flatbuffers.Offset {
+    const offset = builder.endObject();
+    return offset;
+  }
+
+  static createUnsortedSegmentSumOptions(
+    builder: flatbuffers.Builder
+  ): flatbuffers.Offset {
+    UnsortedSegmentSumOptions.startUnsortedSegmentSumOptions(builder);
+    return UnsortedSegmentSumOptions.endUnsortedSegmentSumOptions(builder);
+  }
+
+  unpack(): UnsortedSegmentSumOptionsT {
+    return new UnsortedSegmentSumOptionsT();
+  }
+
+  unpackTo(_o: UnsortedSegmentSumOptionsT): void {}
+}
+
+export class UnsortedSegmentSumOptionsT {
+  constructor() {}
+
+  pack(builder: flatbuffers.Builder): flatbuffers.Offset {
+    return UnsortedSegmentSumOptions.createUnsortedSegmentSumOptions(builder);
+  }
+}
+
+export class ATan2Options {
+  bb: flatbuffers.ByteBuffer | null = null;
+  bb_pos = 0;
+  __init(i: number, bb: flatbuffers.ByteBuffer): ATan2Options {
+    this.bb_pos = i;
+    this.bb = bb;
+    return this;
+  }
+
+  static getRootAsATan2Options(
+    bb: flatbuffers.ByteBuffer,
+    obj?: ATan2Options
+  ): ATan2Options {
+    return (obj || new ATan2Options()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static getSizePrefixedRootAsATan2Options(
+    bb: flatbuffers.ByteBuffer,
+    obj?: ATan2Options
+  ): ATan2Options {
+    bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+    return (obj || new ATan2Options()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static startATan2Options(builder: flatbuffers.Builder) {
+    builder.startObject(0);
+  }
+
+  static endATan2Options(builder: flatbuffers.Builder): flatbuffers.Offset {
+    const offset = builder.endObject();
+    return offset;
+  }
+
+  static createATan2Options(builder: flatbuffers.Builder): flatbuffers.Offset {
+    ATan2Options.startATan2Options(builder);
+    return ATan2Options.endATan2Options(builder);
+  }
+
+  unpack(): ATan2OptionsT {
+    return new ATan2OptionsT();
+  }
+
+  unpackTo(_o: ATan2OptionsT): void {}
+}
+
+export class ATan2OptionsT {
+  constructor() {}
+
+  pack(builder: flatbuffers.Builder): flatbuffers.Offset {
+    return ATan2Options.createATan2Options(builder);
+  }
+}
+
+export class UnsortedSegmentMinOptions {
+  bb: flatbuffers.ByteBuffer | null = null;
+  bb_pos = 0;
+  __init(i: number, bb: flatbuffers.ByteBuffer): UnsortedSegmentMinOptions {
+    this.bb_pos = i;
+    this.bb = bb;
+    return this;
+  }
+
+  static getRootAsUnsortedSegmentMinOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: UnsortedSegmentMinOptions
+  ): UnsortedSegmentMinOptions {
+    return (obj || new UnsortedSegmentMinOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static getSizePrefixedRootAsUnsortedSegmentMinOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: UnsortedSegmentMinOptions
+  ): UnsortedSegmentMinOptions {
+    bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+    return (obj || new UnsortedSegmentMinOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static startUnsortedSegmentMinOptions(builder: flatbuffers.Builder) {
+    builder.startObject(0);
+  }
+
+  static endUnsortedSegmentMinOptions(
+    builder: flatbuffers.Builder
+  ): flatbuffers.Offset {
+    const offset = builder.endObject();
+    return offset;
+  }
+
+  static createUnsortedSegmentMinOptions(
+    builder: flatbuffers.Builder
+  ): flatbuffers.Offset {
+    UnsortedSegmentMinOptions.startUnsortedSegmentMinOptions(builder);
+    return UnsortedSegmentMinOptions.endUnsortedSegmentMinOptions(builder);
+  }
+
+  unpack(): UnsortedSegmentMinOptionsT {
+    return new UnsortedSegmentMinOptionsT();
+  }
+
+  unpackTo(_o: UnsortedSegmentMinOptionsT): void {}
+}
+
+export class UnsortedSegmentMinOptionsT {
+  constructor() {}
+
+  pack(builder: flatbuffers.Builder): flatbuffers.Offset {
+    return UnsortedSegmentMinOptions.createUnsortedSegmentMinOptions(builder);
+  }
+}
+
+export class SignOptions {
+  bb: flatbuffers.ByteBuffer | null = null;
+  bb_pos = 0;
+  __init(i: number, bb: flatbuffers.ByteBuffer): SignOptions {
+    this.bb_pos = i;
+    this.bb = bb;
+    return this;
+  }
+
+  static getRootAsSignOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: SignOptions
+  ): SignOptions {
+    return (obj || new SignOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static getSizePrefixedRootAsSignOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: SignOptions
+  ): SignOptions {
+    bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+    return (obj || new SignOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static startSignOptions(builder: flatbuffers.Builder) {
+    builder.startObject(0);
+  }
+
+  static endSignOptions(builder: flatbuffers.Builder): flatbuffers.Offset {
+    const offset = builder.endObject();
+    return offset;
+  }
+
+  static createSignOptions(builder: flatbuffers.Builder): flatbuffers.Offset {
+    SignOptions.startSignOptions(builder);
+    return SignOptions.endSignOptions(builder);
+  }
+
+  unpack(): SignOptionsT {
+    return new SignOptionsT();
+  }
+
+  unpackTo(_o: SignOptionsT): void {}
+}
+
+export class SignOptionsT {
+  constructor() {}
+
+  pack(builder: flatbuffers.Builder): flatbuffers.Offset {
+    return SignOptions.createSignOptions(builder);
+  }
+}
+
+export class BitcastOptions {
+  bb: flatbuffers.ByteBuffer | null = null;
+  bb_pos = 0;
+  __init(i: number, bb: flatbuffers.ByteBuffer): BitcastOptions {
+    this.bb_pos = i;
+    this.bb = bb;
+    return this;
+  }
+
+  static getRootAsBitcastOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: BitcastOptions
+  ): BitcastOptions {
+    return (obj || new BitcastOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static getSizePrefixedRootAsBitcastOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: BitcastOptions
+  ): BitcastOptions {
+    bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+    return (obj || new BitcastOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static startBitcastOptions(builder: flatbuffers.Builder) {
+    builder.startObject(0);
+  }
+
+  static endBitcastOptions(builder: flatbuffers.Builder): flatbuffers.Offset {
+    const offset = builder.endObject();
+    return offset;
+  }
+
+  static createBitcastOptions(
+    builder: flatbuffers.Builder
+  ): flatbuffers.Offset {
+    BitcastOptions.startBitcastOptions(builder);
+    return BitcastOptions.endBitcastOptions(builder);
+  }
+
+  unpack(): BitcastOptionsT {
+    return new BitcastOptionsT();
+  }
+
+  unpackTo(_o: BitcastOptionsT): void {}
+}
+
+export class BitcastOptionsT {
+  constructor() {}
+
+  pack(builder: flatbuffers.Builder): flatbuffers.Offset {
+    return BitcastOptions.createBitcastOptions(builder);
+  }
+}
+
+export class BitwiseXorOptions {
+  bb: flatbuffers.ByteBuffer | null = null;
+  bb_pos = 0;
+  __init(i: number, bb: flatbuffers.ByteBuffer): BitwiseXorOptions {
+    this.bb_pos = i;
+    this.bb = bb;
+    return this;
+  }
+
+  static getRootAsBitwiseXorOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: BitwiseXorOptions
+  ): BitwiseXorOptions {
+    return (obj || new BitwiseXorOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static getSizePrefixedRootAsBitwiseXorOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: BitwiseXorOptions
+  ): BitwiseXorOptions {
+    bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+    return (obj || new BitwiseXorOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static startBitwiseXorOptions(builder: flatbuffers.Builder) {
+    builder.startObject(0);
+  }
+
+  static endBitwiseXorOptions(
+    builder: flatbuffers.Builder
+  ): flatbuffers.Offset {
+    const offset = builder.endObject();
+    return offset;
+  }
+
+  static createBitwiseXorOptions(
+    builder: flatbuffers.Builder
+  ): flatbuffers.Offset {
+    BitwiseXorOptions.startBitwiseXorOptions(builder);
+    return BitwiseXorOptions.endBitwiseXorOptions(builder);
+  }
+
+  unpack(): BitwiseXorOptionsT {
+    return new BitwiseXorOptionsT();
+  }
+
+  unpackTo(_o: BitwiseXorOptionsT): void {}
+}
+
+export class BitwiseXorOptionsT {
+  constructor() {}
+
+  pack(builder: flatbuffers.Builder): flatbuffers.Offset {
+    return BitwiseXorOptions.createBitwiseXorOptions(builder);
+  }
+}
+
+export class RightShiftOptions {
+  bb: flatbuffers.ByteBuffer | null = null;
+  bb_pos = 0;
+  __init(i: number, bb: flatbuffers.ByteBuffer): RightShiftOptions {
+    this.bb_pos = i;
+    this.bb = bb;
+    return this;
+  }
+
+  static getRootAsRightShiftOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: RightShiftOptions
+  ): RightShiftOptions {
+    return (obj || new RightShiftOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static getSizePrefixedRootAsRightShiftOptions(
+    bb: flatbuffers.ByteBuffer,
+    obj?: RightShiftOptions
+  ): RightShiftOptions {
+    bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+    return (obj || new RightShiftOptions()).__init(
+      bb.readInt32(bb.position()) + bb.position(),
+      bb
+    );
+  }
+
+  static startRightShiftOptions(builder: flatbuffers.Builder) {
+    builder.startObject(0);
+  }
+
+  static endRightShiftOptions(
+    builder: flatbuffers.Builder
+  ): flatbuffers.Offset {
+    const offset = builder.endObject();
+    return offset;
+  }
+
+  static createRightShiftOptions(
+    builder: flatbuffers.Builder
+  ): flatbuffers.Offset {
+    RightShiftOptions.startRightShiftOptions(builder);
+    return RightShiftOptions.endRightShiftOptions(builder);
+  }
+
+  unpack(): RightShiftOptionsT {
+    return new RightShiftOptionsT();
+  }
+
+  unpackTo(_o: RightShiftOptionsT): void {}
+}
+
+export class RightShiftOptionsT {
+  constructor() {}
+
+  pack(builder: flatbuffers.Builder): flatbuffers.Offset {
+    return RightShiftOptions.createRightShiftOptions(builder);
   }
 }
 
@@ -14181,6 +15470,7 @@ export class OperatorT {
     public outputs: number[] = [],
     public builtinOptionsType: BuiltinOptions = BuiltinOptions.NONE,
     public builtinOptions:
+      | ATan2OptionsT
       | AbsOptionsT
       | AddNOptionsT
       | AddOptionsT
@@ -14193,7 +15483,10 @@ export class OperatorT {
       | BatchToSpaceNDOptionsT
       | BidirectionalSequenceLSTMOptionsT
       | BidirectionalSequenceRNNOptionsT
+      | BitcastOptionsT
+      | BitwiseXorOptionsT
       | BroadcastToOptionsT
+      | BucketizeOptionsT
       | CallOnceOptionsT
       | CallOptionsT
       | CastOptionsT
@@ -14208,6 +15501,7 @@ export class OperatorT {
       | DepthwiseConv2DOptionsT
       | DequantizeOptionsT
       | DivOptionsT
+      | DynamicUpdateSliceOptionsT
       | EmbeddingLookupSparseOptionsT
       | EqualOptionsT
       | ExpOptionsT
@@ -14219,6 +15513,7 @@ export class OperatorT {
       | FullyConnectedOptionsT
       | GatherNdOptionsT
       | GatherOptionsT
+      | GeluOptionsT
       | GreaterEqualOptionsT
       | GreaterOptionsT
       | HardSwishOptionsT
@@ -14267,6 +15562,7 @@ export class OperatorT {
       | ReverseSequenceOptionsT
       | ReverseV2OptionsT
       | Rfft2dOptionsT
+      | RightShiftOptionsT
       | SVDFOptionsT
       | ScatterNdOptionsT
       | SegmentSumOptionsT
@@ -14274,6 +15570,7 @@ export class OperatorT {
       | SelectV2OptionsT
       | SequenceRNNOptionsT
       | ShapeOptionsT
+      | SignOptionsT
       | SkipGramOptionsT
       | SliceOptionsT
       | SoftmaxOptionsT
@@ -14294,6 +15591,10 @@ export class OperatorT {
       | UnidirectionalSequenceLSTMOptionsT
       | UniqueOptionsT
       | UnpackOptionsT
+      | UnsortedSegmentMaxOptionsT
+      | UnsortedSegmentMinOptionsT
+      | UnsortedSegmentProdOptionsT
+      | UnsortedSegmentSumOptionsT
       | VarHandleOptionsT
       | WhereOptionsT
       | WhileOptionsT


### PR DESCRIPTION
This PR will update circle-schema to version 0.6.
The `circle-schema.js` file is originally come from [netron](https://github.com/lutzroeder/netron/blob/89104391b1f2dfea9738d064339069ad1db3bd34/source/circle-schema.js).
The `circle_schema_generated.ts` file is originally come from [ONE](https://github.com/Samsung/ONE/blob/e09738db8a7f873005d26a21465dfabca12abf88/res/CircleSchema/0.6/circle_schema.fbs).

ONE-vscode-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>

---

Related: #1651 