### PR TITLE
[EdgeTPU] Add EdgeTPUDebianToolchain

### DIFF
--- a/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
+++ b/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
@@ -26,45 +26,45 @@ class EdgeTPUDebianToolchain extends DebianToolchain {
     let cmd = new Command("edgetpu_compiler");
     var config = ini.parse(fs.readFileSync(cfg, "utf-8").trim());
 
-    if (config["one-import-edgetpu"] === undefined) {
+    if (config["edgetpu-compile"] === undefined) {
       return cmd;
     }
 
-    let outDir = path.dirname(config["one-import-edgetpu"]["output_path"]);
+    let outDir = path.dirname(config["edgetpu-compile"]["output_path"]);
     cmd.push("--out_dir");
     cmd.push(outDir);
 
     let intermediateTensors =
-      config["one-import-edgetpu"]["intermediate_tensors"];
+      config["edgetpu-compile"]["intermediate_tensors"];
     if (intermediateTensors !== undefined) {
       cmd.push("--intermediate_tensors");
       cmd.push(intermediateTensors);
     }
 
-    let showOperations = config["one-import-edgetpu"]["show_operations"];
+    let showOperations = config["edgetpu-compile"]["show_operations"];
     if (showOperations === "True") {
       cmd.push("--show_operations");
     }
 
-    let minRuntimeVersion = config["one-import-edgetpu"]["min_runtime_version"];
+    let minRuntimeVersion = config["edgetpu-compile"]["min_runtime_version"];
     if (minRuntimeVersion !== undefined) {
       cmd.push("--min_runtime_version");
       cmd.push(minRuntimeVersion);
     }
 
-    let searchDelegate = config["one-import-edgetpu"]["search_delegate"];
+    let searchDelegate = config["edgetpu-compile"]["search_delegate"];
     if (searchDelegate === "True") {
       cmd.push("--search_delegate");
     }
 
     let delegateSearchStep =
-      config["one-import-edgetpu"]["delegate_search_step"];
+      config["edgetpu-compile"]["delegate_search_step"];
     if (delegateSearchStep !== undefined) {
       cmd.push("--delegate_search_step");
       cmd.push(delegateSearchStep);
     }
 
-    let inputPath = config["one-import-edgetpu"]["input_path"];
+    let inputPath = config["edgetpu-compile"]["input_path"];
     cmd.push(inputPath);
 
     return cmd;

--- a/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
+++ b/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
+++ b/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
@@ -30,11 +30,11 @@ class EdgeTPUDebianToolchain extends DebianToolchain {
     if (config["edgetpu-compile"] === undefined) {
       Logger.error(
         "EdgeTPUDebianToolchain",
-        `Fail to run. The configuration file doesn't include 'edgetpu-compile' section. Please add one.`
+        `The configuration file doesn't include 'edgetpu-compile' section.`
       );
 
       throw new Error(
-        `Fail to run. The configuration file doesn't include ''edgetpu-compile' section. Please add one.`
+        `The configuration file doesn't include ''edgetpu-compile' section.`
       );
     }
 

--- a/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
+++ b/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
@@ -20,6 +20,7 @@ import { DebianToolchain } from "../ToolchainImpl/DebianToolchain";
 import * as ini from "ini";
 import * as fs from "fs";
 import * as path from "path";
+import { Logger } from "../../Utils/Logger";
 
 class EdgeTPUDebianToolchain extends DebianToolchain {
   run(cfg: string): Command {
@@ -27,15 +28,21 @@ class EdgeTPUDebianToolchain extends DebianToolchain {
     var config = ini.parse(fs.readFileSync(cfg, "utf-8").trim());
 
     if (config["edgetpu-compile"] === undefined) {
-      return cmd;
+      Logger.error(
+        "EdgeTPUDebianToolchain",
+        `Fail to run. The configuration file doesn't include 'edgetpu-compile' section. Please add one.`
+      );
+
+      throw new Error(
+        `Fail to run. The configuration file doesn't include ''edgetpu-compile' section. Please add one.`
+      );
     }
 
     let outDir = path.dirname(config["edgetpu-compile"]["output_path"]);
     cmd.push("--out_dir");
     cmd.push(outDir);
 
-    let intermediateTensors =
-      config["edgetpu-compile"]["intermediate_tensors"];
+    let intermediateTensors = config["edgetpu-compile"]["intermediate_tensors"];
     if (intermediateTensors !== undefined) {
       cmd.push("--intermediate_tensors");
       cmd.push(intermediateTensors);
@@ -57,8 +64,7 @@ class EdgeTPUDebianToolchain extends DebianToolchain {
       cmd.push("--search_delegate");
     }
 
-    let delegateSearchStep =
-      config["edgetpu-compile"]["delegate_search_step"];
+    let delegateSearchStep = config["edgetpu-compile"]["delegate_search_step"];
     if (delegateSearchStep !== undefined) {
       cmd.push("--delegate_search_step");
       cmd.push(delegateSearchStep);

--- a/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
+++ b/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
@@ -23,13 +23,13 @@ import * as ini from "ini";
 import * as fs from "fs";
 
 class EdgeTPUDebianToolchain extends DebianToolchain {
-  run(cfg: string): Command {
-    let cmd = new Command("edgetpu_compiler");
-    var config = ini.parse(fs.readFileSync(cfg, 'utf-8'));    
-    
-    if (config["one-import-edgetpu"] === undefined) {
-        return cmd;
-    }
+    run(cfg: string): Command {
+        let cmd = new Command("edgetpu_compiler");
+        var config = ini.parse(fs.readFileSync(cfg, 'utf-8').trim());
+        
+        if (config["one-import-edgetpu"] === undefined) {
+            return cmd;
+        }
 
     let outputPath = config["one-import-edgetpu"]["output_path"];
     cmd.push("--out_dir");

--- a/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
+++ b/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Command } from "../Command";
+import {
+  DebianToolchain,
+} from "../ToolchainImpl/DebianToolchain";
+
+import * as ini from "ini";
+import * as fs from "fs";
+
+class EdgeTPUDebianToolchain extends DebianToolchain {
+  run(cfg: string): Command {
+    let cmd = new Command("edgetpu_compiler");
+    var config = ini.parse(fs.readFileSync(cfg, 'utf-8'));    
+    
+    if (config["one-import-edgetpu"] === undefined) {
+        return cmd;
+    }
+
+    let outputPath = config["one-import-edgetpu"]["output_path"];
+    cmd.push("--out_dir");
+    cmd.push(outputPath);
+
+    let help = config["one-import-edgetpu"]["help"];
+    if (help === "True") { 
+        cmd.push("--help");
+    } 
+
+    let intermediateTensors = config["one-import-edgetpu"]["intermediate_tensors"];
+    if (intermediateTensors !== undefined) {
+        cmd.push("--intermediate_tensors");
+        cmd.push(intermediateTensors);
+    }
+
+    let showOperations = config["one-import-edgetpu"]["show_operations"];
+    if (showOperations === "True") {
+        cmd.push("--show_operations");
+    }
+
+    let minRuntimeVersion = config["one-import-edgetpu"]["min_runtime_version"];
+    if (minRuntimeVersion !== undefined) {
+        cmd.push("--min_runtime_version");
+        cmd.push(minRuntimeVersion);
+    }
+
+    let searchDelegate = config["one-import-edgetpu"]["search_delegate"];
+    if (searchDelegate === "True") {
+        cmd.push("--search_delegate");
+    }
+
+    let delegateSearchStep = config["one-import-edgetpu"]["delegate_search_step"];
+    if (delegateSearchStep !== undefined) {
+        cmd.push("--delegate_search_step");
+        cmd.push(delegateSearchStep);
+    }
+
+    let inputPath = config["one-import-edgetpu"]["input_path"];
+    cmd.push(inputPath);
+
+    return cmd;
+  }
+}

--- a/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
+++ b/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
@@ -21,6 +21,7 @@ import {
 
 import * as ini from "ini";
 import * as fs from "fs";
+import * as path from "path";
 
 class EdgeTPUDebianToolchain extends DebianToolchain {
     run(cfg: string): Command {
@@ -31,9 +32,9 @@ class EdgeTPUDebianToolchain extends DebianToolchain {
             return cmd;
         }
 
-    let outputPath = config["one-import-edgetpu"]["output_path"];
+    let outDir = path.dirname(config["one-import-edgetpu"]["output_path"]);
     cmd.push("--out_dir");
-    cmd.push(outputPath);
+    cmd.push(outDir);
 
     let help = config["one-import-edgetpu"]["help"];
     if (help === "True") { 

--- a/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
+++ b/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
@@ -15,53 +15,53 @@
  */
 
 import { Command } from "../Command";
-import {
-  DebianToolchain,
-} from "../ToolchainImpl/DebianToolchain";
+import { DebianToolchain } from "../ToolchainImpl/DebianToolchain";
 
 import * as ini from "ini";
 import * as fs from "fs";
 import * as path from "path";
 
 class EdgeTPUDebianToolchain extends DebianToolchain {
-    run(cfg: string): Command {
-        let cmd = new Command("edgetpu_compiler");
-        var config = ini.parse(fs.readFileSync(cfg, 'utf-8').trim());
-        
-        if (config["one-import-edgetpu"] === undefined) {
-            return cmd;
-        }
+  run(cfg: string): Command {
+    let cmd = new Command("edgetpu_compiler");
+    var config = ini.parse(fs.readFileSync(cfg, "utf-8").trim());
+
+    if (config["one-import-edgetpu"] === undefined) {
+      return cmd;
+    }
 
     let outDir = path.dirname(config["one-import-edgetpu"]["output_path"]);
     cmd.push("--out_dir");
     cmd.push(outDir);
 
-    let intermediateTensors = config["one-import-edgetpu"]["intermediate_tensors"];
+    let intermediateTensors =
+      config["one-import-edgetpu"]["intermediate_tensors"];
     if (intermediateTensors !== undefined) {
-        cmd.push("--intermediate_tensors");
-        cmd.push(intermediateTensors);
+      cmd.push("--intermediate_tensors");
+      cmd.push(intermediateTensors);
     }
 
     let showOperations = config["one-import-edgetpu"]["show_operations"];
     if (showOperations === "True") {
-        cmd.push("--show_operations");
+      cmd.push("--show_operations");
     }
 
     let minRuntimeVersion = config["one-import-edgetpu"]["min_runtime_version"];
     if (minRuntimeVersion !== undefined) {
-        cmd.push("--min_runtime_version");
-        cmd.push(minRuntimeVersion);
+      cmd.push("--min_runtime_version");
+      cmd.push(minRuntimeVersion);
     }
 
     let searchDelegate = config["one-import-edgetpu"]["search_delegate"];
     if (searchDelegate === "True") {
-        cmd.push("--search_delegate");
+      cmd.push("--search_delegate");
     }
 
-    let delegateSearchStep = config["one-import-edgetpu"]["delegate_search_step"];
+    let delegateSearchStep =
+      config["one-import-edgetpu"]["delegate_search_step"];
     if (delegateSearchStep !== undefined) {
-        cmd.push("--delegate_search_step");
-        cmd.push(delegateSearchStep);
+      cmd.push("--delegate_search_step");
+      cmd.push(delegateSearchStep);
     }
 
     let inputPath = config["one-import-edgetpu"]["input_path"];
@@ -70,3 +70,5 @@ class EdgeTPUDebianToolchain extends DebianToolchain {
     return cmd;
   }
 }
+
+export { EdgeTPUDebianToolchain };

--- a/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
+++ b/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
@@ -36,11 +36,6 @@ class EdgeTPUDebianToolchain extends DebianToolchain {
     cmd.push("--out_dir");
     cmd.push(outDir);
 
-    let help = config["one-import-edgetpu"]["help"];
-    if (help === "True") { 
-        cmd.push("--help");
-    } 
-
     let intermediateTensors = config["one-import-edgetpu"]["intermediate_tensors"];
     if (intermediateTensors !== undefined) {
         cmd.push("--intermediate_tensors");

--- a/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
+++ b/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
+++ b/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
@@ -22,22 +22,7 @@ import { Version } from "../../../Backend/Version";
 import { TestBuilder } from "../../TestBuilder";
 
 const content = `
-[onecc]
-one-import-tf=False
-one-import-tflite=False
-one-import-bcq=False
-one-import-onnx=False
-one-optimize=False
-one-quantize=True
-one-pack=False
-one-codegen=False
-
-[one-quantize]
-input_path=./inception_v3_tflite.circle
-output_path=./inception_v3_tflite.q8.circle
-input_model_dtype=uint8
-
-[one-import-edgetpu]
+[edgetpu-compile]
 input_path=/home/workspace/models/sample.tflite
 output_path=/home/workspace/models/sample_edge_tpu.tflite
 intermediate_tensors=tensorName1,tensorName2
@@ -48,7 +33,7 @@ delegate_search_step=4
 `;
 
 const relativeOutputPathcontent = `
-[one-import-edgetpu]
+[edgetpu-compile]
 input_path=./sample.tflite
 output_path=./sample_edge_tpu.tflite
 intermediate_tensors=tensorName1,tensorName2

--- a/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
+++ b/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assert } from "chai";
+
+import {
+  EdgeTPUDebianToolchain,
+} from "../../../Backend/EdgeTPU/EdgeTPUToolchain";
+import { ToolchainInfo } from "../../../Backend/Toolchain";
+import { Version } from "../../../Backend/Version";
+import { TestBuilder } from "../../TestBuilder";
+
+const content = `
+[onecc]
+one-import-tf=False
+one-import-tflite=False
+one-import-bcq=False
+one-import-onnx=False
+one-optimize=False
+one-quantize=True
+one-pack=False
+one-codegen=False
+
+[one-quantize]
+input_path=./inception_v3_tflite.circle
+output_path=./inception_v3_tflite.q8.circle
+input_model_dtype=uint8
+
+[one-import-edgetpu]
+input_path=/home/workspace/models/sample.tflite
+output_path=/home/workspace/models/sample_edge_tpu.tflite
+help=True
+intermediate_tensors=tensorName1,tensorName2
+show_operations=True
+min_runtime_version=14
+search_delegate=True
+delegate_search_step=4
+`;
+
+suite("Backend", function () {
+  suite("EdgeTPUDebianToolchain", function () {
+    let testBuilder: TestBuilder;
+
+    setup(() => {
+      testBuilder = new TestBuilder(this);
+      testBuilder.setUp();
+    });
+
+    teardown(() => {
+      testBuilder.tearDown();
+    });
+
+    suite("#run", function () {
+      test("returns Command with cfg", function () {
+        testBuilder.writeFileSync("file.cfg", content);
+        const cfgFilePath = testBuilder.getPath("file.cfg");
+
+        const name = "EdgeTPU";
+        const desc = "EdgeTPU Compiler";
+        const version = new Version(0, 1, 0);
+        const info = new ToolchainInfo(name, desc, version);
+        let dt = new EdgeTPUDebianToolchain(info);
+        let cmd = dt.run(cfgFilePath);
+        
+        const expectedStrs: string[] = ["edgetpu_compiler", "--out_dir", "/home/workspace/models/sample_edge_tpu.tflite", "--help",
+          "--intermediate_tensors", "tensorName1,tensorName2", "--show_operations", "--min_runtime_version", "14", "--search_delegate", "--delegate_search_step",
+          "4", "/home/workspace/models/sample.tflite"];
+
+        assert.deepEqual(cmd, expectedStrs);
+      });
+    });
+  });
+});

--- a/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
+++ b/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
@@ -42,7 +42,6 @@ input_model_dtype=uint8
 [one-import-edgetpu]
 input_path=/home/workspace/models/sample.tflite
 output_path=/home/workspace/models/sample_edge_tpu.tflite
-help=True
 intermediate_tensors=tensorName1,tensorName2
 show_operations=True
 min_runtime_version=14
@@ -54,7 +53,6 @@ const relativeOutputPathcontent = `
 [one-import-edgetpu]
 input_path=./sample.tflite
 output_path=./sample_edge_tpu.tflite
-help=True
 intermediate_tensors=tensorName1,tensorName2
 show_operations=True
 min_runtime_version=14
@@ -91,7 +89,6 @@ suite("Backend", function () {
           "edgetpu_compiler",
           "--out_dir",
           "/home/workspace/models",
-          "--help",
           "--intermediate_tensors",
           "tensorName1,tensorName2",
           "--show_operations",
@@ -121,7 +118,6 @@ suite("Backend", function () {
           "edgetpu_compiler",
           "--out_dir",
           ".",
-          "--help",
           "--intermediate_tensors",
           "tensorName1,tensorName2",
           "--show_operations",

--- a/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
+++ b/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
@@ -16,9 +16,7 @@
 
 import { assert } from "chai";
 
-import {
-  EdgeTPUDebianToolchain,
-} from "../../../Backend/EdgeTPU/EdgeTPUToolchain";
+import { EdgeTPUDebianToolchain } from "../../../Backend/EdgeTPU/EdgeTPUToolchain";
 import { ToolchainInfo } from "../../../Backend/Toolchain";
 import { Version } from "../../../Backend/Version";
 import { TestBuilder } from "../../TestBuilder";

--- a/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
+++ b/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
@@ -50,6 +50,18 @@ search_delegate=True
 delegate_search_step=4
 `;
 
+const relativeOutputPathcontent = `
+[one-import-edgetpu]
+input_path=./sample.tflite
+output_path=./sample_edge_tpu.tflite
+help=True
+intermediate_tensors=tensorName1,tensorName2
+show_operations=True
+min_runtime_version=14
+search_delegate=True
+delegate_search_step=4
+`;
+
 suite("Backend", function () {
   suite("EdgeTPUDebianToolchain", function () {
     let testBuilder: TestBuilder;
@@ -74,10 +86,52 @@ suite("Backend", function () {
         const info = new ToolchainInfo(name, desc, version);
         let dt = new EdgeTPUDebianToolchain(info);
         let cmd = dt.run(cfgFilePath);
-        
-        const expectedStrs: string[] = ["edgetpu_compiler", "--out_dir", "/home/workspace/models/sample_edge_tpu.tflite", "--help",
-          "--intermediate_tensors", "tensorName1,tensorName2", "--show_operations", "--min_runtime_version", "14", "--search_delegate", "--delegate_search_step",
-          "4", "/home/workspace/models/sample.tflite"];
+
+        const expectedStrs: string[] = [
+          "edgetpu_compiler",
+          "--out_dir",
+          "/home/workspace/models",
+          "--help",
+          "--intermediate_tensors",
+          "tensorName1,tensorName2",
+          "--show_operations",
+          "--min_runtime_version",
+          "14",
+          "--search_delegate",
+          "--delegate_search_step",
+          "4",
+          "/home/workspace/models/sample.tflite",
+        ];
+
+        assert.deepEqual(cmd, expectedStrs);
+      });
+
+      test("returns Command with cfg containing relative input path", function () {
+        testBuilder.writeFileSync("file.cfg", relativeOutputPathcontent);
+        const cfgFilePath = testBuilder.getPath("file.cfg");
+
+        const name = "EdgeTPU";
+        const desc = "EdgeTPU Compiler";
+        const version = new Version(0, 1, 0);
+        const info = new ToolchainInfo(name, desc, version);
+        let dt = new EdgeTPUDebianToolchain(info);
+        let cmd = dt.run(cfgFilePath);
+
+        const expectedStrs: string[] = [
+          "edgetpu_compiler",
+          "--out_dir",
+          ".",
+          "--help",
+          "--intermediate_tensors",
+          "tensorName1,tensorName2",
+          "--show_operations",
+          "--min_runtime_version",
+          "14",
+          "--search_delegate",
+          "--delegate_search_step",
+          "4",
+          "./sample.tflite",
+        ];
 
         assert.deepEqual(cmd, expectedStrs);
       });


### PR DESCRIPTION
For #1621, #1628 

This commit adds the EdgeTPUDebianToolchain class extending DebianToolchain.
It implements the codes reading the cfg file to construct the command and uses ini, fs packages to read cfg file.

Also, This commit adds the EdgeTPUDebianToolchain.test.ts file.
It includes the codes testing if EdgeTPUDebianToolchain's run() method returns the expected Command with given absolute and relative input paths.

ONE-vscode-DCO-1.0-Signed-off-by: Bumsoo Ko <rhqjatn2398@naver.com>