### PR TITLE
[Tests] Exclude CircleEditor and MetadataViewer from nyc test files

### DIFF
--- a/src/Tests/index.ts
+++ b/src/Tests/index.ts
@@ -50,7 +50,12 @@ function setupCoverage() {
   const nyc = new NYC({
     extends: "@istanbuljs/nyc-config-typescript",
     cwd: join(__dirname, "..", ".."),
-    exclude: ["**/Tests/**", "**/external/**"],
+    exclude: [
+      "**/Tests/**",
+      "**/external/**",
+      "**/CircleEditor/**",
+      "**/MetadataViewer/**",
+    ],
     include: ["src/**/*.ts", "out/**/*.js"],
     reporter: ["cobertura", "lcov", "html", "text", "text-summary"],
     all: true,


### PR DESCRIPTION
This commit excludes CircleEditor and MetadataViewer from nyc test files. These modules are not an official v0.4 release features.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>