### PR TITLE
[EdgeTPU] Expand createCfg method for other cfg types

### DIFF
--- a/src/CfgEditor/CfgData.ts
+++ b/src/CfgEditor/CfgData.ts
@@ -15,7 +15,7 @@
  */
 
 import * as ini from "ini";
-import { ICfgData } from "./ICfgData";
+import { CfgInfo, ICfgData } from "./ICfgData";
 import { Sections } from "./Sections";
 
 // NOTE: Why is not function overloadding used? Its maintain costs expensive.
@@ -33,7 +33,7 @@ import { Sections } from "./Sections";
 //
 export class CfgData extends ICfgData {
   constructor(cfg = undefined) {
-    super(cfg, Sections.onecc);
+    super(cfg, Sections.onecc, "one.editor.cfg", ".cfg");
   }
 
   setWithConfig(cfg: any): void {
@@ -85,5 +85,18 @@ export class CfgData extends ICfgData {
     const config = this.getAsConfig();
     config[section] = ini.parse(value);
     this.resolveDeprecated();
+  }
+
+  generateCfgInfo(modelName: string, extName: string): CfgInfo {
+    return {
+      title: `Create ONE configuration of '${modelName}.${extName}' :`,
+      viewType: this.viewType,
+      extType: this.extType,
+      content: `[onecc]
+one-import-${extName}=True
+[one-import-${extName}]
+input_path=${modelName}.${extName}
+`,
+    };
   }
 }

--- a/src/CfgEditor/EdgeTPUCfgData.ts
+++ b/src/CfgEditor/EdgeTPUCfgData.ts
@@ -15,12 +15,12 @@
  */
 
 import * as ini from "ini";
-import { ICfgData } from "./ICfgData";
+import { CfgInfo, ICfgData } from "./ICfgData";
 import { Sections } from "./Sections";
 
 export class EdgeTPUCfgData extends ICfgData {
   constructor(cfg = undefined) {
-    super(cfg, Sections.edgetpu);
+    super(cfg, Sections.edgetpu, "one.editor.edgetpucfg", ".edgetpucfg");
   }
 
   setWithConfig(cfg: any): void {
@@ -47,5 +47,21 @@ export class EdgeTPUCfgData extends ICfgData {
     // value should be encoded or stringfied
     const config = this.getAsConfig();
     config[section] = ini.parse(value);
+  }
+
+  generateCfgInfo(modelName: string, extName: string): CfgInfo {
+    return {
+      title: `Create EdgeTPU configuration of '${modelName}.${extName}' :`,
+      viewType: this.viewType,
+      extType: this.extType,
+      content: `[edgetpu-compiler]
+edgetpu-compile=True
+edgetpu-profile=False
+
+[edgetpu-compile]
+input_path=${modelName}.${extName}
+output_path=${modelName}_edgetpu.${extName}
+`,
+    };
   }
 }

--- a/src/CfgEditor/ICfgData.ts
+++ b/src/CfgEditor/ICfgData.ts
@@ -15,15 +15,29 @@
  */
 import * as ini from "ini";
 
-export abstract class ICfgData {
-  //config can be undefined
-  private _config: any;
-  //section must be existed
-  private _section!: string[];
+export type CfgInfo = {
+  title: string;
+  viewType: string;
+  extType: string;
+  content: string;
+};
 
-  constructor(_config: any, _section: string[]) {
+export abstract class ICfgData {
+  private _config: any;
+  private _section!: string[];
+  private _viewType!: string;
+  private _extType!: string;
+
+  constructor(
+    _config: any,
+    _section: string[],
+    _viewType: string,
+    _extType: string
+  ) {
     this._config = _config;
     this._section = _section;
+    this._viewType = _viewType;
+    this._extType = _extType;
   }
 
   // sets data with object decoded or parsed
@@ -36,6 +50,17 @@ export abstract class ICfgData {
     value: string
   ): void;
   abstract updateSectionWithValue(section: string, value: string): void;
+  //Return information about each cfgType
+  abstract generateCfgInfo(modelName: string, extName: string): CfgInfo;
+
+  //getter
+  get viewType(): string {
+    return this._viewType;
+  }
+
+  get extType(): string {
+    return this._extType;
+  }
 
   // set cfgData's config
   // only child class can use this method

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -90,6 +90,13 @@ export enum NodeType {
   product,
 }
 
+export type CfgInfo = {
+  title: string;
+  viewType: string;
+  extType: string;
+  content: string;
+};
+
 export abstract class Node {
   abstract readonly type: NodeType;
   public readonly id: string;
@@ -1252,10 +1259,3 @@ input_path=${modelName}.${extName}
     return this._tree;
   }
 }
-
-type CfgInfo = {
-  title: string;
-  viewType: string;
-  extType: string;
-  content: string;
-};

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -1055,9 +1055,11 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
       });
     }
 
+    const placeHolder = options.map(option=>option.label).join(" / ");
+
     const selectedOption = await vscode.window.showQuickPick(options, {
       title: "Pick a configuration to create",
-      placeHolder: "cfg / edgetpucfg",
+      placeHolder: placeHolder,
     });
     const selectedLabel = selectedOption?.label;
 

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -1039,6 +1039,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
     modelName: string,
     extName: string
   ): Promise<CfgInfo | undefined> {
+    //Options must be added according to extension
     const options: vscode.QuickPickItem[] = [
       { label: ".cfg", description: "configuration file of onecc compiler" },
     ];
@@ -1052,20 +1053,24 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
 
     const placeHolder = options.map((option) => option.label).join(" / ");
 
-    const selectedOption = await vscode.window.showQuickPick(options, {
-      title: "Pick a configuration to create",
-      placeHolder: placeHolder,
-    });
-    const selectedLabel = selectedOption?.label;
-
+    let selectedLabel: string | undefined = ".cfg";
     let cfgData: ICfgData | undefined = undefined;
 
+    //If options array only has the `.cfg` option, skip selecting it.
+    if (options.length !== 1) {
+      const selectedOption = await vscode.window.showQuickPick(options, {
+        title: "Pick a configuration to create",
+        placeHolder: placeHolder,
+      });
+      selectedLabel = selectedOption?.label;
+    }
+
     switch (selectedLabel) {
-      case ".edgetpucfg":
-        cfgData = new EdgeTPUCfgData();
-        break;
       case ".cfg":
         cfgData = new CfgData();
+        break;
+      case ".edgetpucfg":
+        cfgData = new EdgeTPUCfgData();
         break;
       default:
         cfgData = undefined;

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -1044,7 +1044,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
     if (extName === "tflite") {
       options.push({
         label: ".edgetpucfg",
-        description: "configuration file of edgetpu compiler",
+        description: "configuration file of edge tpu compiler",
       });
     }
 

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -1036,7 +1036,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
   private async generateCfgInfo(
     modelName: string,
     extName: string
-  ): Promise<CfgInfo> {
+  ): Promise<CfgInfo | undefined> {
     const options = [
       { label: ".cfg", description: "configuration file of onecc compiler" },
     ];
@@ -1049,7 +1049,7 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
     }
 
     const selectedOption = await vscode.window.showQuickPick(options);
-    const selectedLabel = selectedOption ? selectedOption.label : ".cfg";
+    const selectedLabel = selectedOption?.label;
 
     switch (selectedLabel) {
       case ".edgetpucfg":
@@ -1067,7 +1067,6 @@ output_path=${modelName}_edgetpu.${extName}
 `,
         };
       case ".cfg":
-      default:
         return {
           title: `Create ONE configuration of '${modelName}.${extName}' :`,
           viewType: "one.editor.cfg",
@@ -1078,6 +1077,8 @@ one-import-${extName}=True
 input_path=${modelName}.${extName}
 `,
         };
+      default:
+        return undefined;
     }
   }
 
@@ -1095,6 +1096,11 @@ input_path=${modelName}.${extName}
     const extName = path.parse(node.path).ext.slice(1);
 
     const cfgInfo = await this.generateCfgInfo(modelName, extName);
+
+    //When the user presses the ESC button, it is cancelled
+    if (cfgInfo === undefined) {
+      return;
+    }
 
     // TODO(dayo) Auto-configure more fields
     const validateInputPath = (cfgName: string): string | undefined => {

--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -1048,7 +1048,10 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
       });
     }
 
-    const selectedOption = await vscode.window.showQuickPick(options);
+    const selectedOption = await vscode.window.showQuickPick(options, {
+      title: "Pick a configuration to create",
+      placeHolder: "cfg / edgetpucfg",
+    });
     const selectedLabel = selectedOption?.label;
 
     switch (selectedLabel) {


### PR DESCRIPTION
This PR is about extending the createCfg method for other cfg types.

I wanted to make this UI like this.
![image](https://github.com/Samsung/ONE-vscode/assets/43038815/bd12520b-c81d-45d1-ab29-da6212d40b9f)

But I couldn't find this API, and this program also gets the name for the output as a `quick pick`, so I made it a `quick pick` like this.
![image](https://github.com/Samsung/ONE-vscode/assets/43038815/cad507fe-ff89-40a8-8509-c87440ee9281)

The option '.edgetpucfg' appears only in the tflite file.
![image](https://github.com/Samsung/ONE-vscode/assets/43038815/3440afde-3976-40ca-b987-b6f3f96aba13)

# About Modularizing
I don't think this PR is enough to modularize. So please comment about best modularizing or refactoring
