### PR TITLE
DRAFT: [OneExplorer] Show under multiple parents

### DIFF
--- a/src/OneExplorer/OneExplorer.ts
+++ b/src/OneExplorer/OneExplorer.ts
@@ -559,13 +559,15 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
         }
       }),
       provider.fileWatcher.onDidDelete((uri: vscode.Uri) => {
-        const node = OneStorage.getNode(uri.fsPath);
-        if (!node) {
+        const nodes = OneStorage.getNodes(uri.fsPath);
+        if (nodes.length === 0) {
           return;
         }
 
-        OneStorage.delete(node, true);
-        provider.refresh(node.parent);
+        nodes.forEach((node) => {
+          OneStorage.delete(node, true);
+          provider.refresh(node.parent);
+        });
       }),
       vscode.workspace.onDidChangeWorkspaceFolders(() => {
         provider._workspaceRoots = obtainWorkspaceRoots().map((root) =>
@@ -577,14 +579,14 @@ export class OneTreeDataProvider implements vscode.TreeDataProvider<Node> {
       vscode.commands.registerCommand(
         "one.explorer.revealInOneExplorer",
         (path: string) => {
-          const node = OneStorage.getNode(path);
-          if (node) {
+          const nodes = OneStorage.getNodes(path);
+          nodes.forEach((node) => {
             provider._treeView?.reveal(node, {
               select: true,
               focus: true,
               expand: true,
             });
-          }
+          });
         }
       ),
       vscode.commands.registerCommand(

--- a/src/OneExplorer/OneStorage.ts
+++ b/src/OneExplorer/OneStorage.ts
@@ -27,6 +27,51 @@ import { Node, NodeType } from "./OneExplorer";
 
 export { CfgToCfgObjMap as _unit_test_CfgToCfgObjMap };
 
+
+export class MultiMap<U, T> {
+  private _map: Map<U, T[]>;
+
+  constructor() {
+    this._map = new Map<U, T[]>();
+  }
+
+  get(u: U): T[] {
+    return this._map.get(u) ?? [];
+  }
+
+  exist(u: U, t: T): boolean {
+    return this._map.get(u)?.includes(t) ? true : false;
+  }
+
+  insert(u: U, t: T) {
+    if (this.exist(u, t)) {
+      return;
+    }
+
+    if (!this._map.get(u)) {
+      this._map.set(u, [t]);
+    } else {
+      this._map.set(u, [...this._map.get(u)!, t]);
+    }
+  }
+
+  delete(u: U, t?: T) {
+    if (!t) {
+      this._map.delete(u);
+      return;
+    }
+
+    if (!this.exist(u, t)) {
+      return;
+    }
+
+    this._map.set(
+      u,
+      this._map.get(u)!.filter((_t) => _t !== t)
+    );
+  }
+}
+
 class CfgToCfgObjMap {
   private _map: Map<string, ConfigObj>;
 
@@ -130,7 +175,7 @@ export class OneStorage {
    * pre-built. Mind that it will slow down the extension to gather data about unseen nodes.
    *       Currently, only the two depths from those shown nodes are built.
    */
-  private _nodeMap: Map<string, Node> = new Map<string, Node>();
+  private _nodeMap: MultiMap<string, Node> = new MultiMap<string, Node>();
 
   /**
    * @brief A map of ConfigObj (key: cfg path)
@@ -232,13 +277,19 @@ export class OneStorage {
   /**
    * Get Node from the map
    */
-  public static getNode(fsPath: string): Node | undefined {
+  public static getNodes(fsPath: string): Node[] {
     return OneStorage.get()._nodeMap.get(fsPath);
   }
 
   public static insert(node: Node) {
     const inst = OneStorage.get();
-    inst._nodeMap.set(node.path, node);
+
+    if (inst._nodeMap.exist(node.path, node)) {
+      return;
+    }
+    
+    inst._nodeMap.insert(node.path, node);
+
     if (node.type === NodeType.config) {
       if (!inst._cfgToCfgObjMap.get(node.path)) {
         const cfgObj = ConfigObj.createConfigObj(node.uri);


### PR DESCRIPTION
Currently, config nodes are shown under the first parent written in the file.
To resolve the issue, multimap for node map is required.