### PR TITLE
[workflows] Use boolean type in publish extension workflow

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       prerelease:
         description: 'Identify the release as a prerelease (default: false)'
-        type: string
+        type: boolean
         default: false
       publish:
         description: 'Publish extension to marketplace'


### PR DESCRIPTION
This commit uses boolean type to process true/false value in publish extension workflow.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>