### PR TITLE
[Execute] Use DEVICE view name

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         },
         {
           "id": "TargetDeviceView",
-          "name": "Target Devices"
+          "name": "Device"
         }
       ]
     },


### PR DESCRIPTION
This commit uses DEVICE view name instead of TARGET DEVICES.

ONE-vscode-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>