### PR TITLE
[Execute] Use forEach instead of Map

### DIFF
--- a/src/Execute/DeviceViewProvider.ts
+++ b/src/Execute/DeviceViewProvider.ts
@@ -213,14 +213,14 @@ export class DeviceViewProvider
           }
         });
       } else {
-        Object.entries(globalBackendMap).map(([_, backend]) => {
+        Object.entries(globalBackendMap).forEach(([_, backend]) => {
           if (backend.executor()) {
             const compiler = backend.compiler();
             if (compiler) {
               compiler
                 .getToolchainTypes()
                 .map((type) => compiler.getInstalledToolchains(type))
-                .map((toolchains) => {
+                .forEach((toolchains) => {
                   for (const toolchain of toolchains) {
                     deviceList.push(
                       new SimulatorDevice(


### PR DESCRIPTION
This commit uses forEach instead of Map because it does not use the return value.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>