### PR TITLE
[EdgeTPU] Update Toolchain run notification and log

### DIFF
--- a/src/Toolchain/JobConfig.ts
+++ b/src/Toolchain/JobConfig.ts
@@ -27,7 +27,7 @@ class JobConfig extends JobCommand {
     super(cmd);
     this.jobType = JobType.tConfig;
     this.name = "config";
-    this.notiTitle = "Running onecc...";
+    this.notiTitle = "Running tools...";
     this.valid = true;
     this.isCancelable = true;
   }

--- a/src/Toolchain/ToolchainEnv.ts
+++ b/src/Toolchain/ToolchainEnv.ts
@@ -181,6 +181,7 @@ class ToolchainEnv extends Env {
     return new Promise<boolean>((resolve, reject) => {
       const jobs: Array<Job> = [];
       const job = new JobConfig(toolchain.run(cfg));
+      job.notiTitle = `Running ${toolchain.info.name}`;
       job.workDir = path.dirname(cfg);
       job.successCallback = () => resolve(true);
       job.failureCallback = () => reject();

--- a/src/Toolchain/ToolchainProvider.ts
+++ b/src/Toolchain/ToolchainProvider.ts
@@ -318,7 +318,7 @@ export class ToolchainProvider implements vscode.TreeDataProvider<BaseNode> {
   public _run(cfg: string): boolean {
     const [activeToolchainEnv, activeToolchain] =
       this.checkAvailableToolchain();
-    if (activeToolchainEnv === undefined || activeToolchain === undefined) {
+    if (!activeToolchainEnv || !activeToolchain) {
       return false;
     }
 
@@ -338,7 +338,7 @@ export class ToolchainProvider implements vscode.TreeDataProvider<BaseNode> {
 
     Logger.info(
       this.tag,
-      `Run tools with ${cfg} cfg and ${activeToolchainName}-${activeToolchain.info.version?.str()} toolchain.`
+      `Run ${activeToolchainName}-${activeToolchain.info.version?.str()} toolchain with ${cfg} cfg.`
     );
     activeToolchainEnv.run(cfg, activeToolchain).then(
       () => notifySuccess(),

--- a/src/Toolchain/ToolchainProvider.ts
+++ b/src/Toolchain/ToolchainProvider.ts
@@ -316,27 +316,29 @@ export class ToolchainProvider implements vscode.TreeDataProvider<BaseNode> {
   }
 
   public _run(cfg: string): boolean {
-    /* istanbul ignore next */
-    const notifySuccess = () => {
-      vscode.window.showInformationMessage("Onecc has run successfully.");
-    };
-
-    /* istanbul ignore next */
-    const notifyError = () => {
-      this.error("Running onecc has failed.");
-    };
-
     const [activeToolchainEnv, activeToolchain] =
       this.checkAvailableToolchain();
     if (activeToolchainEnv === undefined || activeToolchain === undefined) {
       return false;
     }
 
+    const activeToolchainName = activeToolchain.info.name;
+
+    /* istanbul ignore next */
+    const notifySuccess = () => {
+      vscode.window.showInformationMessage(
+        `${activeToolchainName} has run successfully.`
+      );
+    };
+
+    /* istanbul ignore next */
+    const notifyError = () => {
+      this.error(`Running ${activeToolchainName} has failed.`);
+    };
+
     Logger.info(
       this.tag,
-      `Run onecc with ${cfg} cfg and ${
-        activeToolchain.info.name
-      }-${activeToolchain.info.version?.str()} toolchain.`
+      `Run tools with ${cfg} cfg and ${activeToolchainName}-${activeToolchain.info.version?.str()} toolchain.`
     );
     activeToolchainEnv.run(cfg, activeToolchain).then(
       () => notifySuccess(),


### PR DESCRIPTION
Modify notiTitle in JobConfig.ts from 'Running onecc...' to 'Running tools...'
Use active toolchain name in notification and log of ToolchainProvider _run method
Add notiTitle in ToolchainEnv run method to provide notification differently for each toolchain

ONE-vscode-DCO-1.0-Signed-off-by: profornnan <profornnan@naver.com>