### PR TITLE
[Execute] Register SimulatorDevice with Toolchain information

### DIFF
--- a/src/Tests/Execute/DeviceViewProvider.test.ts
+++ b/src/Tests/Execute/DeviceViewProvider.test.ts
@@ -114,28 +114,6 @@ suite("DeviceViewProvider", function () {
         done();
       });
     });
-    test("get Children under deviceManager Node", function (done) {
-      let provider = new DeviceViewProvider();
-      provider.loadDeviceManager("local", function () {
-        for (const key in provider.deviceManagerMap) {
-          if (
-            Object.prototype.hasOwnProperty.call(provider.deviceManagerMap, key)
-          ) {
-            const element = provider.deviceManagerMap[key];
-            const label = key;
-            const collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
-            let node = new DeviceViewNode(
-              label,
-              collapsibleState,
-              NodeType.deviceManager
-            );
-            let result = provider.getChildren(node);
-            assert.strictEqual(result.length, element.allDevices.length);
-          }
-        }
-        done();
-      });
-    });
     test("get Children under Device Node", function (done) {
       let provider = new DeviceViewProvider();
       provider.loadDeviceManager("local", function () {


### PR DESCRIPTION
This commit registers SimulatorDevice with Toolchain information.
It does not add device according to the DeviceSpec. All devices are
added to the DeviceManager directly.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

wait for #1660 