### PR TITLE
[Test] Alter mocha timeout

### DIFF
--- a/src/Tests/index.ts
+++ b/src/Tests/index.ts
@@ -98,6 +98,7 @@ export async function run(): Promise<void> {
     ui: "tdd",
     color: true,
     fgrep: testFilter,
+    timeout: 10000,
   };
 
   const runner = new Mocha(mochaOpts);


### PR DESCRIPTION
This commit alter mocha timeout from 2000(default) to 10000 ms. It's to prevent timeout failure during test.

ONE-vscode-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

For #1706

I suspect it as a long latency problem. By rising timeout up to 10000 ms, (default: 2000 ms) the test passes at once. Maybe the CI machine sometime get slower and does not pass within the timeout. They always pass on local machine, so let's simply change the timeout.