### PR TITLE
[OneExplorer] Targeted refresh on Change/Delete

### DIFF
--- a/src/OneExplorer/ConfigObject.ts
+++ b/src/OneExplorer/ConfigObject.ts
@@ -121,6 +121,42 @@ export class ConfigObj {
     };
   }
 
+  static diffBaseModels(
+    newCfgObj?: ConfigObj,
+    oldCfgObj?: ConfigObj
+  ): [addedBaseModels: string[], removedBaseModels: string[]] {
+    const newBaseModels =
+      newCfgObj?.getBaseModelsExists.map((artifact) => artifact.path) ?? [];
+    const oldBaseModels =
+      oldCfgObj?.getBaseModelsExists.map((artifact) => artifact.path) ?? [];
+
+    const addedBaseModels =
+      newBaseModels.filter((path) => !oldBaseModels.includes(path)) ?? [];
+
+    const removedBaseModels =
+      oldBaseModels.filter((path) => !newBaseModels.includes(path)) ?? [];
+
+    return [addedBaseModels, removedBaseModels];
+  }
+
+  static diffProducts(
+    newCfgObj?: ConfigObj,
+    oldCfgObj?: ConfigObj
+  ): [addedProducts: string[], removedProducts: string[]] {
+    const newProducts =
+      newCfgObj?.getProductsExists.map((artifact) => artifact.path) ?? [];
+    const oldProducts =
+      oldCfgObj?.getProductsExists.map((artifact) => artifact.path) ?? [];
+
+    const addedProducts =
+      newProducts.filter((path) => !oldProducts.includes(path)) ?? [];
+
+    const removedProducts =
+      oldProducts.filter((path) => !newProducts.includes(path)) ?? [];
+
+    return [addedProducts, removedProducts];
+  }
+
   public updateBaseModelField(
     oldpath: string,
     newpath: string

--- a/src/OneExplorer/OneStorage.ts
+++ b/src/OneExplorer/OneStorage.ts
@@ -280,6 +280,13 @@ export class OneStorage {
     return OneStorage.get()._nodeMap.get(fsPath);
   }
 
+  public static getBaseModelNode(fsPath: string): Node {
+    const nodes = OneStorage.get()._nodeMap.get(fsPath);
+    assert.ok(nodes.length === 1);
+    assert.ok(nodes[0].type === NodeType.baseModel);
+    return nodes[0];
+  }
+
   public static insert(node: Node) {
     const inst = OneStorage.get();
 


### PR DESCRIPTION
This commit refreshs only the required nodes on change and delete file.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

For #1422 #1501