### PR TITLE
[workflows] Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/check-daily-license.yml
+++ b/.github/workflows/check-daily-license.yml
@@ -45,7 +45,7 @@ jobs:
       - id: get_commit_id
         run: |
           COMMIT_ID=$(git log -1 --format='%H')
-          echo "::set-output name=commit_id::${COMMIT_ID}"
+          echo "commit_id=${COMMIT_ID}" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
ONE-vscode-DCO-1.0-Signed-off-by: Jongwoo Han <jongwooo.han@gmail.com>

## Summary

Update `.github/workflows/check-daily-license.yml` to use environment file instead of deprecated `set-output` command. For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

**AS-IS**

```yaml
echo "::set-output name=commit_id::${COMMIT_ID}"
```

**TO-BE**

```yaml
echo "commit_id=${COMMIT_ID}" >> $GITHUB_OUTPUT
```