### PR TITLE
[Test] Relocate teardown

### DIFF
--- a/src/Tests/MPQEditor/MPQEditor.test.ts
+++ b/src/Tests/MPQEditor/MPQEditor.test.ts
@@ -31,10 +31,6 @@ suite("MPQEditor", function () {
       testBuilder.setUp();
     });
 
-    teardown(() => {
-      testBuilder.tearDown();
-    });
-
     suite("#validateMPQName", function () {
       test("test validateMPQName", function () {
         const dirPath: string = testBuilder.dirInTemp;
@@ -162,6 +158,10 @@ suite("MPQEditor", function () {
         assert.strictEqual(newCont["default_granularity"], "layer");
         assert.strictEqual(newCont["model_path"], "sample_1.circle");
       });
+    });
+
+    teardown(() => {
+      testBuilder.tearDown();
     });
   });
 });

--- a/src/Tests/OneExplorer/ConfigObject.test.ts
+++ b/src/Tests/OneExplorer/ConfigObject.test.ts
@@ -29,10 +29,6 @@ suite("OneExplorer", function () {
       testBuilder.setUp();
     });
 
-    teardown(() => {
-      testBuilder.tearDown();
-    });
-
     suite("#createConfigObj()", function () {
       test("NEG: Returns null when file read failed", function () {
         const configObj = ConfigObj.createConfigObj(
@@ -857,6 +853,10 @@ commands=--save-chrome-trace trace.json
           assert.strictEqual(configObj!.getProducts.length, 0);
         }
       });
+    });
+
+    teardown(() => {
+      testBuilder.tearDown();
     });
   });
 });

--- a/src/Tests/OneExplorer/OneExplorer.test.ts
+++ b/src/Tests/OneExplorer/OneExplorer.test.ts
@@ -35,10 +35,6 @@ suite("OneExplorer", function () {
       testBuilder.setUp();
     });
 
-    teardown(() => {
-      testBuilder.tearDown();
-    });
-
     suite("#NodeFactory", function () {
       test("NEG: create a directory node with attributes", function () {
         assert.throw(() => {
@@ -242,6 +238,10 @@ suite("OneExplorer", function () {
           assert.strictEqual(oneNode.contextValue, "directory");
         }
       });
+    });
+
+    teardown(() => {
+      testBuilder.tearDown();
     });
   });
 });

--- a/src/Tests/OneExplorer/OneStorage.test.ts
+++ b/src/Tests/OneExplorer/OneStorage.test.ts
@@ -33,10 +33,6 @@ suite("OneExplorer", function () {
       testBuilder.setUp();
     });
 
-    teardown(() => {
-      testBuilder.tearDown();
-    });
-
     suite("OneStorage", function () {
       suite("#getCfgs()", function () {
         test("A tflite file with a cfg", function () {
@@ -517,6 +513,10 @@ input_path='model.tflite'
           assert.strictEqual(cfgToCfgObjMap.size, 1);
         });
       });
+    });
+
+    teardown(() => {
+      testBuilder.tearDown();
     });
   });
 });

--- a/src/Tests/Utils/Hash.test.ts
+++ b/src/Tests/Utils/Hash.test.ts
@@ -28,10 +28,6 @@ suite("Utils", function () {
       testBuilder.setUp();
     });
 
-    teardown(() => {
-      testBuilder.tearDown();
-    });
-
     suite("#generateHash()", function () {
       test("generate a file hash", async function () {
         const exampleName = "example.txt";
@@ -53,6 +49,10 @@ suite("Utils", function () {
           assert.ok(true);
         });
       });
+    });
+
+    teardown(() => {
+      testBuilder.tearDown();
     });
   });
 });


### PR DESCRIPTION
This commit relocate teardown function down to the bottom. Currently TCM test is making mistakes of accusing teardown function of having no assertion. Let's do a workaround by relocating the lines.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>


---
For #1678


> ### Workaround
> 
> https://analysishub.sec.samsung.net/service/analyses/2400671
> By relocating the teardown function all the way down to the bottom, we can instantly dodge the warning.
> 
> ![image](https://github.com/Samsung/ONE-vscode/assets/17171963/2b699a24-b1f7-4a65-9dd9-8ed0a40a52fb)
