### PR TITLE
[MetadataViewer] Hide commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -423,19 +423,9 @@
           "command": "one.toolchain.uninstall",
           "when": "view == ToolchainView && viewItem =~ /toolchain/ && !one.job:running",
           "group": "inline"
-        },
-        {
-          "command": "one.viewer.metadata.showFromOneExplorer",
-          "when": "view == OneExplorerView && viewItem =~ /baseModel|product/",
-          "group": "7_metadata@1"
         }
       ],
       "explorer/context": [
-        {
-          "command": "one.viewer.metadata.showFromDefaultExplorer",
-          "when": "resourceExtname in one.metadata.supportedFiles && !explorerResourceIsFolder",
-          "group": "7_metadata@1"
-        },
         {
           "command": "one.editor.mpq.createFromDefaultExplorer",
           "when": "resourceExtname == .circle",


### PR DESCRIPTION
This commit hides commands of MetadataViewer.
Let's show the command when the whole functionality is ready.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>