### PR TITLE
[EdgeTPU] Update Toolchain test code

### DIFF
--- a/src/Tests/Backend/Backend.test.ts
+++ b/src/Tests/Backend/Backend.test.ts
@@ -48,44 +48,51 @@ class BackendMockup implements Backend {
 }
 
 suite("Backend", function () {
+  setup(function () {
+    Object.keys(globalBackendMap).forEach(
+      (key) => delete globalBackendMap[key]
+    );
+    Object.keys(gToolchainEnvMap).forEach(
+      (key) => delete gToolchainEnvMap[key]
+    );
+  });
+
+  teardown(function () {
+    Object.keys(globalBackendMap).forEach(
+      (key) => delete globalBackendMap[key]
+    );
+    Object.keys(gToolchainEnvMap).forEach(
+      (key) => delete gToolchainEnvMap[key]
+    );
+  });
+
   suite("backendAPI", function () {
     test("registers a OneToolchain", function () {
       let oneBackend = new OneToolchain();
-      assert.strictEqual(Object.entries(globalBackendMap).length, 1);
+      API.registerBackend(oneBackend);
 
       const entries = Object.entries(globalBackendMap);
       assert.strictEqual(entries.length, 1);
+
       // this runs once
       for (const [key, value] of entries) {
         assert.strictEqual(key, oneBackendName);
         assert.deepStrictEqual(value, oneBackend);
       }
     });
-    test("registers a backend", function () {
-      assert.strictEqual(Object.entries(globalBackendMap).length, 1);
 
+    test("registers a backend", function () {
       let backend = new BackendMockup();
       API.registerBackend(backend);
 
       const entries = Object.entries(globalBackendMap);
-      assert.strictEqual(entries.length, 2);
+      assert.strictEqual(entries.length, 1);
 
       // this runs once
       for (const [key, value] of entries) {
-        if (key !== oneBackendName) {
-          assert.strictEqual(key, backendName);
-          assert.deepStrictEqual(value, backend);
-        }
+        assert.strictEqual(key, backendName);
+        assert.deepStrictEqual(value, backend);
       }
     });
-  });
-
-  teardown(function () {
-    if (globalBackendMap[backendName] !== undefined) {
-      delete globalBackendMap[backendName];
-    }
-    if (gToolchainEnvMap[backendName] !== undefined) {
-      delete gToolchainEnvMap[backendName];
-    }
   });
 });

--- a/src/Tests/Backend/Backend.test.ts
+++ b/src/Tests/Backend/Backend.test.ts
@@ -49,15 +49,7 @@ class BackendMockup implements Backend {
 
 suite("Backend", function () {
   setup(function () {
-    Object.keys(globalBackendMap).forEach(
-      (key) => delete globalBackendMap[key]
-    );
-    Object.keys(gToolchainEnvMap).forEach(
-      (key) => delete gToolchainEnvMap[key]
-    );
-  });
-
-  teardown(function () {
+    // TODO: provide delete function for backend, which recursively deleting toolchain and executors
     Object.keys(globalBackendMap).forEach(
       (key) => delete globalBackendMap[key]
     );
@@ -94,5 +86,15 @@ suite("Backend", function () {
         assert.deepStrictEqual(value, backend);
       }
     });
+  });
+
+  teardown(function () {
+    // TODO: provide delete function for backend, which recursively deleting toolchain and executors
+    Object.keys(globalBackendMap).forEach(
+      (key) => delete globalBackendMap[key]
+    );
+    Object.keys(gToolchainEnvMap).forEach(
+      (key) => delete gToolchainEnvMap[key]
+    );
   });
 });

--- a/src/Tests/Toolchain/ToolchainProvider.test.ts
+++ b/src/Tests/Toolchain/ToolchainProvider.test.ts
@@ -44,18 +44,13 @@ suite("Toolchain", function () {
   const backendName = "dummy_backend";
 
   setup(function () {
+    // TODO: provide delete function for backend, which recursively deleting toolchain and executors
     Object.keys(gToolchainEnvMap).forEach(
       (key) => delete gToolchainEnvMap[key]
     );
 
     gToolchainEnvMap[oneBackendName] = oneToolhcainEnv;
     gToolchainEnvMap[backendName] = toolchainEnv;
-  });
-
-  teardown(function () {
-    Object.keys(gToolchainEnvMap).forEach(
-      (key) => delete gToolchainEnvMap[key]
-    );
   });
 
   suite("BaseNode", function () {
@@ -372,5 +367,12 @@ suite("Toolchain", function () {
         assert.isFalse(ret);
       });
     });
+  });
+
+  teardown(function () {
+    // TODO: provide delete function for backend, which recursively deleting toolchain and executors
+    Object.keys(gToolchainEnvMap).forEach(
+      (key) => delete gToolchainEnvMap[key]
+    );
   });
 });

--- a/src/Tests/Toolchain/ToolchainProvider.test.ts
+++ b/src/Tests/Toolchain/ToolchainProvider.test.ts
@@ -52,6 +52,12 @@ suite("Toolchain", function () {
     gToolchainEnvMap[backendName] = toolchainEnv;
   });
 
+  teardown(function () {
+    Object.keys(gToolchainEnvMap).forEach(
+      (key) => delete gToolchainEnvMap[key]
+    );
+  });
+
   suite("BaseNode", function () {
     suite("#constructor()", function () {
       test("is constructed with params using base_node", function () {

--- a/src/Tests/Toolchain/ToolchainProvider.test.ts
+++ b/src/Tests/Toolchain/ToolchainProvider.test.ts
@@ -34,21 +34,22 @@ import {
   MockCompilerWithMultipleInstalledToolchains,
   MockCompilerWithNoInstalledToolchain,
 } from "../MockCompiler";
+import { OneCompiler } from "../../Backend/One/OneToolchain";
 
 suite("Toolchain", function () {
+  const oneToolhcainEnv = new ToolchainEnv(new OneCompiler());
   const oneBackendName = "ONE";
   const compiler = new MockCompiler();
   const toolchainEnv = new ToolchainEnv(compiler);
   const backendName = "dummy_backend";
 
   setup(function () {
-    gToolchainEnvMap[backendName] = toolchainEnv;
-  });
+    Object.keys(gToolchainEnvMap).forEach(
+      (key) => delete gToolchainEnvMap[key]
+    );
 
-  teardown(function () {
-    if (gToolchainEnvMap[backendName] !== undefined) {
-      delete gToolchainEnvMap[backendName];
-    }
+    gToolchainEnvMap[oneBackendName] = oneToolhcainEnv;
+    gToolchainEnvMap[backendName] = toolchainEnv;
   });
 
   suite("BaseNode", function () {

--- a/src/Tests/View/InstallQuickInput.test.ts
+++ b/src/Tests/View/InstallQuickInput.test.ts
@@ -26,6 +26,7 @@ import {
   InstallQuickInputStep,
 } from "../../View/InstallQuickInput";
 import { MockCompiler } from "../MockCompiler";
+import { OneCompiler } from "../../Backend/One/OneToolchain";
 
 suite("View", function () {
   suite("InnerButton", function () {
@@ -45,21 +46,30 @@ suite("View", function () {
   // Therefore, we focus on testing things not ui
   suite("InstallQuickInput", function () {
     const oneBackendName = "ONE";
+    const oneCompiler = new OneCompiler();
+    const oneToolchainEnv = new ToolchainEnv(oneCompiler);
+
+    const backendName = "testBackend";
     const compiler = new MockCompiler();
     const toolchainEnv = new ToolchainEnv(compiler);
+
     const toolchainType = toolchainEnv.getToolchainTypes()[0];
     const toolchain = toolchainEnv.listAvailable(toolchainType, 0, 1)[0];
     const version = new Version(1, 0, 0).str();
-    const backendName = "testBackend";
 
     setup(function () {
+      Object.keys(gToolchainEnvMap).forEach(
+        (key) => delete gToolchainEnvMap[key]
+      );
+
+      gToolchainEnvMap[oneBackendName] = oneToolchainEnv;
       gToolchainEnvMap[backendName] = toolchainEnv;
     });
 
     teardown(function () {
-      if (gToolchainEnvMap[backendName] !== undefined) {
-        delete gToolchainEnvMap[backendName];
-      }
+      Object.keys(gToolchainEnvMap).forEach(
+        (key) => delete gToolchainEnvMap[key]
+      );
     });
 
     suite("#constructor()", function () {

--- a/src/Tests/View/InstallQuickInput.test.ts
+++ b/src/Tests/View/InstallQuickInput.test.ts
@@ -58,18 +58,13 @@ suite("View", function () {
     const version = new Version(1, 0, 0).str();
 
     setup(function () {
+      // TODO: provide delete function for backend, which recursively deleting toolchain and executors
       Object.keys(gToolchainEnvMap).forEach(
         (key) => delete gToolchainEnvMap[key]
       );
 
       gToolchainEnvMap[oneBackendName] = oneToolchainEnv;
       gToolchainEnvMap[backendName] = toolchainEnv;
-    });
-
-    teardown(function () {
-      Object.keys(gToolchainEnvMap).forEach(
-        (key) => delete gToolchainEnvMap[key]
-      );
     });
 
     suite("#constructor()", function () {
@@ -675,6 +670,13 @@ suite("View", function () {
           quickInput.getMultiSteps(invalidState);
         }).to.throw(`state is wrong: ` + String(invalidState.current));
       });
+    });
+
+    teardown(function () {
+      // TODO: provide delete function for backend, which recursively deleting toolchain and executors
+      Object.keys(gToolchainEnvMap).forEach(
+        (key) => delete gToolchainEnvMap[key]
+      );
     });
   });
 });


### PR DESCRIPTION
This commit updates the Backend.test.ts, ToolchainProvider.test.ts, InstallQuickInput.test.ts files so that the testing codes work independent from addition of Backend and ToolchainEnv.

AS-IS:
Even though the purpose is not to test the registration of backend and toolchainEnv, the test codes should be updated whenever new backends and toolchainEnvs are registered.

TO-BE:
The test codes only use the Backend and toolchainEnv of ONE and mockup regardless of backend and toolchainEnv registered in the extension.ts file.

ONE-vscode-DCO-1.0-Signed-off-by: profornnan <profornnan@naver.com>
Co-authored-by: Bumsoo Ko <rhqjatn2398@naver.com>

Related: https://github.com/Samsung/ONE-vscode/pull/1628