### PR TITLE
[EdgeTPU] Update Toolchain run notification and log 

### DIFF
--- a/src/Toolchain/JobConfig.ts
+++ b/src/Toolchain/JobConfig.ts
@@ -27,7 +27,7 @@ class JobConfig extends JobCommand {
     super(cmd);
     this.jobType = JobType.tConfig;
     this.name = "config";
-    this.notiTitle = "Running onecc...";
+    this.notiTitle = "Running tools...";
     this.valid = true;
     this.isCancelable = true;
   }

--- a/src/Toolchain/ToolchainEnv.ts
+++ b/src/Toolchain/ToolchainEnv.ts
@@ -182,6 +182,7 @@ class ToolchainEnv extends Env {
     return new Promise<boolean>((resolve, reject) => {
       const jobs: Array<Job> = [];
       const job = new JobConfig(toolchain.run(cfg));
+      job.notiTitle = `Running ${toolchain.info.name}`;
       job.workDir = path.dirname(cfg);
       job.successCallback = () => resolve(true);
       job.failureCallback = () => reject();

--- a/src/Toolchain/ToolchainProvider.ts
+++ b/src/Toolchain/ToolchainProvider.ts
@@ -322,31 +322,33 @@ export class ToolchainProvider implements vscode.TreeDataProvider<BaseNode> {
   }
 
   public _run(cfg: string): boolean {
+    const [activeToolchainEnv, activeToolchain] =
+      this.checkAvailableToolchain();
+    if (!activeToolchainEnv || !activeToolchain) {
+      return false;
+    }
+
+    const activeToolchainName = activeToolchain.info.name;
+
     /* istanbul ignore next */
     const notifySuccess = () => {
-      vscode.window.showInformationMessage("Onecc has run successfully.");
+      vscode.window.showInformationMessage(
+        `${activeToolchainName} has run successfully.`
+      );
     };
 
     /* istanbul ignore next */
     const notifyError = (err?: Error) => {
-      let str = "Running onecc has failed. ";
+      let str = `Running ${activeToolchainName} has failed. `;
       if (err) {
         str += err.message;
       }
       vscode.window.showErrorMessage(str);
     };
 
-    const [activeToolchainEnv, activeToolchain] =
-      this.checkAvailableToolchain();
-    if (activeToolchainEnv === undefined || activeToolchain === undefined) {
-      return false;
-    }
-
     Logger.info(
       this.tag,
-      `Run onecc with ${cfg} cfg and ${
-        activeToolchain.info.name
-      }-${activeToolchain.info.version?.str()} toolchain.`
+      `Run ${activeToolchainName}-${activeToolchain.info.version?.str()} toolchain with ${cfg} cfg.`
     );
     activeToolchainEnv
       .run(cfg, activeToolchain)


### PR DESCRIPTION
Modify notiTitle in JobConfig.ts from 'Running onecc...' to 'Running tools...' Use active toolchain name in notification and log of ToolchainProvider _run method

ONE-vscode-DCO-1.0-Signed-off-by: profornnan <profornnan@naver.com>

---

Origianl PR #1698